### PR TITLE
[ORCA-67] Generalize input/output of copy_to_glacier lambda so it can be used anywhere after MoveGranules in a workflow

### DIFF
--- a/bin/build_tasks.sh
+++ b/bin/build_tasks.sh
@@ -5,7 +5,7 @@ set -e
 rm -rf venv
 python3 -m venv venv
 source venv/bin/activate
-pip install --upgrade pip
+pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org
 deactivate
 echo "pwd `pwd`"
 
@@ -23,7 +23,7 @@ cd "`pwd`/${TASK}"
 rm -rf build
 mkdir build
 source ../../venv/bin/activate
-pip install -t build -r requirements.txt --trusted-host pypi.org
+pip install -t build -r requirements.txt --trusted-host pypi.org --trusted-host pypi.org --trusted-host files.pythonhosted.org
 deactivate
 cp db_deploy.py build/
 cd build
@@ -44,7 +44,7 @@ cd "`pwd`/${TASK}"
 rm -rf build
 mkdir build
 source ../../venv/bin/activate
-pip install -t build -r requirements.txt --trusted-host pypi.org
+pip install -t build -r requirements.txt --trusted-host pypi.org --trusted-host pypi.org --trusted-host files.pythonhosted.org
 deactivate
 cp *.py build/
 cd build
@@ -57,7 +57,7 @@ cd "`pwd`/${TASK}"
 rm -rf build
 mkdir build
 source ../../venv/bin/activate
-pip install -t build -r requirements.txt --trusted-host pypi.org
+pip install -t build -r requirements.txt --trusted-host pypi.org --trusted-host pypi.org --trusted-host files.pythonhosted.org
 deactivate
 cp request_status.py build/
 cd build
@@ -76,7 +76,7 @@ cd "`pwd`/${TASK}"
 rm -rf build
 mkdir build
 source ../../venv/bin/activate
-pip install -t build -r requirements.txt --trusted-host pypi.org
+pip install -t build -r requirements.txt --trusted-host pypi.org --trusted-host pypi.org --trusted-host files.pythonhosted.org
 deactivate
 cp copy_files_to_archive.py build/
 cd build
@@ -95,7 +95,7 @@ cd "`pwd`/${TASK}"
 rm -rf build
 mkdir build
 source ../../venv/bin/activate
-pip install -t build -r requirements.txt --trusted-host pypi.org
+pip install -t build -r requirements.txt --trusted-host pypi.org --trusted-host pypi.org --trusted-host files.pythonhosted.org
 deactivate
 cp request_files.py build/
 cd build
@@ -115,7 +115,7 @@ cd "`pwd`/${TASK}"
 rm -rf build
 mkdir build
 source ../../venv/bin/activate
-pip install -t build -r requirements.txt --trusted-host pypi.org
+pip install -t build -r requirements.txt --trusted-host pypi.org --trusted-host pypi.org --trusted-host files.pythonhosted.org
 deactivate
 cp *.py build/
 cd build

--- a/tasks/copy_to_glacier/README.md
+++ b/tasks/copy_to_glacier/README.md
@@ -3,7 +3,7 @@
 The `copy_to_glacier` module is meant to be deployed as a lambda function that takes a Cumulus message, extracts a list of files, and copies those files from their current storage location into a staging/glacier location.
 
 
-## Excluding certain file extensions from the copy
+## Exclude files by extension.
 
 You are able to specify a list of file types (extensions) that you'd like to exclude from the backup/copy_to_glacier functionality. This is done on a per-collection basis, configured in the `meta` variable of a Cumulus collection configuration:
 
@@ -137,10 +137,13 @@ The `copy_to_glacier` lambda function expects that the input payload has a `gran
 }
 ```
 
+**Note:** We suggest that the `copy_to_glacier` task be placed any time after the `MoveGranulesStep`. It will propagate the input `granules` object as output, so it can be used as the last task in the workflow.
+
+
 ## Output
 
 The copy lambda will, as the name suggests, copy a file from its current some source destination. The destination location is defined as 
-`${glacier_bucket}/${url_path}/filename`, where `${glacier_bucket}` is pulled from your Cumulus `meta.bucket` config, `${url_path}` is pulled from the Cumulus `meta.collection` config, and `filename` is the base name of the file (with the file extension).
+`${glacier_bucket}/${filepath}`, where `${glacier_bucket}` is pulled from your Cumulus `meta.bucket` config and `${filepath}` is pulled from the Cumulus granule object input.
 
 The output of this lambda is a dictionary with a `granules` and `copied_to_glacier` attributes:
 

