### PR TITLE
Feature/orca 172 requests_status_for_* lambda table updates

### DIFF
--- a/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule_unit.py
+++ b/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule_unit.py
@@ -324,7 +324,7 @@ class TestRequestStatusForGranuleUnit(
             SELECT
                 job_id
             FROM
-                orca_recoveryjob
+                recovery_job
             WHERE
                 granule_id = %s
             ORDER BY
@@ -383,7 +383,7 @@ class TestRequestStatusForGranuleUnit(
                 request_time as "{request_status_for_granule.OUTPUT_REQUEST_TIME_KEY}",
                 completion_time as "{request_status_for_granule.OUTPUT_COMPLETION_TIME_KEY}"
             FROM
-                orca_recoveryjob
+                recovery_job
             WHERE
                 granule_id = %s AND job_id = %s""",
             db_connect_info,
@@ -435,13 +435,13 @@ class TestRequestStatusForGranuleUnit(
         mock_single_query.assert_called_once_with(
             f"""
             SELECT
-                orca_recoverfile.filename AS "{request_status_for_granule.OUTPUT_FILENAME_KEY}",
-                orca_recoverfile.restore_destination AS "{request_status_for_granule.OUTPUT_RESTORE_DESTINATION_KEY}",
-                orca_status.value AS "{request_status_for_granule.OUTPUT_STATUS_KEY}",
-                orca_recoverfile.error_message as "{request_status_for_granule.OUTPUT_ERROR_MESSAGE_KEY}"
+                recovery_file.filename AS "{request_status_for_granule.OUTPUT_FILENAME_KEY}",
+                recovery_file.restore_destination AS "{request_status_for_granule.OUTPUT_RESTORE_DESTINATION_KEY}",
+                recovery_status.value AS "{request_status_for_granule.OUTPUT_STATUS_KEY}",
+                recovery_file.error_message as "{request_status_for_granule.OUTPUT_ERROR_MESSAGE_KEY}"
             FROM
-                orca_recoverfile
-            JOIN orca_status ON orca_recoverfile.status_id=orca_status.id
+                recovery_file
+            JOIN recovery_status ON recovery_file.status_id=recovery_status.id
             WHERE
                 granule_id = %s AND job_id = %s
             ORDER BY filename desc""",

--- a/tasks/request_status_for_job/request_status_for_job.py
+++ b/tasks/request_status_for_job/request_status_for_job.py
@@ -6,13 +6,13 @@ import requests_db
 from cumulus_logger import CumulusLogger
 from requests_db import DatabaseError
 
-INPUT_JOB_ID_KEY = 'asyncOperationId'
+INPUT_JOB_ID_KEY = "asyncOperationId"
 
-OUTPUT_JOB_ID_KEY = 'asyncOperationId'
-OUTPUT_JOB_STATUS_TOTALS_KEY = 'job_status_totals'
-OUTPUT_GRANULES_KEY = 'granules'
-OUTPUT_STATUS_KEY = 'status'
-OUTPUT_GRANULE_ID_KEY = 'granule_id'
+OUTPUT_JOB_ID_KEY = "asyncOperationId"
+OUTPUT_JOB_STATUS_TOTALS_KEY = "job_status_totals"
+OUTPUT_GRANULES_KEY = "granules"
+OUTPUT_STATUS_KEY = "status"
+OUTPUT_GRANULE_ID_KEY = "granule_id"
 
 LOGGER = CumulusLogger()
 
@@ -43,20 +43,25 @@ def task(job_id: str, db_connect_info: Dict, request_id: str) -> Dict[str, Any]:
     status_entries = get_granule_status_entries_for_job(job_id, db_connect_info)
     if len(status_entries) == 0:
         return create_http_error_dict(
-            "NotFound", HTTPStatus.NOT_FOUND, request_id,
-            f"No granules found for job id '{job_id}'.")
+            "NotFound",
+            HTTPStatus.NOT_FOUND,
+            request_id,
+            f"No granules found for job id '{job_id}'.",
+        )
 
     status_totals = get_status_totals_for_job(job_id, db_connect_info)
     return {
         OUTPUT_JOB_ID_KEY: job_id,
         OUTPUT_JOB_STATUS_TOTALS_KEY: status_totals,
-        OUTPUT_GRANULES_KEY: status_entries
+        OUTPUT_GRANULES_KEY: status_entries,
     }
 
 
-def get_granule_status_entries_for_job(job_id: str, db_connect_info: Dict) -> List[Dict[str, Any]]:
+def get_granule_status_entries_for_job(
+    job_id: str, db_connect_info: Dict
+) -> List[Dict[str, Any]]:
     """
-    Gets the orca_recoveryjob status entry for the associated job_id.
+    Gets the recovery_job status entry for the associated job_id.
 
     Args:
         job_id: The unique asyncOperationId of the recovery job to retrieve status for.
@@ -70,10 +75,10 @@ def get_granule_status_entries_for_job(job_id: str, db_connect_info: Dict) -> Li
     sql = f"""
             SELECT
                 granule_id as "{OUTPUT_GRANULE_ID_KEY}",
-                orca_status.value AS "{OUTPUT_STATUS_KEY}"
+                recovery_status.value AS "{OUTPUT_STATUS_KEY}"
             FROM
-                orca_recoveryjob
-            JOIN orca_status ON orca_recoveryjob.status_id=orca_status.id
+                recovery_job
+            JOIN recovery_status ON recovery_job.status_id=recovery_status.id
             WHERE
                 job_id = %s
             """
@@ -90,7 +95,7 @@ def get_granule_status_entries_for_job(job_id: str, db_connect_info: Dict) -> Li
 def get_status_totals_for_job(job_id: str, db_connect_info: Dict) -> Dict[str, int]:
     # noinspection SpellCheckingInspection
     """
-    Gets the number of orca_recoveryjobs for the given job_id for each possible status value.
+    Gets the number of recovery_job for the given job_id for each possible status value.
 
     Args:
         job_id: The unique id of the recovery job to retrieve status for.
@@ -107,13 +112,13 @@ def get_status_totals_for_job(job_id: str, db_connect_info: Dict) -> Dict[str, i
             with granule_status_count AS (
                 SELECT status_id
                     , count(*) as total
-                FROM orca_recoveryjob
+                FROM recovery_job
                 WHERE job_id = %s
                 GROUP BY status_id
             )
             SELECT value
                 , coalesce(total, 0) as total
-            FROM orca_status os
+            FROM recovery_status os
             LEFT JOIN granule_status_count gsc ON (gsc.status_id = os.id)"""
 
     try:
@@ -121,11 +126,13 @@ def get_status_totals_for_job(job_id: str, db_connect_info: Dict) -> Dict[str, i
     except database.DbError as err:
         LOGGER.error(f"DbError: {str(err)}")
         raise DatabaseError(str(err))
-    totals = {row['value']: row['total'] for row in rows}
+    totals = {row["value"]: row["total"] for row in rows}
     return totals
 
 
-def create_http_error_dict(error_type: str, http_status_code: int, request_id: str, message: str) -> Dict[str, Any]:
+def create_http_error_dict(
+    error_type: str, http_status_code: int, request_id: str, message: str
+) -> Dict[str, Any]:
     """
     Creates a standardized dictionary for error reporting.
     Args:
@@ -142,10 +149,10 @@ def create_http_error_dict(error_type: str, http_status_code: int, request_id: s
     """
     LOGGER.error(message)
     return {
-        'errorType': error_type,
-        'httpStatus': http_status_code,
-        'requestId': request_id,
-        'message': message
+        "errorType": error_type,
+        "httpStatus": http_status_code,
+        "requestId": request_id,
+        "message": message,
     }
 
 
@@ -183,12 +190,19 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     job_id = event.get(INPUT_JOB_ID_KEY, None)
     if job_id is None or len(job_id) == 0:
-        return create_http_error_dict("BadRequest", HTTPStatus.BAD_REQUEST, context.aws_request_id,
-                                      f"{INPUT_JOB_ID_KEY} must be set to a non-empty value.")
+        return create_http_error_dict(
+            "BadRequest",
+            HTTPStatus.BAD_REQUEST,
+            context.aws_request_id,
+            f"{INPUT_JOB_ID_KEY} must be set to a non-empty value.",
+        )
     db_connect_info = requests_db.get_dbconnect_info()
     try:
         return task(job_id, db_connect_info, context.aws_request_id)
     except DatabaseError as db_error:
         return create_http_error_dict(
-            "InternalServerError", HTTPStatus.INTERNAL_SERVER_ERROR, context.aws_request_id, db_error.__str__())
-
+            "InternalServerError",
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            context.aws_request_id,
+            db_error.__str__(),
+        )

--- a/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job_unit.py
+++ b/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job_unit.py
@@ -124,7 +124,7 @@ class TestRequestStatusForJobUnit(
         mock_create_http_error_dict: MagicMock,
     ):
         """
-        If no orca_recoveryjob entries exist for the given job_id, return 404.
+        If no recovery_job entries exist for the given job_id, return 404.
         """
         job_id = uuid.uuid4().__str__()
         db_connect_info = Mock()
@@ -161,10 +161,10 @@ class TestRequestStatusForJobUnit(
             f"""
             SELECT
                 granule_id as "{request_status_for_job.OUTPUT_GRANULE_ID_KEY}",
-                orca_status.value AS "{request_status_for_job.OUTPUT_STATUS_KEY}"
+                recovery_status.value AS "{request_status_for_job.OUTPUT_STATUS_KEY}"
             FROM
-                orca_recoveryjob
-            JOIN orca_status ON orca_recoveryjob.status_id=orca_status.id
+                recovery_job
+            JOIN recovery_status ON recovery_job.status_id=recovery_status.id
             WHERE
                 job_id = %s
             """,
@@ -214,13 +214,13 @@ class TestRequestStatusForJobUnit(
             with granule_status_count AS (
                 SELECT status_id
                     , count(*) as total
-                FROM orca_recoveryjob
+                FROM recovery_job
                 WHERE job_id = %s
                 GROUP BY status_id
             )
             SELECT value
                 , coalesce(total, 0) as total
-            FROM orca_status os
+            FROM recovery_status os
             LEFT JOIN granule_status_count gsc ON (gsc.status_id = os.id)""",
             db_connect_info,
             (job_id,),


### PR DESCRIPTION
## Summary of Changes

Updated the name of the tables used in queries to normalize naming from db_deploy and other database scripts.

Addresses [ORCA-172: DB migration for new status table](https://bugs.earthdata.nasa.gov/browse/ORCA-172)

## Changes

### Modified
* tasks/request_status_for_job
  * request_status_for_job.py - changed orca recovery table names to actual names used in migration.
  * test/unit_tests/test_request_status_for_job.py - changed orca recovery table names to actual names used in migration.
* tasks/request_status_for_granule
  * request_status_for_granule.py - changed orca recovery table names to actual names used in migration.
  * test/unit_tests/test_request_status_for_granule.py - changed orca recovery table names to actual names used in migration.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests were ran to validate the fix.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
    - [X] Automated tests passing (if not fork)
- [X] My code has passed security scanning
    - [X] Snyk
    - [X] git-secrets

