### PR TITLE
[ORCA-84] Added content to the Deployment Information page.

### DIFF
--- a/website/docs/developer/deployment-guide/deployment.md
+++ b/website/docs/developer/deployment-guide/deployment.md
@@ -3,15 +3,6 @@ id: deployment
 title: Deployment Information
 description: Provides developer information for ORCA code deployment.
 ---
-
-## Introduction to ORCA
-The Operational Recovery Cloud Archive (ORCA) provides 
-a baseline solution for creating, and managing 
-operational backups in the cloud. In addition, best
-practices and recovery code that manages common 
-baseline recovery scenarios is also maintained.
-
-
 ## Deploying ORCA
 The following sections provide information on how to
 deploy ORCA with or along-side Cumulus.

--- a/website/docs/developer/deployment-guide/deployment.md
+++ b/website/docs/developer/deployment-guide/deployment.md
@@ -45,7 +45,6 @@ for instructions to deploy ORCA with Cumulus.
 
 
 ## Configuring ORCA
-Once ORCA is deployed, configure the collection in the Cumulus 
-Dashboard for utilizing ORCA. See ORCA Configuration for 
-instructions.
+Once ORCA is deployed, configure the collection in the Cumulus Dashboard for utilizing ORCA. See [ORCA Configuration](deployment-with-cumulus.md#collection-configuration) 
+for instructions.
 

--- a/website/docs/developer/deployment-guide/deployment.md
+++ b/website/docs/developer/deployment-guide/deployment.md
@@ -1,8 +1,51 @@
 ---
 id: deployment
-title: Developer Deployment
+title: Deployment Information
 description: Provides developer information for ORCA code deployment.
 ---
 
-This document is currently under construction.
+## Introduction to ORCA
+The Operational Recovery Cloud Archive (ORCA) provides 
+a baseline solution for creating, and managing 
+operational backups in the cloud. In addition, best
+practices and recovery code that manages common 
+baseline recovery scenarios is also maintained.
+
+
+## Deploying ORCA
+The following sections provide information on how to
+deploy ORCA with or along-side Cumulus.
+### Setup Deployment Environment
+In order to deploy ORCA into an NGAP environment with 
+Cumulus, a deployment environment needs be created.
+
+Visit [Creating a Deployment Environment](setting-up-deployment-environment.md)
+to view the instructions for setting up your ORCA deployment environment.
+
+### ORCA Archive Bucket
+ORCA maintains a cloud ready backup of science and 
+ancillary data in an S3-IA bucket and utilizes AWS 
+bucket transition policies to store the data in S3 
+Glacier for the long term. The ORCA archive bucket can 
+live in any NGAP Organizational Unit (OU).
+
+Visit [Creating the Glacier Bucket](creating-orca-glacier-bucket.md)
+to view the instructions for setting up a Glacier 
+bucket.
+
+:::important
+Prior to deploying ORCA with Cumulus, the ORCA archive bucket must be
+created.
+:::
+
+### Deploy ORCA with Cumulus
+After the ORCA archive bucket has been created, ORCA is ready to be
+deployed. Visit [ORCA deployment documentation](deployment-with-cumulus.md)
+for instructions to deploy ORCA with Cumulus.
+
+
+## Configuring ORCA
+Once ORCA is deployed, configure the collection in the Cumulus 
+Dashboard for utilizing ORCA. See ORCA Configuration for 
+instructions.
 


### PR DESCRIPTION
## Summary of Changes

Created content for the Deployment Information page. Included descriptions and links for deploying ORCA and its prerequisites.

Addresses [ORCA-84: Create "How to Deploy ORCA" page for ORCA developer documentation.](https://bugs.earthdata.nasa.gov/browse/ORCA-84)

## Changes

* Updated title to "Deployment Information"
* Updated description of the page to "Provides developer information for ORCA code deployment."
* Added content for the Deploying ORCA section, including subsections critical to ORCA deployment.
* Added content for the Configuring ORCA section.

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

## How Has This Been Tested?

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [X] User documentation
 - [X] My changes generate no new warnings