--- a/tasks/copy_to_glacier/README.md
+++ b/tasks/copy_to_glacier/README.md
@@ -200,3 +200,98 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_glaci
   ]
 }
 ```
+
+## pydoc request_files
+
+```
+NAME
+    handler
+
+FUNCTIONS
+    copy_granule_between_buckets(source_bucket_name: str, source_key: str, destination_bucket: str, destination_key: str) -> None
+        Copies granule from source bucket to destination.
+        Args:
+            source_bucket_name: The name of the bucket in which the granule is currently located.
+            source_key: source Granule path excluding s3://[bucket]/
+            destination_bucket: The name of the bucket the granule is to be copied to.
+            destination_key: Destination granule path excluding s3://[bucket]/
+    
+    handler(event: Dict[str, Union[List[str], Dict]], context: object) -> Any
+        Lambda handler. Runs a cumulus task that
+        copies the files in {event}['input'] from the collection specified in {config} to the {config}'s 'glacier' bucket.
+        
+        Args:
+            event: Event passed into the step from the aws workflow. A dict with the following keys:
+                input (dict): Dictionary with the followig keys:
+                    granules (List): List of granule objects (dictionaries)
+                config (dict): A dict with the following keys:
+                    collection (dict): The collection from AWS.
+                        See https://nasa.github.io/cumulus/docs/data-cookbooks/sips-workflow
+                        A dict with the following keys:
+                        name (str): The name of the collection.
+                            Used when generating the default value for {event}[config][fileStagingDir].
+                        version (str): The version of the collection.
+                            Used when generating the default value for {event}[config][fileStagingDir].
+                        files (list[Dict]): A list of dicts representing file types within the collection.
+                            The first file where the file's ['regex'] matches the filename from the input
+                            Is used to identify the bucket referenced in return's['granules'][filename]['files']['bucket']
+                            Each dict contains the following keys:
+                                regex (str): The regex that all files in the bucket must match with their name.
+                                bucket (str): The name of the bucket containing the files.
+                        url_path (str): Used when calling {copy_granule_between_buckets} as a part of the destination_key.
+                    buckets (dict): A dict with the following keys:
+                        glacier (dict): A dict with the following keys:
+                            name (str): The name of the bucket to copy to.
+        
+        
+            context: An object required by AWS Lambda. Unused.
+        
+        Returns:
+            The result of the cumulus task.
+    
+    should_exclude_files_type(granule_url: str, exclude_file_types: List[str]) -> bool
+        Tests whether or not file is included in {excludeFileTypes} from copy to glacier.
+        Args:
+            granule_url: s3 url of granule.
+            exclude_file_types: List of extensions to exclude in the backup
+        Returns:
+            True if file should be excluded from copy, False otherwise.
+    
+    task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str, Any]
+        Copies the files in {event}['input'] from the collection specified in {config} to the {config}'s 'glacier' bucket.
+        
+        Args:
+            event: Passed through from {handler}
+            context: An object required by AWS Lambda. Unused.
+        
+        Returns:
+            A dict with the following keys:
+                granules (List[Dict[str, Union[str, bytes, list]]]): A list of dicts where each dict has the following keys:
+                    granuleId (str): The filename from the granule url.
+                    files (List): A list of dicts with the following keys:
+                        name (str)
+                        filename (str)
+                        filepath (str)
+                        bucket (str)
+                copied_to_glacier (list): List of S3 paths - one for each file copied
+
+DATA
+    Any = typing.Any
+    COLLECTION_META_KEY = 'meta'
+    COLLECTION_NAME_KEY = 'name'
+    COLLECTION_URL_PATH_KEY = 'url_path'
+    COLLECTION_VERSION_KEY = 'version'
+    CONFIG_BUCKETS_KEY = 'buckets'
+    CONFIG_COLLECTION_KEY = 'collection'
+    CONFIG_FILE_STAGING_DIRECTORY_KEY = 'fileStagingDir'
+    CONFIG_URL_PATH_KEY = 'url_path'
+    Dict = typing.Dict
+    EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
+    List = typing.List
+    Optional = typing.Optional
+    Union = typing.Union
+
+FILE
+    /Users/jmcampbell/cumulus-orca/tasks/copy_to_glacier/handler.py
+```
+

--- a/tasks/copy_to_glacier/README.md
+++ b/tasks/copy_to_glacier/README.md
@@ -74,117 +74,65 @@ Manual integration testing is being worked on. TBD.
 
 The `handler` function expects input as a Cumulus Message. The actual format of that input may change over time, so we use the `cumulus-process` package (check `requirements.txt`), which Cumulus develops and updates, to parse the input.
 
-Example of expected [payload](https://nasa.github.io/cumulus/docs/workflows/input_output#5-resolve-task-output) to the task in a workflow:
-
-```json
-[
-  "s3://testdaac-internal/file-staging/testdaac/goesrpltavirisng__1/goesrplt_avng_20170328t210208.tar.gz"
-]
-```
-
-Example of expected input to the `handler` task itself:
+The `copy_to_glacier` lambda function expects that the input payload has a `granules` object, similar to the output of `MoveGranulesStep`:
 
 ```json
 {
-  "input": [
-      "s3://testdaac-internal/file-staging/testdaac/goesrpltavirisng__1/goesrplt_avng_20170328t210208.tar.gz"
-  ],
-  "config": {
-      "files_config": [
+  "payload": {
+    "granules": [
+      {
+        "granuleId": "MOD09GQ.A2017025.h21v00.006.2017034065109",
+        "dataType": "MOD09GQ",
+        "version": "006",
+        "files": [
           {
-              "regex": "^(.*).*\\.cmr.xml$",
-              "sampleFileName": "goesrplt_avng_20170323t184858.tar.gz.cmr.xml",
-              "bucket": "public"
+            "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+            "path": "MOD09GQ/006",
+            "size": 6,
+            "time": 1608318361000,
+            "bucket": "orca-sandbox-protected",
+            "url_path": "MOD09GQ/006/",
+            "type": "",
+            "filename": "s3://orca-sandbox-protected/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+            "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+            "duplicate_found": true
           },
           {
-              "regex": "^(.*).*(\\.gz|\\.hdr|clip)$",
-              "sampleFileName": "goesrplt_avng_20170323t184858.tar.gz",
-              "bucket": "protected"
-          }
-      ],
-      "buckets": {
-          "protected": {
-              "type": "protected",
-              "name": "testdaac-protected"
+            "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+            "path": "MOD09GQ/006",
+            "size": 6,
+            "time": 1608318366000,
+            "bucket": "orca-sandbox-private",
+            "url_path": "MOD09GQ/006",
+            "type": "",
+            "filename": "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+            "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+            "duplicate_found": true
           },
-          "internal": {
-              "type": "internal",
-              "name": "testdaac-internal"
-          },
-          "private": {
-              "type": "private",
-              "name": "testdaac-private"
-          },
-          "public": {
-              "type": "public",
-              "name": "testdaac-public"
-          },
-          "glacier": {
-              "type": "private",
-              "name": "testdaac-glacier"
-          }
-      },
-      "collection": {
-          "name": "goesrpltavirisng",
-          "version": "1",
-          "dataType": "goesrpltavirisng",
-          "process": "metadataextractor",
-          "provider_path": "/goesrpltavirisng/fieldCampaigns/goesrplt/AVIRIS-NG/data/",
-          "url_path": "goesrpltavirisng__1",
-          "duplicateHandling": "replace",
-          "granuleId": "^goesrplt_avng_.*(\\.gz|\\.hdr|clip)$",
-          "granuleIdExtraction": "^((goesrplt_avng_).*)",
-          "sampleFileName": "goesrplt_avng_20170323t184858.tar.gz",
-          "files": [
-              {
-                  "bucket": "public",
-                  "regex": "^goesrplt_avng_(.*).*\\.cmr.xml$",
-                  "sampleFileName": "goesrplt_avng_20170323t184858.tar.gz.cmr.xml"
-              },
-              {
-                  "bucket": "protected",
-                  "regex": "^goesrplt_avng_(.*).*(\\.gz|\\.hdr|clip)$",
-                  "sampleFileName": "goesrplt_avng_20170323t184858.tar.gz"
-              }
-          ],
-          "meta": {
-              "metadata_extractor": [
-                  {
-                      "regex": "^(.*).*(\\.gz|\\.hdr|clip)$",
-                      "module": "ascii"
-                  }
-              ],
-              "granuleRecoveryWorkflow": "DrRecoveryWorkflow",
-              "excludeFileTypes": [".cmr", ".cmr.xml"]
-          }}
-  }
-}
-```
-
-**Note:** According to the Cumulus documentation above, the output of the previous task (or a portion of it) is moved into the `input` key shown above. This means that the output of the task (in your workflow) leading up to this lambda function _must_ output the list of S3 file urls.
-
-The following is an example of [Cumulus workflow configuration](https://nasa.github.io/cumulus/docs/workflows/input_output#cma-configuration) for the `copy_to_glacier.handler` task:
-
-```json
-{
-  "cma": {
-    "event.$": "$",
-    "ReplaceConfig": {
-      "FullMessage": true
-    },
-    "task_config": {
-      "collection": "{$.meta.collection}",
-      "files_config": "{$.meta.collection.files}",
-      "buckets": "{$.meta.buckets}",
-      "cumulus_message": {
-        "outputs": [ // Check Output documentation below for an explanation of this config.
           {
-            "source": "{$}",
-            "destination": "{$.payload}"
+            "name": "MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+            "path": "MOD09GQ/006",
+            "size": 6,
+            "time": 1608318372000,
+            "bucket": "orca-sandbox-public",
+            "url_path": "MOD09GQ/006",
+            "type": "",
+            "filename": "s3://orca-sandbox-public/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+            "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+            "duplicate_found": true
+          },
+          {
+            "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+            "bucket": "orca-sandbox-private",
+            "filename": "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+            "type": "metadata",
+            "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+            "url_path": "MOD09GQ/006"
           }
-        ]
+        ],
+        "sync_granule_duration": 1728
       }
-    }
+    ]
   }
 }
 ```
@@ -194,26 +142,58 @@ The following is an example of [Cumulus workflow configuration](https://nasa.git
 The copy lambda will, as the name suggests, copy a file from its current some source destination. The destination location is defined as 
 `${glacier_bucket}/${url_path}/filename`, where `${glacier_bucket}` is pulled from your Cumulus `meta.bucket` config, `${url_path}` is pulled from the Cumulus `meta.collection` config, and `filename` is the base name of the file (with the file extension).
 
-The output of this lambda is a dictionary with a `granules` and `input` attribute:
+The output of this lambda is a dictionary with a `granules` and `copied_to_glacier` attributes:
 
 ```json
 {
 	"granules": [
-		{
-			"granuleId": "goesrplt_avng_20170328t210208.tar.gz",
-			"files": [
-				{
-					"path": "goesrpltavirisng__1",
-					"url_path": "goesrpltavirisng__1",
-					"bucket": "protected",
-					"filename": "s3://testdaaac-internal/file-staging/testdaac/goesrpltavirisng__1/goesrplt_avng_20170328t210208.tar.gz",
-					"name": "s3://testdaac-internal/file-staging/testdaac/goesrpltavirisng__1/goesrplt_avng_20170328t210208.tar.gz"
-				}
-			]
-		}
-	],
-	"input": {
-    ...
-  }
+    {
+      "granuleId": "MOD09GQ.A2017025.h21v00.006.2017034065109",
+      "dataType": "MOD09GQ",
+      "version": "006",
+      "files": [
+        {
+          "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+          "path": "MOD09GQ/006",
+          "size": 6,
+          "time": 1608318361000,
+          "bucket": "orca-sandbox-internal",
+          "url_path": "MOD09GQ/006/",
+          "type": "",
+          "filename": "s3://orca-sandbox-internal/file-staging/orca-sandbox/MOD09GQ___006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+          "fileStagingDir": "file-staging/orca-sandbox/MOD09GQ___006"
+        },
+        {
+          "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+          "path": "MOD09GQ/006",
+          "size": 6,
+          "time": 1608318366000,
+          "bucket": "orca-sandbox-internal",
+          "url_path": "MOD09GQ/006",
+          "type": "",
+          "filename": "s3://orca-sandbox-internal/file-staging/orca-sandbox/MOD09GQ___006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+          "fileStagingDir": "file-staging/orca-sandbox/MOD09GQ___006"
+        },
+        {
+          "name": "MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+          "path": "MOD09GQ/006",
+          "size": 6,
+          "time": 1608318372000,
+          "bucket": "orca-sandbox-internal",
+          "url_path": "MOD09GQ/006",
+          "type": "",
+          "filename": "s3://orca-sandbox-internal/file-staging/orca-sandbox/MOD09GQ___006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+          "fileStagingDir": "file-staging/orca-sandbox/MOD09GQ___006"
+        }
+      ],
+      "sync_granule_duration": 1676
+    }
+  ],
+	"copied_to_glacier": [
+      "s3://orca-sandbox-protected/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+      "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+      "s3://orca-sandbox-public/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+      "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml"
+  ]
 }
 ```

--- a/tasks/copy_to_glacier/README.md
+++ b/tasks/copy_to_glacier/README.md
@@ -275,23 +275,5 @@ FUNCTIONS
                         bucket (str)
                 copied_to_glacier (list): List of S3 paths - one for each file copied
 
-DATA
-    Any = typing.Any
-    COLLECTION_META_KEY = 'meta'
-    COLLECTION_NAME_KEY = 'name'
-    COLLECTION_URL_PATH_KEY = 'url_path'
-    COLLECTION_VERSION_KEY = 'version'
-    CONFIG_BUCKETS_KEY = 'buckets'
-    CONFIG_COLLECTION_KEY = 'collection'
-    CONFIG_FILE_STAGING_DIRECTORY_KEY = 'fileStagingDir'
-    CONFIG_URL_PATH_KEY = 'url_path'
-    Dict = typing.Dict
-    EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
-    List = typing.List
-    Optional = typing.Optional
-    Union = typing.Union
-
-FILE
-    /Users/jmcampbell/cumulus-orca/tasks/copy_to_glacier/handler.py
 ```
 

--- a/tasks/copy_to_glacier/handler.py
+++ b/tasks/copy_to_glacier/handler.py
@@ -84,7 +84,6 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     """
     print(event)
     event_input = event.get('input')
-    # If there is no granules object, fail the workflow.
     granules_list = event_input.get('granules')
     config = event.get('config')
     collection = config.get(CONFIG_COLLECTION_KEY)

--- a/tasks/copy_to_glacier/handler.py
+++ b/tasks/copy_to_glacier/handler.py
@@ -64,8 +64,6 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
 
     Args:
         event: Passed through from {handler}
-
-
         context: An object required by AWS Lambda. Unused.
 
     Returns:
@@ -73,14 +71,11 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
             granules (List[Dict[str, Union[str, bytes, list]]]): A list of dicts where each dict has the following keys:
                 granuleId (str): The filename from the granule url.
                 files (List): A list of dicts with the following keys:
-                    path (str): config['fileStagingDir']
-                    url_path (str): config['url_path'] if present, otherwise config['fileStagingDir']
-                    bucket (str): The name of the config['buckets'] that matches the filename.
-                    filename (str): The granule_url from event['input']
-                    # todo: It is confusing that granuleId holds the filename while filename holds the url.
-                    name (str): The granule_url from event['input']
-                    # todo: This inclusion implies to me we are matching an un-linked schema.
-            input (list): event['input']
+                    name (str)
+                    filename (str)
+                    filepath (str)
+                    bucket (str)
+            copied_to_glacier (list): List of S3 paths - one for each file copied
     """
     print(event)
     event_input = event['input']
@@ -122,7 +117,8 @@ def handler(event: Dict[str, Union[List[str], Dict]], context: object) -> Any:
 
     Args:
         event: Event passed into the step from the aws workflow. A dict with the following keys:
-            input (list): A list of urls for granules to copy. Defaults to an empty list.
+            input (dict): Dictionary with the followig keys:
+                granules (List): List of granule objects (dictionaries)
             config (dict): A dict with the following keys:
                 collection (dict): The collection from AWS.
                     See https://nasa.github.io/cumulus/docs/data-cookbooks/sips-workflow
@@ -138,14 +134,9 @@ def handler(event: Dict[str, Union[List[str], Dict]], context: object) -> Any:
                             regex (str): The regex that all files in the bucket must match with their name.
                             bucket (str): The name of the bucket containing the files.
                     url_path (str): Used when calling {copy_granule_between_buckets} as a part of the destination_key.
-
-                fileStagingDir (str): Is placed as the value of the return's['granules'][filename]['files']['path']
-                    Will default to name__version where 'name' and 'version' come from 'config[collection]'.
                 buckets (dict): A dict with the following keys:
                     glacier (dict): A dict with the following keys:
                         name (str): The name of the bucket to copy to.
-                url_path (str): Is placed as the value of the return's['granules'][filename]['files']['url_path']
-                    Will default to the fileStagingDir.
 
 
         context: An object required by AWS Lambda. Unused.

--- a/tasks/copy_to_glacier/handler.py
+++ b/tasks/copy_to_glacier/handler.py
@@ -83,9 +83,10 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
             input (list): event['input']
     """
     print(event)
-    event_input = event.get('input')
-    granules_list = event_input.get('granules')
-    config = event.get('config')
+    event_input = event['input']
+    granules_list = event_input['granules']
+    config = event['config']
+
     collection = config.get(CONFIG_COLLECTION_KEY)
     exclude_file_types = collection.get(COLLECTION_META_KEY, {}).get(EXCLUDE_FILE_TYPES_KEY, [])
     glacier_bucket = config.get(CONFIG_BUCKETS_KEY).get('glacier').get('name')

--- a/tasks/copy_to_glacier/test/test_handler.py
+++ b/tasks/copy_to_glacier/test/test_handler.py
@@ -466,6 +466,9 @@ class TestCopyToGlacierHandler(TestCase):
             }
         )])
 
+    def test_get_granule_urls_from_granules_list(self):
+        pass
+
 # todo: switch this to large test
 #    def test_5_task(self):
 #        """

--- a/tasks/copy_to_glacier/test/test_handler.py
+++ b/tasks/copy_to_glacier/test/test_handler.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import copy
 from os import path
 from unittest import TestCase
 from unittest.mock import Mock, call
@@ -109,7 +110,7 @@ class TestCopyToGlacierHandler(TestCase):
         s3_cli.head_object = Mock(return_value={'ContentType': content_type})
 
         event = {
-            'input': self.event_granules,
+            'input': copy.deepcopy(self.event_granules),
             'config': {
                 CONFIG_COLLECTION_KEY: {
                     COLLECTION_NAME_KEY: collection_name,
@@ -135,7 +136,6 @@ class TestCopyToGlacierHandler(TestCase):
         self.assertEqual(1, len(granules))
         granule = granules[0]
         self.assertEqual(4, len(granule['files']))
-        file = granule['files'][0]
 
         head_object_calls = []
         copy_calls = []

--- a/tasks/copy_to_glacier/test/test_handler.py
+++ b/tasks/copy_to_glacier/test/test_handler.py
@@ -155,8 +155,12 @@ class TestCopyToGlacierHandler(TestCase):
         s3_cli.head_object.assert_has_calls(head_object_calls)
         s3_cli.copy.assert_has_calls(copy_calls)
 
+        self.assertEqual(s3_cli.head_object.call_count, 4)
+        self.assertEqual(s3_cli.copy.call_count, 4)
+
         expected_copied_file_urls = [ file['filename'] for file in self.event_granules['granules'][0]['files'] ]
         self.assertEqual(expected_copied_file_urls, result['copied_to_glacier'])
+        self.assertEqual(self.event_granules['granules'], result['granules'])
 
     def test_task_empty_granules_list(self):
         """

--- a/tasks/copy_to_glacier/test/test_handler.py
+++ b/tasks/copy_to_glacier/test/test_handler.py
@@ -18,48 +18,76 @@ class TestCopyToGlacierHandler(TestCase):
     two_prefix_file = 's3://test-bucket/prefix1/prefix2/file.txt'
     path_to_this_file = os.path.abspath(os.path.dirname(__file__))
     event_path = os.path.join(path_to_this_file, "event.json")
+    event_granules = {
+        'granules': [
+            {
+                "granuleId": "MOD09GQ.A2017025.h21v00.006.2017034065109",
+                "dataType": "MOD09GQ",
+                "version": "006",
+                "files": [
+                    {
+                        "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+                        "path": "MOD09GQ/006",
+                        "size": 6,
+                        "time": 1608318361000,
+                        "bucket": "orca-sandbox-protected",
+                        "url_path": "MOD09GQ/006/",
+                        "type": "",
+                        "filename": "s3://orca-sandbox-protected/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+                        "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+                        "duplicate_found": True
+                    },
+                    {
+                        "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+                        "path": "MOD09GQ/006",
+                        "size": 6,
+                        "time": 1608318366000,
+                        "bucket": "orca-sandbox-private",
+                        "url_path": "MOD09GQ/006",
+                        "type": "",
+                        "filename": "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+                        "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+                        "duplicate_found": True
+                    },
+                    {
+                        "name": "MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+                        "path": "MOD09GQ/006",
+                        "size": 6,
+                        "time": 1608318372000,
+                        "bucket": "orca-sandbox-public",
+                        "url_path": "MOD09GQ/006",
+                        "type": "",
+                        "filename": "s3://orca-sandbox-public/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+                        "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+                        "duplicate_found": True
+                    },
+                    {
+                        "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+                        "bucket": "orca-sandbox-private",
+                        "filename": "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+                        "type": "metadata",
+                        "filepath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+                        "url_path": "MOD09GQ/006"
+                    }
+                ]
+            }
+        ]
+    }
 
-    def test_1_exclude_file_types_excluded(self):
+    def test_exclude_file_types_excluded(self):
         """
         Testing exclude file types to be excluded
         """
         excluded_flag = should_exclude_files_type(self.excluded_file, ['.example'])
         self.assertEqual(excluded_flag, True)
 
-    def test_2_excluded_file_types_not_excluded(self):
+    def test_excluded_file_types_not_excluded(self):
         """
         Testing exclude file types not to be excluded
         """
 
         not_excluded_flag = should_exclude_files_type(self.not_excluded_file, ['.example'])
         self.assertEqual(not_excluded_flag, False)
-
-    def test_3_get_source_bucket_and_key(self):
-        """
-        Testing get source bucket and key
-        """
-        no_prefix_source = get_source_bucket_and_key(self.excluded_file)
-        self.assertEqual(no_prefix_source[1], 'test-bucket')
-        self.assertEqual(no_prefix_source[2], 'this_file_should_be_exclude.example')
-
-        one_prefix_source = get_source_bucket_and_key(self.not_excluded_file)
-        self.assertEqual(one_prefix_source[1], 'test-bucket')
-        self.assertEqual(one_prefix_source[2], 'prefix/this_file_should_not_be_exclude.txt')
-
-        two_prefix_source = get_source_bucket_and_key(self.two_prefix_file)
-        self.assertEqual(two_prefix_source[1], 'test-bucket')
-        self.assertEqual(two_prefix_source[2], 'prefix1/prefix2/file.txt')
-
-    def test_4_get_bucket(self):
-        """
-        Testing get bucket
-        """
-        with open(self.event_path) as f:
-            event = json.load(f)
-            filename = path.basename(event.get('input', [])[0])
-            files = event.get('config').get('collection').get('files', [])
-            bucket = get_bucket_name_for_filename(filename, files)
-            self.assertEqual(bucket, 'protected')
 
     def test_task_happy_path(self):
         """
@@ -69,35 +97,23 @@ class TestCopyToGlacierHandler(TestCase):
         collection_version = uuid.uuid4().__str__()
         destination_bucket_name = uuid.uuid4().__str__()
         source_bucket_name = uuid.uuid4().__str__()
-        filename = 'test' + uuid.uuid4().__str__() + '.ext'
         collection_url_path = uuid.uuid4().__str__()
         content_type = uuid.uuid4().__str__()
-        source_key = f'file-staging/blah/{collection_name}__{collection_version}/{filename}'
-        granule_url = f"s3://{source_bucket_name}/{source_key}"
+        source_bucket_names = [ file['bucket'] for file in self.event_granules['granules'][0]['files'] ]
+        source_keys = [ file['filepath'] for file in self.event_granules['granules'][0]['files'] ]
 
         # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
         boto3.client = Mock()
         s3_cli = boto3.client('s3')
-        s3_cli.copy = Mock(side_effect=[None])
+        s3_cli.copy = Mock(return_value=None)
         s3_cli.head_object = Mock(return_value={'ContentType': content_type})
 
         event = {
-            'input': [granule_url],
+            'input': self.event_granules,
             'config': {
                 CONFIG_COLLECTION_KEY: {
                     COLLECTION_NAME_KEY: collection_name,
                     COLLECTION_VERSION_KEY: collection_version,
-                    'files': [
-                        {
-                            'regex': '[a]+',
-                            'bucket': 'bad_bucket'
-                        },
-                        {
-                            'regex': '^test*.',
-                            'bucket': source_bucket_name
-                        }
-                    ],
-                    COLLECTION_URL_PATH_KEY: collection_url_path
                 },
                 CONFIG_BUCKETS_KEY: {
                     'bad_bucket': {
@@ -113,68 +129,56 @@ class TestCopyToGlacierHandler(TestCase):
 
         result = task(event, None)
 
-        self.assertEqual(event['input'], result['input'])
+        self.assertEqual(event['input']['granules'], result['granules'])
         granules = result['granules']
         self.assertIsNotNone(granules)
-        granules = list(granules)
         self.assertEqual(1, len(granules))
         granule = granules[0]
-        self.assertEqual(filename, granule['granuleId'])
-        self.assertEqual(1, len(granule['files']))
+        self.assertEqual(4, len(granule['files']))
         file = granule['files'][0]
-        self.assertEqual(f"{collection_name}__{collection_version}", file['path'])
-        self.assertEqual(f"{collection_name}__{collection_version}", file['url_path'])
-        self.assertEqual(source_bucket_name, file['bucket'])
-        self.assertEqual(granule_url, file['filename'])
-        self.assertEqual(granule_url, file['name'])
 
-        s3_cli.head_object.assert_called_once_with(Bucket=source_bucket_name, Key=source_key)
-        s3_cli.copy.assert_has_calls([call(
-            {'Bucket': source_bucket_name, 'Key': source_key},
-            destination_bucket_name,
-            f"{collection_url_path}/{filename}",
-            ExtraArgs={
-                'StorageClass': 'GLACIER',
-                'MetadataDirective': 'COPY',
-                'ContentType': content_type
-            }
-        )])
+        head_object_calls = []
+        copy_calls = []
+        for i in range(0, len(source_bucket_names)):
+            head_object_calls.append(call(Bucket=source_bucket_names[i], Key=source_keys[i]))
+            copy_calls.append(call(
+                {'Bucket': source_bucket_names[i], 'Key': source_keys[i]},
+                destination_bucket_name,
+                source_keys[i],
+                ExtraArgs={
+                    'StorageClass': 'GLACIER',
+                    'MetadataDirective': 'COPY',
+                    'ContentType': content_type
+                }
+            ))
 
-    def test_task_bucket_not_present(self):
+        s3_cli.head_object.assert_has_calls(head_object_calls)
+        s3_cli.copy.assert_has_calls(copy_calls)
+
+        expected_copied_file_urls = [ file['filename'] for file in self.event_granules['granules'][0]['files'] ]
+        self.assertEqual(expected_copied_file_urls, result['copied_to_glacier'])
+
+    def test_task_empty_granules_list(self):
         """
-        Bucket not present in collection, should default to 'public' in output.
-        Copy still uses passed in bucket name.
-        # todo: Why is this the way it is?
+        Basic path with buckets present.
         """
+        # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
         collection_name = uuid.uuid4().__str__()
         collection_version = uuid.uuid4().__str__()
         destination_bucket_name = uuid.uuid4().__str__()
-        source_bucket_name = uuid.uuid4().__str__()
-        filename = 'test' + uuid.uuid4().__str__() + '.ext'
-        collection_url_path = uuid.uuid4().__str__()
-        content_type = uuid.uuid4().__str__()
-        source_key = f'file-staging/blah/{collection_name}__{collection_version}/{filename}'
-        granule_url = f"s3://{source_bucket_name}/{source_key}"
-
-        # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
         boto3.client = Mock()
         s3_cli = boto3.client('s3')
-        s3_cli.copy = Mock(side_effect=[None])
-        s3_cli.head_object = Mock(return_value={'ContentType': content_type})
+        s3_cli.copy = Mock()
+        s3_cli.head_object = Mock()
 
         event = {
-            'input': [granule_url],
+            'input': {
+                "granules": []
+            },
             'config': {
                 CONFIG_COLLECTION_KEY: {
                     COLLECTION_NAME_KEY: collection_name,
                     COLLECTION_VERSION_KEY: collection_version,
-                    'files': [
-                        {
-                            'regex': '[a]+',
-                            'bucket': 'bad_bucket'
-                        }
-                    ],
-                    COLLECTION_URL_PATH_KEY: collection_url_path
                 },
                 CONFIG_BUCKETS_KEY: {
                     'bad_bucket': {
@@ -190,284 +194,12 @@ class TestCopyToGlacierHandler(TestCase):
 
         result = task(event, None)
 
-        self.assertEqual(event['input'], result['input'])
+        self.assertEqual([], result['granules'])
         granules = result['granules']
-        self.assertIsNotNone(granules)
-        granules = list(granules)
-        self.assertEqual(1, len(granules))
-        granule = granules[0]
-        self.assertEqual(filename, granule['granuleId'])
-        self.assertEqual(1, len(granule['files']))
-        file = granule['files'][0]
-        self.assertEqual(f"{collection_name}__{collection_version}", file['path'])
-        self.assertEqual(f"{collection_name}__{collection_version}", file['url_path'])
-        self.assertEqual('public', file['bucket'])
-        self.assertEqual(granule_url, file['filename'])
-        self.assertEqual(granule_url, file['name'])
+        self.assertEqual(0, len(granules))
 
-        s3_cli.head_object.assert_called_once_with(Bucket=source_bucket_name, Key=source_key)
-        s3_cli.copy.assert_has_calls([call(
-            {'Bucket': source_bucket_name, 'Key': source_key},
-            destination_bucket_name,
-            f"{collection_url_path}/{filename}",
-            ExtraArgs={
-                'StorageClass': 'GLACIER',
-                'MetadataDirective': 'COPY',
-                'ContentType': content_type
-            }
-        )])
-
-    def test_task_bad_file_type_does_not_halt(self):
-        """
-        A file whose extension is not safe to copy should NOT be copied between buckets.
-        It should also not halt execution, as other files can still be copied.
-        """
-        bad_file_type = '.garbage'
-        collection_name = uuid.uuid4().__str__()
-        collection_version = uuid.uuid4().__str__()
-        destination_bucket_name = uuid.uuid4().__str__()
-        source_bucket_name = uuid.uuid4().__str__()
-        filename = 'test' + uuid.uuid4().__str__() + '.ext'
-        bad_filename = 'test' + uuid.uuid4().__str__() + '.' + bad_file_type
-        collection_url_path = uuid.uuid4().__str__()
-        content_type = uuid.uuid4().__str__()
-        bad_source_key = f'file-staging/blah/{collection_name}__{collection_version}/{bad_filename}'
-        source_key = f'file-staging/blah/{collection_name}__{collection_version}/{filename}'
-        bad_granule_url = f"s3://{source_bucket_name}/{bad_source_key}"
-        granule_url = f"s3://{source_bucket_name}/{source_key}"
-
-        # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
-        boto3.client = Mock()
-        s3_cli = boto3.client('s3')
-        s3_cli.copy = Mock(side_effect=[None])
-        s3_cli.head_object = Mock(return_value={'ContentType': content_type})
-
-        event = {
-            'input': [bad_granule_url, granule_url],
-            'config': {
-                CONFIG_COLLECTION_KEY: {
-                    COLLECTION_NAME_KEY: collection_name,
-                    COLLECTION_VERSION_KEY: collection_version,
-                    'files': [
-                        {
-                            'regex': '[a]+',
-                            'bucket': 'bad_bucket'
-                        },
-                        {
-                            'regex': '^test*.',
-                            'bucket': source_bucket_name
-                        }
-                    ],
-                    COLLECTION_URL_PATH_KEY: collection_url_path,
-                    COLLECTION_META_KEY: {
-                        EXCLUDE_FILE_TYPES_KEY: [bad_file_type]
-                    }
-                },
-                CONFIG_BUCKETS_KEY: {
-                    'bad_bucket': {
-                        'name': 'not_glacier'
-                    },
-                    'glacier': {
-                        'name': destination_bucket_name
-                    }
-                }
-            }
-
-        }
-
-        result = task(event, None)
-
-        self.assertEqual(event['input'], result['input'])
-        granules = result['granules']
-        self.assertIsNotNone(granules)
-        granules = list(granules)
-        self.assertEqual(2, len(granules), 'There should be a granule even if nothing was copied.')
-        granule = granules[1]
-        self.assertEqual(filename, granule['granuleId'])
-        self.assertEqual(1, len(granule['files']))
-        file = granule['files'][0]
-        self.assertEqual(f"{collection_name}__{collection_version}", file['path'])
-        self.assertEqual(f"{collection_name}__{collection_version}", file['url_path'])
-        self.assertEqual(source_bucket_name, file['bucket'])
-        self.assertEqual(granule_url, file['filename'])
-        self.assertEqual(granule_url, file['name'])
-
-        s3_cli.head_object.assert_called_once_with(Bucket=source_bucket_name, Key=source_key)
-        s3_cli.copy.assert_has_calls([call(
-            {'Bucket': source_bucket_name, 'Key': source_key},
-            destination_bucket_name,
-            f"{collection_url_path}/{filename}",
-            ExtraArgs={
-                'StorageClass': 'GLACIER',
-                'MetadataDirective': 'COPY',
-                'ContentType': content_type
-            }
-        )])
-
-    def test_fileStagingDir_overridden(self):
-        """
-        Overriding fileStagingDir affects output.
-        """
-        collection_name = uuid.uuid4().__str__()
-        collection_version = uuid.uuid4().__str__()
-        destination_bucket_name = uuid.uuid4().__str__()
-        source_bucket_name = uuid.uuid4().__str__()
-        filename = 'test' + uuid.uuid4().__str__() + '.ext'
-        collection_url_path = uuid.uuid4().__str__()
-        content_type = uuid.uuid4().__str__()
-        file_staging_dir = uuid.uuid4().__str__()
-        source_key = f'file-staging/blah/{file_staging_dir}/{filename}'
-        granule_url = f"s3://{source_bucket_name}/{source_key}"
-
-        # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
-        boto3.client = Mock()
-        s3_cli = boto3.client('s3')
-        s3_cli.copy = Mock(side_effect=[None])
-        s3_cli.head_object = Mock(return_value={'ContentType': content_type})
-
-        event = {
-            'input': [granule_url],
-            'config': {
-                CONFIG_FILE_STAGING_DIRECTORY_KEY: file_staging_dir,
-                CONFIG_COLLECTION_KEY: {
-                    COLLECTION_NAME_KEY: collection_name,
-                    COLLECTION_VERSION_KEY: collection_version,
-                    'files': [
-                        {
-                            'regex': '[a]+',
-                            'bucket': 'bad_bucket'
-                        },
-                        {
-                            'regex': '^test*.',
-                            'bucket': source_bucket_name
-                        }
-                    ],
-                    COLLECTION_URL_PATH_KEY: collection_url_path
-                },
-                CONFIG_BUCKETS_KEY: {
-                    'bad_bucket': {
-                        'name': 'not_glacier'
-                    },
-                    'glacier': {
-                        'name': destination_bucket_name
-                    }
-                }
-            }
-
-        }
-
-        result = task(event, None)
-
-        self.assertEqual(event['input'], result['input'])
-        granules = result['granules']
-        self.assertIsNotNone(granules)
-        granules = list(granules)
-        self.assertEqual(1, len(granules))
-        granule = granules[0]
-        self.assertEqual(filename, granule['granuleId'])
-        self.assertEqual(1, len(granule['files']))
-        file = granule['files'][0]
-        self.assertEqual(file_staging_dir, file['path'])
-        self.assertEqual(file_staging_dir, file['url_path'])
-        self.assertEqual(source_bucket_name, file['bucket'])
-        self.assertEqual(granule_url, file['filename'])
-        self.assertEqual(granule_url, file['name'])
-
-        s3_cli.head_object.assert_called_once_with(Bucket=source_bucket_name, Key=source_key)
-        s3_cli.copy.assert_has_calls([call(
-            {'Bucket': source_bucket_name, 'Key': source_key},
-            destination_bucket_name,
-            f"{collection_url_path}/{filename}",
-            ExtraArgs={
-                'StorageClass': 'GLACIER',
-                'MetadataDirective': 'COPY',
-                'ContentType': content_type
-            }
-        )])
-
-    def test_url_path_overridden(self):
-        """
-        Overriding url_path in config affects output.
-        """
-        collection_name = uuid.uuid4().__str__()
-        collection_version = uuid.uuid4().__str__()
-        destination_bucket_name = uuid.uuid4().__str__()
-        source_bucket_name = uuid.uuid4().__str__()
-        filename = 'test' + uuid.uuid4().__str__() + '.ext'
-        collection_url_path = uuid.uuid4().__str__()
-        content_type = uuid.uuid4().__str__()
-        source_key = f'file-staging/blah/{collection_name}__{collection_version}/{filename}'
-        granule_url = f"s3://{source_bucket_name}/{source_key}"
-        config_url_path = uuid.uuid4().__str__()
-
-        # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
-        boto3.client = Mock()
-        s3_cli = boto3.client('s3')
-        s3_cli.copy = Mock(side_effect=[None])
-        s3_cli.head_object = Mock(return_value={'ContentType': content_type})
-
-        event = {
-            'input': [granule_url],
-            'config': {
-                CONFIG_URL_PATH_KEY: config_url_path,
-                CONFIG_COLLECTION_KEY: {
-                    COLLECTION_NAME_KEY: collection_name,
-                    COLLECTION_VERSION_KEY: collection_version,
-                    'files': [
-                        {
-                            'regex': '[a]+',
-                            'bucket': 'bad_bucket'
-                        },
-                        {
-                            'regex': '^test*.',
-                            'bucket': source_bucket_name
-                        }
-                    ],
-                    COLLECTION_URL_PATH_KEY: collection_url_path
-                },
-                CONFIG_BUCKETS_KEY: {
-                    'bad_bucket': {
-                        'name': 'not_glacier'
-                    },
-                    'glacier': {
-                        'name': destination_bucket_name
-                    }
-                }
-            }
-
-        }
-
-        result = task(event, None)
-
-        self.assertEqual(event['input'], result['input'])
-        granules = result['granules']
-        self.assertIsNotNone(granules)
-        granules = list(granules)
-        self.assertEqual(1, len(granules))
-        granule = granules[0]
-        self.assertEqual(filename, granule['granuleId'])
-        self.assertEqual(1, len(granule['files']))
-        file = granule['files'][0]
-        self.assertEqual(f"{collection_name}__{collection_version}", file['path'])
-        self.assertEqual(config_url_path, file['url_path'])
-        self.assertEqual(source_bucket_name, file['bucket'])
-        self.assertEqual(granule_url, file['filename'])
-        self.assertEqual(granule_url, file['name'])
-
-        s3_cli.head_object.assert_called_once_with(Bucket=source_bucket_name, Key=source_key)
-        s3_cli.copy.assert_has_calls([call(
-            {'Bucket': source_bucket_name, 'Key': source_key},
-            destination_bucket_name,
-            f"{collection_url_path}/{filename}",
-            ExtraArgs={
-                'StorageClass': 'GLACIER',
-                'MetadataDirective': 'COPY',
-                'ContentType': content_type
-            }
-        )])
-
-    def test_get_granule_urls_from_granules_list(self):
-        pass
+        s3_cli.head_object.assert_not_called()
+        s3_cli.copy.assert_not_called()
 
 # todo: switch this to large test
 #    def test_5_task(self):


### PR DESCRIPTION
## Summary of Changes

Generalize input/output of copy_to_glacier lambda so it can be used anywhere in a workflow.

Addresses [ORCA-67: Generalize input/output of copy_to_glacier lambda so it can be used anywhere in a workflow.](https://bugs.earthdata.nasa.gov/browse/ORCA-67)

## Changes

* `copy_to_glacier` function now takes a granule object, like the one returned from Cumulus' `MoveGranules` as input.
* Removed a bunch of code that was used for generating filepaths/meta information based on the s3 filepath. Those values are all part of the input `granule` object.
* Remove support for setting a custom staging directory - files in Glacier storage will have the same s3 key as those in primary storage - only the bucket is different.
* Update tests and `README.md`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual integration testing with the orca-sandbox stack

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Testing documentation
    - [x] Development documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
    - [x] Manual testing/integration testing passes (if forked)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets

## What is the current behavior?

Currently the input to `copy_to_glacier` is a list of s3 filepaths. This is simple, but also means that users somehow have to generate this string in some previous Cumulus task.

## What is the expected correct/added behavior?

My changes take the input of a standard Cumulus task as output so the `copy_to_glacier` task is easier to integrate into a workflow.
