### PR TITLE
Hotfix/orca 125

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+## [v2.0.1] 2021-2-5
+
+### Changed
+* *ORCA-125* BucketOwnerFullControl ACL is now set on PUT requests to buckets.
+  Prevents errors during cross-OU copying.
+
 ## [v2.0.0] 2021-1-15
 
 ### Migration Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [v2.0.1] 2021-2-5
 
 ### Changed
-* *ORCA-125* BucketOwnerFullControl ACL is now set on PUT requests to buckets.
-  Prevents errors during cross-OU copying.
+* *ORCA-125* BucketOwnerFullControl ACL is now set on for storage PUT requests in the copy_to_glacier lambda. This prevents errors during cross account (OU) copying of data.
 
 ## [v2.0.0] 2021-1-15
 

--- a/tasks/copy_to_glacier/test/unit_tests/test_handler.py
+++ b/tasks/copy_to_glacier/test/unit_tests/test_handler.py
@@ -1,7 +1,6 @@
-import json
-import uuid
 import copy
-from os import path
+import os
+import uuid
 from unittest import TestCase
 from unittest.mock import Mock, call
 
@@ -100,8 +99,8 @@ class TestCopyToGlacierHandler(TestCase):
         source_bucket_name = uuid.uuid4().__str__()
         collection_url_path = uuid.uuid4().__str__()
         content_type = uuid.uuid4().__str__()
-        source_bucket_names = [ file['bucket'] for file in self.event_granules['granules'][0]['files'] ]
-        source_keys = [ file['filepath'] for file in self.event_granules['granules'][0]['files'] ]
+        source_bucket_names = [file['bucket'] for file in self.event_granules['granules'][0]['files']]
+        source_keys = [file['filepath'] for file in self.event_granules['granules'][0]['files']]
 
         # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
         boto3.client = Mock()
@@ -148,7 +147,8 @@ class TestCopyToGlacierHandler(TestCase):
                 ExtraArgs={
                     'StorageClass': 'GLACIER',
                     'MetadataDirective': 'COPY',
-                    'ContentType': content_type
+                    'ContentType': content_type,
+                    'ACL': 'bucket-owner-full-control'
                 }
             ))
 
@@ -158,7 +158,7 @@ class TestCopyToGlacierHandler(TestCase):
         self.assertEqual(s3_cli.head_object.call_count, 4)
         self.assertEqual(s3_cli.copy.call_count, 4)
 
-        expected_copied_file_urls = [ file['filename'] for file in self.event_granules['granules'][0]['files'] ]
+        expected_copied_file_urls = [file['filename'] for file in self.event_granules['granules'][0]['files']]
         self.assertEqual(expected_copied_file_urls, result['copied_to_glacier'])
         self.assertEqual(self.event_granules['granules'], result['granules'])
 


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-125: copy-to-glacier lambda needs to set BucketOwnerFullControl ACL](https://bugs.earthdata.nasa.gov/browse/ORCA-125)

## Changes

* Adds ACL rule for PUT requests to buckets.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Setup
- A full Cumulus stack is needed that includes the ORCA code.
- 2 ORCA buckets were created.
    - The first ORCA bucket resides in the disaster recovery OU and has cross account policies applied to it.
    - The second ORCA bucket was created in the Cumulus OU with no cross account policies
- Python 3.7 is needed to build the new lambda code. Following the build instructions, a new `copy_to_glacier` lambda zip file with the changes.

### DR OU Test Procedure
- The ORCA DR OU bucket was configured as part of the Cumulus stack and the stack was redeployed using the following commands.
  ```bash
  terraform init
  terraform apply
  ``` 
- The updated lambda code was loaded into the workflow using the following command
   ```bash
   aws lambda update-function-code --function-name orca-sandbox_copy_to_glacier --zip-file fileb://copy_to_glacier.zip --profile default
   ```
- 9 Granules were ingested into the Cumulus instance. No errors occurred from the execution on the dashboard.
- Outputs from CloudWatch for the copy_to_glacier lambda,  and the Cumulus Dashboard were manually verified.
- Contents of the ORCA DR OU Bucket were manually verified.

### Cumulus OU Test Procedure
- The ORCA Cumulus OU bucket was configured as part of the Cumulus stack and the stack was redeployed using the following commands.
  ```bash
  terraform init
  terraform apply
  ``` 
- The updated lambda code was loaded into the workflow using the following command
   ```bash
   aws lambda update-function-code --function-name orca-sandbox_copy_to_glacier --zip-file fileb://copy_to_glacier.zip --profile default
   ```
- 9 Granules were ingested into the Cumulus instance. No errors occurred from the execution on the dashboard.
- Outputs from CloudWatch for the copy_to_glacier lambda,  and the Cumulus Dashboard were manually verified.
- Contents of the ORCA Cumulus OU Bucket were manually verified.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests (outlined above)
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
    - [x] Manual testing/integration testing passes (if forked)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
