### PR TITLE
Feature/orca 170

### DIFF
--- a/bin/build_tasks.sh
+++ b/bin/build_tasks.sh
@@ -48,7 +48,7 @@ cd ../../
 
 
 failure=0
-for TASK in $(ls -d tasks/* | egrep "request_status_|db_deploy|copy_files_to_archive|post_copy_request_to_queue|request_files")
+for TASK in $(ls -d tasks/* | egrep "request_status_|db_deploy|post_to_database|copy_files_to_archive|post_copy_request_to_queue|orca_catalog_reporting_dummy")
 do
   echo "Building ${TASK}"
   cd ${TASK}

--- a/bin/build_tasks.sh
+++ b/bin/build_tasks.sh
@@ -31,26 +31,6 @@ cd build
 zip -qr "../extract_filepaths_for_granule.zip" .
 cd ../../../
 
-TASK='tasks/request_files/'
-echo "Building `pwd`/${TASK}"
-cd "`pwd`/${TASK}"
-rm -rf build
-mkdir build
-source ../../venv/bin/activate
-pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host pypi.org --trusted-host files.pythonhosted.org
-deactivate
-cp request_files.py build/
-cd build
-mkdir psycopg2
-cd ..
-cp ../package/awslambda-psycopg2/psycopg2-3.7/* build/psycopg2/
-cd build
-zip -qr "../request_files.zip" .
-cd ..
-rm -rf build
-cd ../../
-
-
 TASK='tasks/copy_to_glacier/'
 echo "Building `pwd`/${TASK}"
 cd "`pwd`/${TASK}"
@@ -68,7 +48,7 @@ cd ../../
 
 
 failure=0
-for TASK in $(ls -d tasks/* | egrep "request_status_|db_deploy|copy_files_to_archive")
+for TASK in $(ls -d tasks/* | egrep "request_status_|db_deploy|copy_files_to_archive|post_copy_request_to_queue|request_files")
 do
   echo "Building ${TASK}"
   cd ${TASK}

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -5,7 +5,7 @@ base=$(pwd)
 failed=0
 
 # Crawl the task directories
-for taskdir in `ls -d tasks/* | egrep -v 'request_status_for|shared_libraries|db_deploy|package|copy_files_to_archive' `
+for taskdir in `ls -d tasks/* | egrep -v 'request_status_for|shared_libraries|db_deploy|package|copy_files_to_archive|post_copy_request_to_queue|request_files' `
 do
   # Build and run tests for each task directory
   cd $taskdir
@@ -47,7 +47,7 @@ done
 
 ## Call each tasks testing suite
 ## TODO: Add more logging output and possibly make asynchronus
-for task in $(ls -d tasks/* | egrep "request_status_|db_deploy"|copy_files_to_archive")
+for task in $(ls -d tasks/* | "egrep "request_status_|db_deploy|copy_files_to_archive|post_copy_request_to_queue|request_files"")
 do
   echo
   echo "Running tests in $task"

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -5,7 +5,7 @@ base=$(pwd)
 failed=0
 
 # Crawl the task directories
-for taskdir in `ls -d tasks/* | egrep -v 'request_status_for|shared_libraries|db_deploy|package|copy_files_to_archive|post_copy_request_to_queue|request_files' `
+for taskdir in `ls -d tasks/* | egrep -v 'request_status_for|shared_libraries|db_deploy|package|post_to_database|copy_files_to_archive|post_copy_request_to_queue|orca_catalog_reporting_dummy' `
 do
   # Build and run tests for each task directory
   cd $taskdir
@@ -47,7 +47,7 @@ done
 
 ## Call each tasks testing suite
 ## TODO: Add more logging output and possibly make asynchronus
-for task in $(ls -d tasks/* | "egrep "request_status_|db_deploy|copy_files_to_archive|post_copy_request_to_queue|request_files"")
+for task in $(ls -d tasks/* | egrep "request_status_|db_deploy|post_to_database|copy_files_to_archive|post_copy_request_to_queue|orca_catalog_reporting_dummy")
 do
   echo
   echo "Running tests in $task"

--- a/tasks/request_files/bin/build.sh
+++ b/tasks/request_files/bin/build.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+## =============================================================================
+## NAME: build.sh
+##
+##
+## DESCRIPTION
+## -----------------------------------------------------------------------------
+## Builds the lambda (task) zip file for request_files.
+##
+##
+## USAGE
+## -----------------------------------------------------------------------------
+## bin/build.sh
+##
+## This must be called from the (root) lambda directory /tasks/request_files
+## =============================================================================
+
+## Set this for Debugging only
+#set -ex
+
+## Make sure we are calling the script the correct way.
+BASEDIR=$(dirname $0)
+if [ "$BASEDIR" != "bin" ]; then
+  >&2 echo "ERROR: This script must be called from the root directory of the task lambda [bin/build.sh]."
+  exit 1
+fi
+
+
+## FUNCTIONS
+## -----------------------------------------------------------------------------
+function check_rc () {
+  ## Checks the return code of call and if not equal to 0, emits an error and
+  ## exits the script with a failure.
+  ##
+  ## Args:
+  ##   $1 - Return Code from command
+  ##   $2 - Error message if failure occurs.
+
+  let RC=$1
+  MESSAGE=$2
+
+  if [ $RC -ne 0 ]; then
+      >&2 echo "$MESSAGE"
+      deactivate
+      exit 1
+  fi
+}
+
+## MAIN
+## -----------------------------------------------------------------------------
+## Create the build director. Remove it if it exists.
+echo "INFO: Creating build directory ..."
+if [ -d build ]; then
+    rm -rf build
+fi
+
+mkdir build
+let return_code=$?
+
+if [ $return_code -ne 0 ]; then
+  >&2 echo "ERROR: Failed to create build directory."
+  exit 1
+fi
+
+## Create the virtual env. Remove it if it already exists.
+echo "INFO: Creating virtual environment ..."
+if [ -d venv ]; then
+  rm -rf venv
+  find . -type d -name "__pycache__" -exec rm -rf {} +
+fi
+
+python3 -m venv venv
+source venv/bin/activate
+
+## Install the requirements
+pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org
+pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org
+let return_code=$?
+
+check_rc $return_code "ERROR: pip install encountered an error."
+
+# Install the aws-lambda psycopg2 libraries
+mkdir -p build/psycopg2
+
+## copy the shared_recovery.py
+echo "INFO: Copying ORCA shared libraries ..."
+if [ -d orca_shared ]; then
+    rm -rf orca_shared
+fi
+
+mkdir -p build/orca_shared
+let return_code=$?
+check_rc $return_code "ERROR: Unable to create orca_shared directory."
+
+touch build/orca_shared/__init__.py
+let return_code=$?
+check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
+
+cp ../shared_libraries/recovery/shared_recovery.py build/orca_shared/
+let return_code=$?
+check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
+
+##TODO: Adjust build scripts to put shared packages needed under a task/build/packages directory.
+##      and copy the packages from there.
+if [ ! -d "../package" ]; then
+    mkdir -p ../package
+    let return_code=$?
+    check_rc $return_code "ERROR: Unable to create tasks/package directory."
+fi
+
+if [ ! -d "../package/awslambda-psycopg2" ]; then
+    ## TODO: This should be pulling based on a release version instead of latest
+    git clone https://github.com/jkehler/awslambda-psycopg2.git ../package/awslambda-psycopg2
+    let return_code=$?
+    check_rc $return_code "ERROR: Unable to retrieve awslambda-psycopg2 code."
+fi
+
+cp ../package/awslambda-psycopg2/psycopg2-3.7/* build/psycopg2/
+let return_code=$?
+check_rc $return_code "ERROR: Unable to install psycopg2."
+
+## Copy the lambda files to build
+echo "INFO: Creating the Lambda package ..."
+cp *.py build/
+let return_code=$?
+
+check_rc $return_code "ERROR: Failed to copy lambda files to build directory."
+
+## Create the zip archive
+cd build
+zip -qr ../request_files.zip .
+let return_code=$?
+cd -
+
+check_rc $return_code "ERROR: Failed to create zip archive."
+
+## Perform cleanup
+echo "INFO: Cleaning up build ..."
+deactivate
+rm -rf build
+
+exit 0

--- a/tasks/request_files/bin/run_tests.sh
+++ b/tasks/request_files/bin/run_tests.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+## =============================================================================
+## NAME: run_tests.sh
+##
+##
+## DESCRIPTION
+## -----------------------------------------------------------------------------
+## Tests the lambda (task) for request_files using unit tests.
+##
+##
+## USAGE
+## -----------------------------------------------------------------------------
+## bin/run_tests.sh
+##
+## This must be called from the (root) lambda directory /tasks/request_files
+## =============================================================================
+
+## Set this for Debugging only
+#set -ex
+
+## Make sure we are calling the script the correct way.
+BASEDIR=$(dirname $0)
+if [ "$BASEDIR" != "bin" ]; then
+  >&2 echo "ERROR: This script must be called from the root directory of the task lambda [bin/run_tests.sh]."
+  exit 1
+fi
+
+
+## FUNCTIONS
+## -----------------------------------------------------------------------------
+function check_rc () {
+  ## Checks the return code of call and if not equal to 0, emits an error and
+  ## exits the script with a failure.
+  ##
+  ## Args:
+  ##   $1 - Return Code from command
+  ##   $2 - Error message if failure occurs.
+
+  let RC=$1
+  MESSAGE=$2
+
+  if [ $RC -ne 0 ]; then
+      >&2 echo "$MESSAGE"
+      deactivate
+      exit 1
+  fi
+}
+## copy the shared_recovery.py
+echo "INFO: Copying ORCA shared libraries ..."
+if [ -d orca_shared ]; then
+    rm -rf orca_shared
+fi
+
+mkdir orca_shared
+let return_code=$?
+check_rc $return_code "ERROR: Unable to create orca_shared directory."
+
+touch orca_shared/__init__.py
+let return_code=$?
+check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
+
+cp ../shared_libraries/recovery/shared_recovery.py orca_shared/
+let return_code=$?
+check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
+
+## MAIN
+## -----------------------------------------------------------------------------
+## Create the virtual env. Remove it if it exists.
+echo "INFO: Creating virtual environment ..."
+if [ -d venv ]; then
+  rm -rf venv
+  find . -type d -name "__pycache__" -exec rm -rf {} +
+fi
+
+python3 -m venv venv
+source venv/bin/activate
+
+## Install the requirements
+pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org
+pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org
+let return_code=$?
+
+check_rc $return_code "ERROR: pip install encountered an error."
+
+
+## Run unit tests and check Coverage
+echo "INFO: Running unit and coverage tests ..."
+
+# Currently just running unit tests until we fix/support large tests
+coverage run --source request_files -m pytest
+let return_code=$?
+check_rc $return_code "ERROR: Unit tests encountered failures."
+
+# Unit tests expected to cover minimum of 80%.
+coverage report --fail-under=80
+let return_code=$?
+check_rc $return_code "ERROR: Unit tests coverage is less than 80%"
+
+## Deactivate and remove the virtual env
+echo "INFO: Cleaning up the environment ..."
+deactivate
+rm -rf venv
+find . -type d -name "__pycache__" -exec rm -rf {} +
+# Remove the shared library
+rm -rf orca_shared
+exit 0

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -12,55 +12,61 @@ from datetime import datetime, timezone
 
 # noinspection PyPackageRequirements
 import boto3
+
 # noinspection PyPackageRequirements
 from botocore.client import BaseClient
+
 # noinspection PyPackageRequirements
 from botocore.exceptions import ClientError
 from cumulus_logger import CumulusLogger
 from run_cumulus_task import run_cumulus_task
 
+# from orca_shared import shared_recovery
+import shared_recovery
 
-# todo: Move to shared lib after ORCA-170
-class RequestMethod(Enum):
-    POST = 'post'
-    PUT = 'put'
+# # todo: Move to shared lib after ORCA-170
+# class RequestMethod(Enum):
+#     POST = 'post'
+#     PUT = 'put'
 
 
 DEFAULT_RESTORE_EXPIRE_DAYS = 5
 DEFAULT_MAX_REQUEST_RETRIES = 2
 DEFAULT_RESTORE_RETRY_SLEEP_SECS = 0
-DEFAULT_RESTORE_RETRIEVAL_TYPE = 'Standard'
+DEFAULT_RESTORE_RETRIEVAL_TYPE = "Standard"
 
-OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY = 'RESTORE_EXPIRE_DAYS'
-OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY = 'RESTORE_REQUEST_RETRIES'
-OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY = 'RESTORE_RETRY_SLEEP_SECS'
-OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY = 'RESTORE_RETRIEVAL_TYPE'
-OS_ENVIRON_DB_QUEUE_URL_KEY = 'DB_QUEUE_URL'
-OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY = 'ORCA_DEFAULT_BUCKET'
+OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY = "RESTORE_EXPIRE_DAYS"
+OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY = "RESTORE_REQUEST_RETRIES"
+OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY = "RESTORE_RETRY_SLEEP_SECS"
+OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY = "RESTORE_RETRIEVAL_TYPE"
+OS_ENVIRON_DB_QUEUE_URL_KEY = "DB_QUEUE_URL"
+OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY = "ORCA_DEFAULT_BUCKET"
 
-EVENT_CONFIG_KEY = 'config'
-EVENT_INPUT_KEY = 'input'
-INPUT_JOB_ID_KEY = 'job_id'
+EVENT_CONFIG_KEY = "config"
+EVENT_INPUT_KEY = "input"
+INPUT_JOB_ID_KEY = "job_id"
 
-INPUT_GRANULES_KEY = 'granules'
+INPUT_GRANULES_KEY = "granules"
 
-CONFIG_GLACIER_BUCKET_KEY = 'glacier-bucket'  # todo: Rename. This ONE property uses '-' instead of '_'
+CONFIG_GLACIER_BUCKET_KEY = (
+    "glacier-bucket"  # todo: Rename. This ONE property uses '-' instead of '_'
+)
 
-GRANULE_GRANULE_ID_KEY = 'granuleId'
-GRANULE_KEYS_KEY = 'keys'
-GRANULE_RECOVER_FILES_KEY = 'recover_files'
+GRANULE_GRANULE_ID_KEY = "granuleId"
+GRANULE_KEYS_KEY = "keys"
+GRANULE_RECOVER_FILES_KEY = "recover_files"
 
 # noinspection SpellCheckingInspection
-FILE_DEST_BUCKET_KEY = 'dest_bucket'
-FILE_KEY_KEY = 'key'
-FILE_SUCCESS_KEY = 'success'
-FILE_ERROR_MESSAGE_KEY = 'err_msg'
+FILE_DEST_BUCKET_KEY = "dest_bucket"
+FILE_KEY_KEY = "key"
+FILE_SUCCESS_KEY = "success"
+FILE_ERROR_MESSAGE_KEY = "err_msg"
 
-# todo: Move to shared lib after ORCA-170
-ORCA_STATUS_PENDING = 1
-# ORCA_STATUS_STAGED = 2
-# ORCA_STATUS_SUCCESS = 3
-ORCA_STATUS_FAILED = 4
+# # todo: Move to shared lib after ORCA-170
+# ORCA_STATUS_PENDING = 1
+# # ORCA_STATUS_STAGED = 2
+# # ORCA_STATUS_SUCCESS = 3
+# ORCA_STATUS_FAILED = 4
 
 LOGGER = CumulusLogger()
 
@@ -72,7 +78,9 @@ class RestoreRequestError(Exception):
 
 
 # noinspection PyUnusedLocal
-def task(event: Dict, context: object) -> Dict[str, Any]:  # pylint: disable-msg=unused-argument
+def task(
+    event: Dict, context: object
+) -> Dict[str, Any]:  # pylint: disable-msg=unused-argument
     """
     Pulls information from os.environ, utilizing defaults if needed.
     Then calls inner_task.
@@ -128,9 +136,11 @@ def task(event: Dict, context: object) -> Dict[str, Any]:  # pylint: disable-msg
 
     try:
         retrieval_type = os.environ[OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY]
-        if retrieval_type not in ('Standard', 'Bulk', 'Expedited'):
-            msg = (f"Invalid RESTORE_RETRIEVAL_TYPE: '{retrieval_type}'"
-                   " defaulting to 'Standard'")
+        if retrieval_type not in ("Standard", "Bulk", "Expedited"):
+            msg = (
+                f"Invalid RESTORE_RETRIEVAL_TYPE: '{retrieval_type}'"
+                " defaulting to 'Standard'"
+            )
             LOGGER.info(msg)
             retrieval_type = DEFAULT_RESTORE_RETRIEVAL_TYPE
     except KeyError:
@@ -139,9 +149,10 @@ def task(event: Dict, context: object) -> Dict[str, Any]:  # pylint: disable-msg
     db_queue_url = str(os.environ[OS_ENVIRON_DB_QUEUE_URL_KEY])
 
     # Use the default glacier bucket if none is given.
-    event[EVENT_CONFIG_KEY][CONFIG_GLACIER_BUCKET_KEY] = \
-        event[EVENT_CONFIG_KEY].get(CONFIG_GLACIER_BUCKET_KEY,
-                                    str(os.environ[OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]))
+    event[EVENT_CONFIG_KEY][CONFIG_GLACIER_BUCKET_KEY] = event[EVENT_CONFIG_KEY].get(
+        CONFIG_GLACIER_BUCKET_KEY,
+        str(os.environ[OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]),
+    )
 
     try:
         exp_days = int(os.environ[OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY])
@@ -151,11 +162,19 @@ def task(event: Dict, context: object) -> Dict[str, Any]:  # pylint: disable-msg
     if not event[EVENT_INPUT_KEY].keys().__contains__(INPUT_JOB_ID_KEY):
         event[EVENT_INPUT_KEY][INPUT_JOB_ID_KEY] = uuid.uuid4().__str__()
 
-    return inner_task(event, max_retries, retry_sleep_secs, retrieval_type, exp_days, db_queue_url)
+    return inner_task(
+        event, max_retries, retry_sleep_secs, retrieval_type, exp_days, db_queue_url
+    )
 
 
-def inner_task(event: Dict, max_retries: int, retry_sleep_secs: float,
-               retrieval_type: str, restore_expire_days: int, db_queue_url: str):
+def inner_task(
+    event: Dict,
+    max_retries: int,
+    retry_sleep_secs: float,
+    retrieval_type: str,
+    restore_expire_days: int,
+    db_queue_url: str,
+):
     """
     Task called by the handler to perform the work.
     This task will call the restore_request for each file. Restored files will be kept
@@ -202,14 +221,17 @@ def inner_task(event: Dict, max_retries: int, retry_sleep_secs: float,
         glacier_bucket = event[EVENT_CONFIG_KEY][CONFIG_GLACIER_BUCKET_KEY]
     except KeyError:
         raise RestoreRequestError(
-            f'request: {event} does not contain a config value for glacier-bucket')
+            f"request: {event} does not contain a config value for glacier-bucket"
+        )
 
     granules = event[EVENT_INPUT_KEY][INPUT_GRANULES_KEY]
     if len(granules) > 1:
         # todo: This is either a lie, or the loop below should be removed.  ORCA-202
-        raise RestoreRequestError(f'request_files can only accept 1 granule in the list. '
-                                  f'This input contains {len(granules)}')
-    s3 = boto3.client('s3')  # pylint: disable-msg=invalid-name
+        raise RestoreRequestError(
+            f"request_files can only accept 1 granule in the list. "
+            f"This input contains {len(granules)}"
+        )
+    s3 = boto3.client("s3")  # pylint: disable-msg=invalid-name
 
     # todo: Singular output variable from loop?  ORCA-202
     copied_granule = {}
@@ -219,12 +241,14 @@ def inner_task(event: Dict, max_retries: int, retry_sleep_secs: float,
             file_key = keys[FILE_KEY_KEY]
             destination_bucket_name = keys[FILE_DEST_BUCKET_KEY]
             if object_exists(s3, glacier_bucket, file_key):
-                LOGGER.info(f"Added {file_key} to the list of files we'll attempt to recover.")
+                LOGGER.info(
+                    f"Added {file_key} to the list of files we'll attempt to recover."
+                )
                 a_file = {
                     FILE_KEY_KEY: file_key,
                     FILE_DEST_BUCKET_KEY: destination_bucket_name,
                     FILE_SUCCESS_KEY: False,
-                    FILE_ERROR_MESSAGE_KEY: ''
+                    FILE_ERROR_MESSAGE_KEY: "",
                 }
                 files.append(a_file)
             else:
@@ -235,88 +259,117 @@ def inner_task(event: Dict, max_retries: int, retry_sleep_secs: float,
     # todo: Looks like this line is why multiple granules are not supported.  ORCA-202
     # todo: Using the default value {} for copied_granule will cause this function to raise errors every time.  ORCA-202
     process_granule(
-        s3, copied_granule, glacier_bucket, restore_expire_days, max_retries, retry_sleep_secs, retrieval_type,
-        event[EVENT_INPUT_KEY][INPUT_JOB_ID_KEY], db_queue_url)
+        s3,
+        copied_granule,
+        glacier_bucket,
+        restore_expire_days,
+        max_retries,
+        retry_sleep_secs,
+        retrieval_type,
+        event[EVENT_INPUT_KEY][INPUT_JOB_ID_KEY],
+        db_queue_url,
+    )
 
     # Cumulus expects response (payload.granules) to be a list of granule objects.
     return {
         INPUT_GRANULES_KEY: [copied_granule],
-        INPUT_JOB_ID_KEY: event[EVENT_INPUT_KEY][INPUT_JOB_ID_KEY]
+        INPUT_JOB_ID_KEY: event[EVENT_INPUT_KEY][INPUT_JOB_ID_KEY],
     }
 
 
-def process_granule(s3: BaseClient,
-                    granule: Dict[str, Union[str, List[Dict]]],
-                    glacier_bucket: str,
-                    restore_expire_days: int,
-                    max_retries: int, retry_sleep_secs: float,
-                    retrieval_type: str,
-                    job_id: str,
-                    db_queue_url: str):  # pylint: disable-msg=invalid-name
+def process_granule(
+    s3: BaseClient,
+    granule: Dict[str, Union[str, List[Dict]]],
+    glacier_bucket: str,
+    restore_expire_days: int,
+    max_retries: int,
+    retry_sleep_secs: float,
+    retrieval_type: str,
+    job_id: str,
+    db_queue_url: str,
+):  # pylint: disable-msg=invalid-name
     """Call restore_object for the files in the granule_list. Modifies granule for output.
-        Args:
-            s3: An instance of boto3 s3 client
-            granule: A dict with the following keys:
-                'granuleId' (str): The id of the granule being restored.
-                'recover_files' (list(dict)): A list of dicts with the following keys:
-                    'key' (str): Name of the file within the granule.
-                    'dest_bucket' (str): The bucket the restored file will be moved
-                        to after the restore completes
-                    'success' (bool): Should enter this method set to False. Modified to 'True' by method end.
-                    'err_msg' (str): Will be modified if error occurs.
+    Args:
+        s3: An instance of boto3 s3 client
+        granule: A dict with the following keys:
+            'granuleId' (str): The id of the granule being restored.
+            'recover_files' (list(dict)): A list of dicts with the following keys:
+                'key' (str): Name of the file within the granule.
+                'dest_bucket' (str): The bucket the restored file will be moved
+                    to after the restore completes
+                'success' (bool): Should enter this method set to False. Modified to 'True' by method end.
+                'err_msg' (str): Will be modified if error occurs.
 
 
-            glacier_bucket: The S3 glacier bucket name.
-            restore_expire_days:
-                The number of days the restored file will be accessible in the S3 bucket before it expires.
-            max_retries: todo
-            retry_sleep_secs: todo
-            retrieval_type: todo
-            db_queue_url: todo
-            job_id: The unique identifier used for tracking requests.
+        glacier_bucket: The S3 glacier bucket name.
+        restore_expire_days:
+            The number of days the restored file will be accessible in the S3 bucket before it expires.
+        max_retries: todo
+        retry_sleep_secs: todo
+        retrieval_type: todo
+        db_queue_url: todo
+        job_id: The unique identifier used for tracking requests.
 
-        Raises: RestoreRequestError if any file restore could not be initiated.
+    Raises: RestoreRequestError if any file restore could not be initiated.
     """
-    request_time = datetime.now(timezone.utc).isoformat()
     attempt = 1
     granule_id = granule[GRANULE_GRANULE_ID_KEY]
-
-    post_status_for_job_to_queue(job_id, granule_id, ORCA_STATUS_PENDING, request_time, None, glacier_bucket,
-                                 RequestMethod.POST,
-                                 db_queue_url,
-                                 max_retries, retry_sleep_secs)
+    files = [
+        {
+            "filename": os.path.basename(
+                granule[GRANULE_RECOVER_FILES_KEY][FILE_KEY_KEY]
+            )
+        },
+        {"key_path": "TBD"},
+        {"restore_destination": "TBD"},
+        {"status_id": shared_recovery.OrcaStatus.PENDING.value},
+        {"error_message": None},
+        {"request_time": datetime.now(timezone.utc).isoformat()},
+        {"last_update": datetime.now(timezone.utc).isoformat()},
+        {"completion_time": datetime.now(timezone.utc).isoformat()},
+    ]
+    shared_recovery.create_status_for_job(
+        job_id, granule_id, glacier_bucket, files, db_queue_url
+    )
 
     while attempt <= max_retries + 1:
         for a_file in granule[GRANULE_RECOVER_FILES_KEY]:
             if not a_file[FILE_SUCCESS_KEY]:
                 try:
-                    restore_object(s3, a_file[FILE_KEY_KEY], restore_expire_days, glacier_bucket, attempt, job_id,
-                                   retrieval_type)
-                    a_file[FILE_SUCCESS_KEY] = True
-                    a_file[FILE_ERROR_MESSAGE_KEY] = ''
-
-                    post_status_for_file_to_queue(
-                        job_id, granule_id, os.path.basename(a_file[FILE_KEY_KEY]),
+                    restore_object(
+                        s3,
                         a_file[FILE_KEY_KEY],
-                        a_file[FILE_DEST_BUCKET_KEY],
-                        ORCA_STATUS_PENDING,
+                        restore_expire_days,
+                        glacier_bucket,
+                        attempt,
+                        job_id,
+                        retrieval_type,
+                    )
+                    a_file[FILE_SUCCESS_KEY] = True
+                    a_file[FILE_ERROR_MESSAGE_KEY] = ""
+
+                    shared_recovery.update_status_for_file(
+                        job_id,
+                        granule_id,
+                        os.path.basename(a_file[FILE_KEY_KEY]),
+                        shared_recovery.OrcaStatus.PENDING.value,
                         None,
-                        request_time,
-                        datetime.now(timezone.utc).isoformat(),
-                        None,
-                        RequestMethod.POST,
                         db_queue_url,
-                        max_retries,
-                        retry_sleep_secs)
+                    )
 
                 except ClientError as err:
                     LOGGER.warning(err)
                     a_file[FILE_ERROR_MESSAGE_KEY] = str(err)
 
         attempt = attempt + 1
-        if attempt <= max_retries + 1:  # Only sleep if not on last attempt. # todo: Use backoff code. ORCA-201
+        if (
+            attempt <= max_retries + 1
+        ):  # Only sleep if not on last attempt. # todo: Use backoff code. ORCA-201
             # Check for early completion.
-            if all(a_file[FILE_SUCCESS_KEY] for a_file in granule[GRANULE_RECOVER_FILES_KEY]):
+            if all(
+                a_file[FILE_SUCCESS_KEY]
+                for a_file in granule[GRANULE_RECOVER_FILES_KEY]
+            ):
                 break
             time.sleep(retry_sleep_secs)
 
@@ -326,34 +379,33 @@ def process_granule(s3: BaseClient,
         if not a_file[FILE_SUCCESS_KEY]:
             any_error = True
             # If this is reached, that means there is no entry in the db for file's status.
-            post_status_for_file_to_queue(
-                job_id, granule_id, os.path.basename(a_file[FILE_KEY_KEY]),
-                a_file[FILE_KEY_KEY],
-                a_file[FILE_DEST_BUCKET_KEY],
-                ORCA_STATUS_FAILED,
+            shared_recovery.update_status_for_file(
+                job_id,
+                granule_id,
+                os.path.basename(a_file[FILE_KEY_KEY]),
+                shared_recovery.OrcaStatus.FAILED.value,
                 a_file.get(FILE_ERROR_MESSAGE_KEY, None),
-                request_time,
-                datetime.now(timezone.utc).isoformat(),
-                None,
-                RequestMethod.POST,
                 db_queue_url,
-                max_retries,
-                retry_sleep_secs)
+            )
 
     if any_error:
-        LOGGER.error(f"One or more files failed to be requested from {glacier_bucket}.{granule}")
-        raise RestoreRequestError(f'One or more files failed to be requested. {granule}')
+        LOGGER.error(
+            f"One or more files failed to be requested from {glacier_bucket}.{granule}"
+        )
+        raise RestoreRequestError(
+            f"One or more files failed to be requested. {granule}"
+        )
 
 
 def object_exists(s3_cli: BaseClient, glacier_bucket: str, file_key: str) -> bool:
     """Check to see if an object exists in S3 Glacier.
-        Args:
-            s3_cli: An instance of boto3 s3 client
-            glacier_bucket: The S3 glacier bucket name
-            file_key: The key of the Glacier object
-        Returns:
-            True if the object exists, otherwise False.
-        """
+    Args:
+        s3_cli: An instance of boto3 s3 client
+        glacier_bucket: The S3 glacier bucket name
+        file_key: The key of the Glacier object
+    Returns:
+        True if the object exists, otherwise False.
+    """
     try:
         # head_object will fail with a thrown 404 if the object doesn't exist
         # todo: The above case was not covered, and should be considered untested.
@@ -361,137 +413,57 @@ def object_exists(s3_cli: BaseClient, glacier_bucket: str, file_key: str) -> boo
         return True
     except ClientError as err:
         LOGGER.error(err)
-        code = err.response['Error']['Code']
-        message = err.response['Error']['Message']
-        if message == 'NoSuchKey' or message == 'Not Found' or code == '404':  # Unit tests say 'Not Found', some online docs say 'NoSuchKey'
+        code = err.response["Error"]["Code"]
+        message = err.response["Error"]["Message"]
+        if (
+            message == "NoSuchKey" or message == "Not Found" or code == "404"
+        ):  # Unit tests say 'Not Found', some online docs say 'NoSuchKey'
             return False
         raise
         # todo: Online docs suggest we could catch 'S3.Client.exceptions.NoSuchKey instead of deconstructing ClientError
 
 
-def restore_object(s3_cli: BaseClient, key: str, days: int, db_glacier_bucket_key: str, attempt: int, job_id: str,
-                   retrieval_type: str = 'Standard'
-                   ) -> None:
+def restore_object(
+    s3_cli: BaseClient,
+    key: str,
+    days: int,
+    db_glacier_bucket_key: str,
+    attempt: int,
+    job_id: str,
+    retrieval_type: str = "Standard",
+) -> None:
     # noinspection SpellCheckingInspection
     """Restore an archived S3 Glacier object in an Amazon S3 bucket.
-        Args:
-            s3_cli: An instance of boto3 s3 client.
-            key: The key of the Glacier object being restored.
-            days: How many days the restored file will be accessible in the S3 bucket before it expires.
-            db_glacier_bucket_key: The S3 bucket name.
-            attempt: The attempt number for logging purposes.
-            job_id: The unique id of the job. Used for logging.
-            retrieval_type: Glacier Tier. Valid values are 'Standard'|'Bulk'|'Expedited'. Defaults to 'Standard'.
-        Raises:
-            ClientError: Raises ClientErrors from restore_object.
+    Args:
+        s3_cli: An instance of boto3 s3 client.
+        key: The key of the Glacier object being restored.
+        days: How many days the restored file will be accessible in the S3 bucket before it expires.
+        db_glacier_bucket_key: The S3 bucket name.
+        attempt: The attempt number for logging purposes.
+        job_id: The unique id of the job. Used for logging.
+        retrieval_type: Glacier Tier. Valid values are 'Standard'|'Bulk'|'Expedited'. Defaults to 'Standard'.
+    Raises:
+        ClientError: Raises ClientErrors from restore_object.
     """
-    request = {'Days': days,
-               'GlacierJobParameters': {'Tier': retrieval_type}}
+    request = {"Days": days, "GlacierJobParameters": {"Tier": retrieval_type}}
     # Submit the request
     try:
-        s3_cli.restore_object(Bucket=db_glacier_bucket_key,
-                              Key=key,
-                              RestoreRequest=request)
+        s3_cli.restore_object(
+            Bucket=db_glacier_bucket_key, Key=key, RestoreRequest=request
+        )
 
     except ClientError as c_err:
         # NoSuchBucket, NoSuchKey, or InvalidObjectState error == the object's
         # storage class was not GLACIER
-        LOGGER.error(f"{c_err}. bucket: {db_glacier_bucket_key} file: {key} Job ID: {job_id}")
+        LOGGER.error(
+            f"{c_err}. bucket: {db_glacier_bucket_key} file: {key} Job ID: {job_id}"
+        )
         raise c_err
 
     LOGGER.info(
         f"Restore {key} from {db_glacier_bucket_key} "
-        f"attempt {attempt} successful. Job ID: {job_id}")
-
-
-# todo: Move to shared lib after ORCA-170
-def post_status_for_job_to_queue(job_id: str, granule_id: str, status_id: Optional[int],
-                                 request_time: Optional[str], completion_time: Optional[str],
-                                 archive_destination: Optional[str],
-                                 request_method: RequestMethod, db_queue_url: str,
-                                 max_retries: int, retry_sleep_secs: float):
-    new_data = {'job_id': job_id, 'granule_id': granule_id}
-    if status_id is not None:
-        new_data['status_id'] = status_id
-    if request_time is not None:
-        new_data['request_time'] = request_time
-    if completion_time is not None:
-        new_data['completion_time'] = completion_time
-    if archive_destination is not None:
-        new_data['archive_destination'] = archive_destination
-
-    post_entry_to_queue('orca_recoveryjob',
-                        new_data,
-                        request_method, db_queue_url, max_retries, retry_sleep_secs)
-
-
-# todo: Move to shared lib after ORCA-170
-def post_status_for_file_to_queue(job_id: str, granule_id: str, filename: str, key_path: Optional[str],
-                                  restore_destination: Optional[str],
-                                  status_id: Optional[int], error_message: Optional[str],
-                                  request_time: Optional[str], last_update: str,
-                                  completion_time: Optional[str],
-                                  request_method: RequestMethod,
-                                  db_queue_url: str,
-                                  max_retries: int, retry_sleep_secs: float):
-    new_data = {'job_id': job_id,
-                'granule_id': granule_id,
-                'filename': filename}
-    if key_path is not None:
-        new_data['key_path'] = key_path
-    if restore_destination is not None:
-        new_data['restore_destination'] = restore_destination
-    if status_id is not None:
-        new_data['status_id'] = status_id
-    if error_message is not None:
-        new_data['error_message'] = error_message
-    if request_time is not None:
-        new_data['request_time'] = request_time
-    if last_update is not None:
-        new_data['last_update'] = last_update
-    if completion_time is not None:
-        new_data['completion_time'] = completion_time
-
-    post_entry_to_queue('orca_recoverfile',
-                        new_data,
-                        request_method,
-                        db_queue_url, max_retries, retry_sleep_secs)
-
-
-# todo: Move to shared lib after ORCA-170
-def post_entry_to_queue(table_name: str, new_data: Dict[str, Any], request_method: RequestMethod, db_queue_url: str,
-                        max_retries: int, retry_sleep_secs: float):
-    sqs = boto3.client('sqs')
-    body = json.dumps(new_data, indent=4)
-    for attempt in range(1, max_retries + 1):
-        try:
-            sqs.send_message(
-                QueueUrl=db_queue_url
-            )
-            sqs.send_message(
-                QueueUrl=db_queue_url,
-                MessageDeduplicationId=table_name + request_method.value + body,
-                MessageGroupId='request_files',
-                MessageAttributes={
-                    'RequestMethod': {
-                        'DataType': 'String',
-                        'StringValue': request_method.value
-                    },
-                    'TableName': {
-                        'DataType': 'String',
-                        'StringValue': table_name
-                    }
-                },
-                MessageBody=body
-            )
-            return
-        except Exception as e:
-            if attempt == max_retries + 1:
-                LOGGER.error(f"Error while logging row {json.dumps(new_data, indent=4)} "
-                             f"to table {table_name}: {e}")
-                raise e
-            time.sleep(retry_sleep_secs)  # todo: Use backoff code. ORCA-201
-            continue
+        f"attempt {attempt} successful. Job ID: {job_id}"
+    )
 
 
 def handler(event: Dict[str, Any], context):  # pylint: disable-msg=unused-argument

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -320,8 +320,8 @@ def process_granule(
                 granule[GRANULE_RECOVER_FILES_KEY][FILE_KEY_KEY]
             )
         },
-        {"key_path": "TBD"},
-        {"restore_destination": "TBD"},
+        {"key_path": "TBD"}, #TBD
+        {"restore_destination": "TBD"}, #TBD
         {"status_id": shared_recovery.OrcaStatus.PENDING.value},
         {"error_message": None},
         {"request_time": datetime.now(timezone.utc).isoformat()},
@@ -329,7 +329,7 @@ def process_granule(
         {"completion_time": datetime.now(timezone.utc).isoformat()},
     ]
     shared_recovery.create_status_for_job(
-        job_id, granule_id, glacier_bucket, files, db_queue_url
+        job_id, granule_id, glacier_bucket, files , db_queue_url
     )
 
     while attempt <= max_retries + 1:

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -315,7 +315,7 @@ def process_granule(
                     )
                     a_file[FILE_SUCCESS_KEY] = True
                     a_file[FILE_ERROR_MESSAGE_KEY] = ""
-                    
+
                     files = [
                         {"filename": os.path.basename(a_file[FILE_KEY_KEY])},
                         {"key_path": a_file[FILE_KEY_KEY]},

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -19,8 +19,7 @@ from botocore.exceptions import ClientError
 from cumulus_logger import CumulusLogger
 from run_cumulus_task import run_cumulus_task
 
-# from orca_shared import shared_recovery
-import shared_recovery
+from orca_shared import shared_recovery
 
 DEFAULT_RESTORE_EXPIRE_DAYS = 5
 DEFAULT_MAX_REQUEST_RETRIES = 2
@@ -364,7 +363,7 @@ def process_granule(
                 LOGGER.error(
                     f"Ran into error posting to SQS {retry+1} time(s) with exception {ex}"
                 )
-                time.sleep(2)
+                time.sleep(retry_sleep_secs) # todo: Use backoff code. ORCA-201
                 continue
         else:
             message = "Error sending message to db_queue_url"

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -550,14 +550,12 @@ class TestRequestFiles(unittest.TestCase):
         )
 
     @patch("request_files.shared_recovery.create_status_for_job")
-    @patch("request_files.shared_recovery.update_status_for_file")
     @patch("time.sleep")
     @patch("request_files.restore_object")
     def test_process_granule_minimal_path(
         self,
         mock_restore_object: MagicMock,
         mock_sleep: MagicMock,
-        mock_update_status_for_file: MagicMock,
         mock_create_status_for_job: MagicMock,
     ):
         mock_s3 = Mock()
@@ -616,25 +614,29 @@ class TestRequestFiles(unittest.TestCase):
         )
 
         files_0 = [
-            {"filename": file_name_0},
-            {"key_path": file_name_0},
-            {"restore_destination": dest_bucket_0},
-            {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
-            {"error_message": None},
-            {"request_time": mock.ANY},
-            {"last_update": mock.ANY},
-            {"completion_time": mock.ANY},
+            {
+                "filename": file_name_0,
+                "key_path": file_name_0,
+                "restore_destination": dest_bucket_0,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                "error_message": None,
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+                "completion_time": None,
+            },
         ]
 
         files_1 = [
-            {"filename": file_name_1},
-            {"key_path": file_name_1},
-            {"restore_destination": dest_bucket_1},
-            {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
-            {"error_message": None},
-            {"request_time": mock.ANY},
-            {"last_update": mock.ANY},
-            {"completion_time": mock.ANY},
+            {
+                "filename": file_name_1,
+                "key_path": file_name_1,
+                "restore_destination": dest_bucket_1,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                "error_message": None,
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+                "completion_time": None,
+            },
         ]
 
         mock_create_status_for_job.assert_has_calls(
@@ -667,38 +669,15 @@ class TestRequestFiles(unittest.TestCase):
             ]
         )
         self.assertEqual(2, mock_restore_object.call_count)
-        mock_update_status_for_file.assert_has_calls(
-            [
-                call(
-                    job_id,
-                    granule_id,
-                    file_name_0,
-                    request_files.shared_recovery.OrcaStatus.PENDING,
-                    None,
-                    db_queue_url,
-                ),
-                call(
-                    job_id,
-                    granule_id,
-                    file_name_1,
-                    request_files.shared_recovery.OrcaStatus.PENDING,
-                    None,
-                    db_queue_url,
-                ),
-            ]
-        )
-        self.assertEqual(2, mock_update_status_for_file.call_count)
         mock_sleep.assert_not_called()
 
     @patch("request_files.shared_recovery.create_status_for_job")
-    @patch("request_files.shared_recovery.update_status_for_file")
     @patch("time.sleep")
     @patch("request_files.restore_object")
     def test_process_granule_one_client_error_retries(
         self,
         mock_restore_object: MagicMock,
         mock_sleep: MagicMock,
-        mock_update_status_for_file: MagicMock,
         mock_create_status_for_job: MagicMock,
     ):
         mock_s3 = Mock()
@@ -745,14 +724,16 @@ class TestRequestFiles(unittest.TestCase):
             ]
         )
         files = [
-            {"filename": file_name_0},
-            {"key_path": file_name_0},
-            {"restore_destination": dest_bucket_0},
-            {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
-            {"error_message": None},
-            {"request_time": mock.ANY},
-            {"last_update": mock.ANY},
-            {"completion_time": mock.ANY},
+            {
+                "filename": file_name_0,
+                "key_path": file_name_0,
+                "restore_destination": dest_bucket_0,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                "error_message": None,
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+                "completion_time": None,
+            },
         ]
         mock_create_status_for_job.assert_called_once_with(
             job_id,
@@ -784,23 +765,9 @@ class TestRequestFiles(unittest.TestCase):
             ]
         )
         self.assertEqual(2, mock_restore_object.call_count)
-        mock_update_status_for_file.assert_has_calls(
-            [
-                call(
-                    job_id,
-                    granule_id,
-                    file_name_0,
-                    request_files.shared_recovery.OrcaStatus.PENDING,
-                    None,
-                    db_queue_url,
-                )
-            ]
-        )
-        self.assertEqual(1, mock_update_status_for_file.call_count)
         mock_sleep.assert_called_once_with(retry_sleep_secs)
 
     @patch("request_files.shared_recovery.create_status_for_job")
-    @patch("request_files.shared_recovery.update_status_for_file")
     @patch("time.sleep")
     @patch("request_files.restore_object")
     @patch("cumulus_logger.CumulusLogger.error")
@@ -809,7 +776,6 @@ class TestRequestFiles(unittest.TestCase):
         mock_logger_error: MagicMock,
         mock_restore_object: MagicMock,
         mock_sleep: MagicMock,
-        mock_update_status_for_file: MagicMock,
         mock_create_status_for_job: MagicMock,
     ):
         mock_s3 = Mock()
@@ -858,14 +824,16 @@ class TestRequestFiles(unittest.TestCase):
                 ]
             )
             files = [
-                {"filename": file_name_0},
-                {"key_path": file_name_0},
-                {"restore_destination": dest_bucket_0},
-                {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
-                {"error_message": None},
-                {"request_time": mock.ANY},
-                {"last_update": mock.ANY},
-                {"completion_time": mock.ANY},
+                {
+                    "filename": file_name_0,
+                    "key_path": file_name_0,
+                    "restore_destination": dest_bucket_0,
+                    "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                    "error_message": None,
+                    "request_time": mock.ANY,
+                    "last_update": mock.ANY,
+                    "completion_time": None,
+                },
             ]
 
             mock_restore_object.assert_has_calls(
@@ -900,19 +868,6 @@ class TestRequestFiles(unittest.TestCase):
                 ]
             )
             self.assertEqual(max_retries + 1, mock_restore_object.call_count)
-            mock_update_status_for_file.assert_has_calls(
-                [
-                    call(
-                        job_id,
-                        granule_id,
-                        file_name_0,
-                        request_files.shared_recovery.OrcaStatus.FAILED,
-                        mock.ANY,
-                        db_queue_url,
-                    )
-                ]
-            )
-            self.assertEqual(1, mock_update_status_for_file.call_count)
             mock_sleep.assert_has_calls([call(retry_sleep_secs)] * max_retries)
 
     def test_object_exists_happy_path(self):
@@ -1447,7 +1402,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_s3_cli.restore_object.assert_called_with(
             Bucket="some_bucket", Key=FILE1, RestoreRequest=restore_req_exp
         )
-        self.assertEqual(2, mock_post_entry_to_queue.call_count)
+        self.assertEqual(1, mock_post_entry_to_queue.call_count)
 
     @patch("request_files.shared_recovery.post_entry_to_queue")
     @patch("boto3.client")

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -639,7 +639,7 @@ class TestRequestFiles(unittest.TestCase):
             },
         ]
 
-        files_all= [
+        files_all = [
             {
                 "filename": file_name_0,
                 "key_path": file_name_0,
@@ -650,7 +650,6 @@ class TestRequestFiles(unittest.TestCase):
                 "last_update": mock.ANY,
                 "completion_time": None,
             },
-
             {
                 "filename": file_name_1,
                 "key_path": file_name_1,
@@ -661,9 +660,11 @@ class TestRequestFiles(unittest.TestCase):
                 "last_update": mock.ANY,
                 "completion_time": None,
             },
-            ]
+        ]
 
-        mock_create_status_for_job.assert_called_with(job_id, granule_id, glacier_bucket, files_all, db_queue_url)
+        mock_create_status_for_job.assert_called_with(
+            job_id, granule_id, glacier_bucket, files_all, db_queue_url
+        )
 
         mock_restore_object.assert_has_calls(
             [

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -594,22 +594,38 @@ class TestRequestFiles(unittest.TestCase):
 
         self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][0][request_files.FILE_SUCCESS_KEY])
         self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][1][request_files.FILE_SUCCESS_KEY])
-        files = [
+
+        files_0 = [
             {
-                "filename": mock.ANY
+                "filename": file_name_0
             },
-            {"key_path": mock.ANY}, #TBD
-            {"restore_destination": mock.ANY}, #TBD
+            {"key_path": file_name_0},
+            {"restore_destination": dest_bucket_0},
             {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
             {"error_message": None},
             {"request_time": mock.ANY},
             {"last_update": mock.ANY},
-            {"completion_time": None},
+            {"completion_time": mock.ANY},
         ]
-        mock_create_status_for_job.assert_called_once_with(job_id, granule_id, glacier_bucket,
-                                                                    files,
-                                                                  db_queue_url,
-                                                                  )
+
+        files_1 = [
+            {
+                "filename": file_name_1
+            },
+            {"key_path": file_name_1},
+            {"restore_destination": dest_bucket_1},
+            {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
+            {"error_message": None},
+            {"request_time": mock.ANY},
+            {"last_update": mock.ANY},
+            {"completion_time": mock.ANY},
+        ]
+        
+        mock_create_status_for_job.assert_has_calls([
+            call(job_id, granule_id, glacier_bucket, files_0, db_queue_url),
+            call(job_id, granule_id, glacier_bucket, files_1, db_queue_url)])
+
+
         mock_restore_object.assert_has_calls([
             call(
                 mock_s3,
@@ -628,9 +644,9 @@ class TestRequestFiles(unittest.TestCase):
         ])
         self.assertEqual(2, mock_restore_object.call_count)
         mock_update_status_for_file.assert_has_calls([
-            call(job_id, granule_id, file_name_0, request_files.shared_recovery.OrcaStatus.PENDING.value,
+            call(job_id, granule_id, file_name_0, request_files.shared_recovery.OrcaStatus.PENDING,
                  None,db_queue_url),
-            call(job_id, granule_id, file_name_1, request_files.shared_recovery.OrcaStatus.PENDING.value,
+            call(job_id, granule_id, file_name_1, request_files.shared_recovery.OrcaStatus.PENDING,
                 None,db_queue_url,)])
         self.assertEqual(2, mock_update_status_for_file.call_count)
         mock_sleep.assert_not_called()
@@ -690,9 +706,9 @@ class TestRequestFiles(unittest.TestCase):
             ]
         )
         files = [
-            {"filename": mock.ANY},
-            {"key_path": mock.ANY},
-            {"restore_destination": mock.ANY},
+            {"filename": file_name_0},
+            {"key_path": file_name_0},
+            {"restore_destination": dest_bucket_0},
             {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
             {"error_message": None},
             {"request_time": mock.ANY},
@@ -735,7 +751,7 @@ class TestRequestFiles(unittest.TestCase):
                     job_id,
                     granule_id,
                     file_name_0,
-                    request_files.shared_recovery.OrcaStatus.PENDING.value,
+                    request_files.shared_recovery.OrcaStatus.PENDING,
                     None,
                     db_queue_url,
                 )
@@ -803,22 +819,15 @@ class TestRequestFiles(unittest.TestCase):
                 ]
             )
             files = [
-                {"filename": mock.ANY},
-                {"key_path": mock.ANY},
-                {"restore_destination": mock.ANY},
+                {"filename": file_name_0},
+                {"key_path": file_name_0},
+                {"restore_destination": dest_bucket_0},
                 {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
                 {"error_message": None},
                 {"request_time": mock.ANY},
                 {"last_update": mock.ANY},
                 {"completion_time": mock.ANY},
             ]
-            mock_create_status_for_job.assert_called_once_with(
-                job_id,
-                granule_id,
-                glacier_bucket,
-                files,
-                db_queue_url,
-            )
 
             mock_restore_object.assert_has_calls(
                 [
@@ -858,7 +867,7 @@ class TestRequestFiles(unittest.TestCase):
                         job_id,
                         granule_id,
                         file_name_0,
-                        request_files.shared_recovery.OrcaStatus.FAILED.value,
+                        request_files.shared_recovery.OrcaStatus.FAILED,
                         mock.ANY,
                         db_queue_url,
                     )

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -10,14 +10,12 @@ import uuid
 from random import randint, uniform
 from unittest import mock
 from unittest.mock import patch, MagicMock, call, Mock
-
+from test.request_helpers import LambdaContextMock, create_handler_event
 # noinspection PyPackageRequirements
 import fastjsonschema as fastjsonschema
 from botocore.exceptions import ClientError
 
 import request_files
-from test.request_helpers import (LambdaContextMock,
-                                  create_handler_event)
 
 # noinspection PyPackageRequirements
 
@@ -41,279 +39,415 @@ class TestRequestFiles(unittest.TestCase):
     def setUp(self):
         # todo: These values should NOT be hard-coded as present for every test.
         os.environ[request_files.OS_ENVIRON_DB_QUEUE_URL_KEY] = "https://db.queue.url"
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = '5'
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = '2'
-        os.environ[request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY] = 'default_glacier_bucket'
-        os.environ['PREFIX'] = uuid.uuid4().__str__()
-        os.environ.pop('CUMULUS_MESSAGE_ADAPTER_DISABLED', None)
+        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = "5"
+        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = "2"
+        os.environ[
+            request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY
+        ] = "default_glacier_bucket"
+        os.environ["PREFIX"] = uuid.uuid4().__str__()
+        os.environ.pop("CUMULUS_MESSAGE_ADAPTER_DISABLED", None)
         self.context = LambdaContextMock()
 
     def tearDown(self):
-        os.environ.pop('PREFIX', None)
+        os.environ.pop("PREFIX", None)
         os.environ.pop(request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY, None)
         os.environ.pop(request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY, None)
         os.environ.pop(request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY, None)
         os.environ.pop(request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY, None)
         os.environ.pop(request_files.OS_ENVIRON_DB_QUEUE_URL_KEY, None)
 
-    @patch('request_files.inner_task')
-    def test_task_happy_path(self,
-                             mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_happy_path(self, mock_inner_task: MagicMock):
         """
         All variables present and valid.
         """
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-                      request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}
-        max_retries = randint(0, 99999)
-        retry_sleep_secs = uniform(0, 99999)
-        retrieval_type = 'Bulk'
-        exp_days = randint(0, 99999)
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+            },
+        }
+        max_retries = randint(0, 99999) # nosec
+        retry_sleep_secs = uniform(0, 99999) # nosec
+        retrieval_type = "Bulk"
+        exp_days = randint(0, 99999) # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = max_retries.__str__()
-        os.environ[request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY] = retry_sleep_secs.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY
+        ] = max_retries.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY
+        ] = retry_sleep_secs.__str__()
         os.environ[request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY] = retrieval_type
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = exp_days.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
+        ] = exp_days.__str__()
 
         request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}, max_retries,
-            retry_sleep_secs, retrieval_type, exp_days,
-            db_queue_url)
+            {
+                request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
+            max_retries,
+            retry_sleep_secs,
+            retrieval_type,
+            exp_days,
+            db_queue_url,
+        )
 
-    @patch('request_files.inner_task')
-    def test_task_default_for_missing_max_retries(self,
-                                                  mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_default_for_missing_max_retries(self, mock_inner_task: MagicMock):
         """
         If max_retries missing, use default.
         """
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-                      request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}
-        retry_sleep_secs = uniform(0, 99999)
-        retrieval_type = 'Bulk'
-        exp_days = randint(0, 99999)
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+            },
+        }
+        retry_sleep_secs = uniform(0, 99999) # nosec
+        retrieval_type = "Bulk"
+        exp_days = randint(0, 99999) # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
-        os.environ[request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY] = retry_sleep_secs.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY
+        ] = retry_sleep_secs.__str__()
         os.environ[request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY] = retrieval_type
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = exp_days.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
+        ] = exp_days.__str__()
 
         request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}},
+            {
+                request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
             request_files.DEFAULT_MAX_REQUEST_RETRIES,
-            retry_sleep_secs, retrieval_type, exp_days,
-            db_queue_url)
+            retry_sleep_secs,
+            retrieval_type,
+            exp_days,
+            db_queue_url,
+        )
 
-    @patch('request_files.inner_task')
-    def test_task_default_for_missing_sleep_secs(self,
-                                                 mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_default_for_missing_sleep_secs(self, mock_inner_task: MagicMock):
         """
         If sleep_secs missing, use default.
         """
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-                      request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}
-        max_retries = randint(0, 99999)
-        retrieval_type = 'Bulk'
-        exp_days = randint(0, 99999)
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+            },
+        }
+        max_retries = randint(0, 99999) # nosec
+        retrieval_type = "Bulk"
+        exp_days = randint(0, 99999) # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
         os.environ["DB_QUEUE_URL"] = db_queue_url
 
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = max_retries.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY
+        ] = max_retries.__str__()
         os.environ[request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY] = retrieval_type
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = exp_days.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
+        ] = exp_days.__str__()
 
         request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}},
+            {
+                request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
             max_retries,
-            request_files.DEFAULT_RESTORE_RETRY_SLEEP_SECS, retrieval_type, exp_days,
-            db_queue_url)
+            request_files.DEFAULT_RESTORE_RETRY_SLEEP_SECS,
+            retrieval_type,
+            exp_days,
+            db_queue_url,
+        )
 
-    @patch('request_files.inner_task')
-    def test_task_default_for_missing_retrieval_type(self,
-                                                     mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_default_for_missing_retrieval_type(self, mock_inner_task: MagicMock):
         """
         If retrieval_type is missing, use default.
         """
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-                      request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}
-        max_retries = randint(0, 99999)
-        retry_sleep_secs = uniform(0, 99999)
-        exp_days = randint(0, 99999)
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+            },
+        }
+        max_retries = randint(0, 99999) # nosec
+        retry_sleep_secs = uniform(0, 99999) # nosec
+        exp_days = randint(0, 99999) # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
         os.environ["DB_QUEUE_URL"] = db_queue_url
 
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = max_retries.__str__()
-        os.environ[request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY] = retry_sleep_secs.__str__()
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = exp_days.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY
+        ] = max_retries.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY
+        ] = retry_sleep_secs.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
+        ] = exp_days.__str__()
 
         request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}},
-            max_retries, retry_sleep_secs,
-            request_files.DEFAULT_RESTORE_RETRIEVAL_TYPE, exp_days,
-            db_queue_url)
+            {
+                request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
+            max_retries,
+            retry_sleep_secs,
+            request_files.DEFAULT_RESTORE_RETRIEVAL_TYPE,
+            exp_days,
+            db_queue_url,
+        )
 
-    @patch('request_files.inner_task')
-    def test_task_default_for_bad_retrieval_type(self,
-                                                 mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_default_for_bad_retrieval_type(self, mock_inner_task: MagicMock):
         """
         If retrieval_type is invalid, use default.
         """
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-                      request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}
-        max_retries = randint(0, 99999)
-        retry_sleep_secs = uniform(0, 99999)
-        retrieval_type = 'Nope'
-        exp_days = randint(0, 99999)
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+            },
+        }
+        max_retries = randint(0, 99999) # nosec
+        retry_sleep_secs = uniform(0, 99999) # nosec
+        retrieval_type = "Nope"
+        exp_days = randint(0, 99999) # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = max_retries.__str__()
-        os.environ[request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY] = retry_sleep_secs.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY
+        ] = max_retries.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY
+        ] = retry_sleep_secs.__str__()
         os.environ[request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY] = retrieval_type
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = exp_days.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
+        ] = exp_days.__str__()
 
         request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}},
-            max_retries, retry_sleep_secs,
-            request_files.DEFAULT_RESTORE_RETRIEVAL_TYPE, exp_days,
-            db_queue_url)
+            {
+                request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
+            max_retries,
+            retry_sleep_secs,
+            request_files.DEFAULT_RESTORE_RETRIEVAL_TYPE,
+            exp_days,
+            db_queue_url,
+        )
 
-    @patch('request_files.inner_task')
-    def test_task_default_for_missing_exp_days(self,
-                                               mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_default_for_missing_exp_days(self, mock_inner_task: MagicMock):
         """
         Uses default missing_exp_days if needed.
         """
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-                      request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}
-        max_retries = randint(0, 99999)
-        retry_sleep_secs = uniform(0, 99999)
-        retrieval_type = 'Bulk'
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+            },
+        }
+        max_retries = randint(0, 99999) # nosec
+        retry_sleep_secs = uniform(0, 99999) # nosec
+        retrieval_type = "Bulk"
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = max_retries.__str__()
-        os.environ[request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY] = retry_sleep_secs.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY
+        ] = max_retries.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY
+        ] = retry_sleep_secs.__str__()
         os.environ[request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY] = retrieval_type
 
         request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}},
-            max_retries, retry_sleep_secs, retrieval_type,
+            {
+                request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
+            max_retries,
+            retry_sleep_secs,
+            retrieval_type,
             request_files.DEFAULT_RESTORE_EXPIRE_DAYS,
-            db_queue_url)
+            db_queue_url,
+        )
 
-    @patch('request_files.inner_task')
-    def test_task_job_id_missing_generates(self,
-                                           mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_job_id_missing_generates(self, mock_inner_task: MagicMock):
         """
         If job_id missing, generates a new one.
         """
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {},
-                      request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}}
-        max_retries = randint(0, 99999)
-        retry_sleep_secs = uniform(0, 99999)
-        retrieval_type = 'Bulk'
-        exp_days = randint(0, 99999)
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {},
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+            },
+        }
+        max_retries = randint(0, 99999) # nosec
+        retry_sleep_secs = uniform(0, 99999) # nosec
+        retrieval_type = "Bulk"
+        exp_days = randint(0, 99999) # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
         job_id = uuid.uuid4()
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = max_retries.__str__()
-        os.environ[request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY] = retry_sleep_secs.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY
+        ] = max_retries.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY
+        ] = retry_sleep_secs.__str__()
         os.environ[request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY] = retrieval_type
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = exp_days.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
+        ] = exp_days.__str__()
 
-        with patch.object(uuid, 'uuid4', return_value=job_id):
+        with patch.object(uuid, "uuid4", return_value=job_id):
             request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id.__str__()},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}},
+            {
+                request_files.EVENT_INPUT_KEY: {
+                    request_files.INPUT_JOB_ID_KEY: job_id.__str__()
+                },
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
             max_retries,
-            retry_sleep_secs, retrieval_type, exp_days,
-            db_queue_url)
+            retry_sleep_secs,
+            retrieval_type,
+            exp_days,
+            db_queue_url,
+        )
 
-    @patch('request_files.inner_task')
-    def test_task_glacier_bucket_missing_uses_default(self,
-                                                      mock_inner_task: MagicMock):
+    @patch("request_files.inner_task")
+    def test_task_glacier_bucket_missing_uses_default(self, mock_inner_task: MagicMock):
         """
         If glacier_bucket is missing, use default from env.
         """
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
-        mock_event = {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
-                      request_files.EVENT_CONFIG_KEY: {}}
-        os.environ[request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY] = glacier_bucket
-        max_retries = randint(0, 99999)
-        retry_sleep_secs = uniform(0, 99999)
-        retrieval_type = 'Bulk'
-        exp_days = randint(0, 99999)
+        mock_event = {
+            request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id},
+            request_files.EVENT_CONFIG_KEY: {},
+        }
+        os.environ[
+            request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY
+        ] = glacier_bucket
+        max_retries = randint(0, 99999) # nosec
+        retry_sleep_secs = uniform(0, 99999) # nosec
+        retrieval_type = "Bulk"
+        exp_days = randint(0, 99999) # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
-        os.environ[request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY] = max_retries.__str__()
-        os.environ[request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY] = retry_sleep_secs.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY
+        ] = max_retries.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY
+        ] = retry_sleep_secs.__str__()
         os.environ[request_files.OS_ENVIRON_RESTORE_RETRIEVAL_TYPE_KEY] = retrieval_type
-        os.environ[request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY] = exp_days.__str__()
+        os.environ[
+            request_files.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
+        ] = exp_days.__str__()
 
-        with patch.object(uuid, 'uuid4', return_value=job_id):
+        with patch.object(uuid, "uuid4", return_value=job_id):
             request_files.task(mock_event, None)
 
         mock_inner_task.assert_called_once_with(
-            {request_files.EVENT_INPUT_KEY: {request_files.INPUT_JOB_ID_KEY: job_id.__str__()},
-             request_files.EVENT_CONFIG_KEY: {request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket}},
+            {
+                request_files.EVENT_INPUT_KEY: {
+                    request_files.INPUT_JOB_ID_KEY: job_id.__str__()
+                },
+                request_files.EVENT_CONFIG_KEY: {
+                    request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
+                },
+            },
             max_retries,
-            retry_sleep_secs, retrieval_type, exp_days,
-            db_queue_url)
+            retry_sleep_secs,
+            retrieval_type,
+            exp_days,
+            db_queue_url,
+        )
 
     def test_inner_task_missing_glacier_bucket_raises(self):
         try:
-            request_files.inner_task({request_files.EVENT_CONFIG_KEY: dict()},
-                                     randint(0, 99999), randint(0, 99999), uuid.uuid4().__str__(), randint(0, 99999),
-                                     'https://db.queue.url')
-            self.fail('Error not raised.')
+            request_files.inner_task(
+                {request_files.EVENT_CONFIG_KEY: dict()},
+                randint(0, 99999), # nosec
+                randint(0, 99999), # nosec
+                uuid.uuid4().__str__(),
+                randint(0, 99999), # nosec
+                "https://db.queue.url",
+            )
+            self.fail("Error not raised.")
         except request_files.RestoreRequestError:
             pass
 
-    @patch('request_files.process_granule')
-    @patch('request_files.object_exists')
-    @patch('boto3.client')
-    def test_inner_task_missing_files_do_not_halt(self,
-                                                  mock_boto3_client: MagicMock,
-                                                  mock_object_exists: MagicMock,
-                                                  mock_process_granule: MagicMock):
+    @patch("request_files.process_granule")
+    @patch("request_files.object_exists")
+    @patch("boto3.client")
+    def test_inner_task_missing_files_do_not_halt(
+        self,
+        mock_boto3_client: MagicMock,
+        mock_object_exists: MagicMock,
+        mock_process_granule: MagicMock,
+    ):
         """
         A return of 'false' from object_exists should ignore the file and continue.
         """
@@ -328,65 +462,91 @@ class TestRequestFiles(unittest.TestCase):
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
         file_0 = {
             request_files.FILE_KEY_KEY: file_key_0,
-            request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_0
+            request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_0,
         }
         expected_file0_output = file_0.copy()
         # noinspection PyTypeChecker
         expected_file0_output[request_files.FILE_SUCCESS_KEY] = False
-        expected_file0_output[request_files.FILE_ERROR_MESSAGE_KEY] = ''
+        expected_file0_output[request_files.FILE_ERROR_MESSAGE_KEY] = ""
         file_1 = {
             request_files.FILE_KEY_KEY: file_key_1,
-            request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_1
+            request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_1,
         }
         expected_file1_output = file_1.copy()
         # noinspection PyTypeChecker
         expected_file1_output[request_files.FILE_SUCCESS_KEY] = False
-        expected_file1_output[request_files.FILE_ERROR_MESSAGE_KEY] = ''
+        expected_file1_output[request_files.FILE_ERROR_MESSAGE_KEY] = ""
         expected_input_granule_files = [expected_file0_output, expected_file1_output]
         granule = {
             request_files.GRANULE_KEYS_KEY: [
                 file_0,
                 {
                     request_files.FILE_KEY_KEY: missing_file_key,
-                    request_files.FILE_DEST_BUCKET_KEY: missing_file_dest_bucket
+                    request_files.FILE_DEST_BUCKET_KEY: missing_file_dest_bucket,
                 },
-                file_1
+                file_1,
             ]
         }
         expected_input_granule = granule.copy()
-        expected_input_granule[request_files.GRANULE_RECOVER_FILES_KEY] = expected_input_granule_files
+        expected_input_granule[
+            request_files.GRANULE_RECOVER_FILES_KEY
+        ] = expected_input_granule_files
         event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
             request_files.EVENT_INPUT_KEY: {
-                request_files.INPUT_GRANULES_KEY: [
-                    granule
-                ],
-                request_files.INPUT_JOB_ID_KEY: job_id
-            }
+                request_files.INPUT_GRANULES_KEY: [granule],
+                request_files.INPUT_JOB_ID_KEY: job_id,
+            },
         }
-        max_retries = randint(0, 99999)
-        retry_sleep_secs = randint(0, 99999)
+        max_retries = randint(0, 99999) # nosec
+        retry_sleep_secs = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
-        mock_s3_cli = mock_boto3_client('s3')
+        restore_expire_days = randint(0, 99999) # nosec
+        mock_s3_cli = mock_boto3_client("s3")
 
         # noinspection PyUnusedLocal
-        def object_exists_return_func(input_s3_cli, input_glacier_bucket, input_file_key):
+        def object_exists_return_func(
+            input_s3_cli, input_glacier_bucket, input_file_key
+        ):
             return input_file_key in [file_key_0, file_key_1]
 
         mock_object_exists.side_effect = object_exists_return_func
 
-        result = request_files.inner_task(event, max_retries, retry_sleep_secs, retrieval_type, restore_expire_days,
-                                          db_queue_url)
-        mock_process_granule.assert_has_calls([
-            call(mock_s3_cli, expected_input_granule, glacier_bucket, restore_expire_days, max_retries,
-                 retry_sleep_secs, retrieval_type, job_id, db_queue_url)])
-        self.assertEqual(1, mock_process_granule.call_count)  # I'm hoping that we can remove the 'one granule' limit.
+        result = request_files.inner_task(
+            event,
+            max_retries,
+            retry_sleep_secs,
+            retrieval_type,
+            restore_expire_days,
+            db_queue_url,
+        )
+        mock_process_granule.assert_has_calls(
+            [
+                call(
+                    mock_s3_cli,
+                    expected_input_granule,
+                    glacier_bucket,
+                    restore_expire_days,
+                    max_retries,
+                    retry_sleep_secs,
+                    retrieval_type,
+                    job_id,
+                    db_queue_url,
+                )
+            ]
+        )
         self.assertEqual(
-            {request_files.INPUT_GRANULES_KEY: [expected_input_granule], request_files.INPUT_JOB_ID_KEY: job_id},
-            result)
+            1, mock_process_granule.call_count
+        )  # I'm hoping that we can remove the 'one granule' limit.
+        self.assertEqual(
+            {
+                request_files.INPUT_GRANULES_KEY: [expected_input_granule],
+                request_files.INPUT_JOB_ID_KEY: job_id,
+            },
+            result,
+        )
 
     @patch('request_files.shared_recovery.create_status_for_job')
     @patch('request_files.shared_recovery.update_status_for_file')
@@ -398,11 +558,11 @@ class TestRequestFiles(unittest.TestCase):
                                           mock_update_status_for_file: MagicMock,
                                           mock_create_status_for_job: MagicMock):
         mock_s3 = Mock()
-        max_retries = randint(10, 999)
+        max_retries = randint(10, 999) # nosec
         glacier_bucket = uuid.uuid4().__str__()
-        retry_sleep_secs = randint(0, 99999)
+        retry_sleep_secs = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
+        restore_expire_days = randint(0, 99999) # nosec
         granule_id = uuid.uuid4().__str__()
         file_name_0 = uuid.uuid4().__str__()
         dest_bucket_0 = uuid.uuid4().__str__()
@@ -436,13 +596,11 @@ class TestRequestFiles(unittest.TestCase):
         self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][1][request_files.FILE_SUCCESS_KEY])
         files = [
             {
-                "filename": os.path.basename(
-                    granule[GRANULE_RECOVER_FILES_KEY][FILE_KEY_KEY]
-                )
+                "filename": mock.ANY
             },
             {"key_path": mock.ANY}, #TBD
             {"restore_destination": mock.ANY}, #TBD
-            {"status_id": shared_recovery.OrcaStatus.PENDING.value},
+            {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
             {"error_message": None},
             {"request_time": mock.ANY},
             {"last_update": mock.ANY},
@@ -470,28 +628,30 @@ class TestRequestFiles(unittest.TestCase):
         ])
         self.assertEqual(2, mock_restore_object.call_count)
         mock_update_status_for_file.assert_has_calls([
-            call(job_id, granule_id, file_name_0, request_files.shared_recovery.OrcaStatus.PENDING.value, 
+            call(job_id, granule_id, file_name_0, request_files.shared_recovery.OrcaStatus.PENDING.value,
                  None,db_queue_url),
-            call(job_id, granule_id, file_name_1, request_files.shared_recovery.OrcaStatus.PENDING.value, 
+            call(job_id, granule_id, file_name_1, request_files.shared_recovery.OrcaStatus.PENDING.value,
                 None,db_queue_url,)])
         self.assertEqual(2, mock_update_status_for_file.call_count)
         mock_sleep.assert_not_called()
 
-    @patch('request_files.shared_recovery.create_status_for_job')
-    @patch('request_files.shared_recovery.update_status_for_file')
-    @patch('time.sleep')
-    @patch('request_files.restore_object')
-    def test_process_granule_one_client_error_retries(self,
-                                                      mock_restore_object: MagicMock,
-                                                      mock_sleep: MagicMock,
-                                                      mock_update_status_for_file: MagicMock,
-                                                      mock_create_status_for_job: MagicMock):
+    @patch("request_files.shared_recovery.create_status_for_job")
+    @patch("request_files.shared_recovery.update_status_for_file")
+    @patch("time.sleep")
+    @patch("request_files.restore_object")
+    def test_process_granule_one_client_error_retries(
+        self,
+        mock_restore_object: MagicMock,
+        mock_sleep: MagicMock,
+        mock_update_status_for_file: MagicMock,
+        mock_create_status_for_job: MagicMock,
+    ):
         mock_s3 = Mock()
         max_retries = 5
         glacier_bucket = uuid.uuid4().__str__()
-        retry_sleep_secs = randint(0, 99999)
+        retry_sleep_secs = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
+        restore_expire_days = randint(0, 99999) # nosec
         granule_id = uuid.uuid4().__str__()
         file_name_0 = uuid.uuid4().__str__()
         dest_bucket_0 = uuid.uuid4().__str__()
@@ -505,61 +665,104 @@ class TestRequestFiles(unittest.TestCase):
                     request_files.FILE_KEY_KEY: file_name_0,
                     request_files.FILE_DEST_BUCKET_KEY: dest_bucket_0,
                     request_files.FILE_SUCCESS_KEY: False,
-                    request_files.FILE_ERROR_MESSAGE_KEY: ''
+                    request_files.FILE_ERROR_MESSAGE_KEY: "",
                 }
-            ]
+            ],
         }
 
-        mock_restore_object.side_effect = [ClientError({}, ''), None]
+        mock_restore_object.side_effect = [ClientError({}, ""), None]
 
-        request_files.process_granule(mock_s3, granule, glacier_bucket, restore_expire_days, max_retries,
-                                      retry_sleep_secs, retrieval_type, job_id, db_queue_url)
+        request_files.process_granule(
+            mock_s3,
+            granule,
+            glacier_bucket,
+            restore_expire_days,
+            max_retries,
+            retry_sleep_secs,
+            retrieval_type,
+            job_id,
+            db_queue_url,
+        )
 
-        self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][0][request_files.FILE_SUCCESS_KEY])
-
-        mock_create_status_for_job.assert_called_once_with(job_id, granule_id, glacier_bucket,
-                                                            files, #TBD
-                                                             db_queue_url,)
-        mock_restore_object.assert_has_calls([
-            call(
-                mock_s3,
-                file_name_0, restore_expire_days, glacier_bucket,
-                1,
-                job_id,
-                retrieval_type
-            ),
-            call(
-                mock_s3,
-                file_name_0, restore_expire_days, glacier_bucket,
-                2,
-                job_id,
-                retrieval_type
-            )
-        ])
+        self.assertTrue(
+            granule[request_files.GRANULE_RECOVER_FILES_KEY][0][
+                request_files.FILE_SUCCESS_KEY
+            ]
+        )
+        files = [
+            {"filename": mock.ANY},
+            {"key_path": mock.ANY},
+            {"restore_destination": mock.ANY},
+            {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
+            {"error_message": None},
+            {"request_time": mock.ANY},
+            {"last_update": mock.ANY},
+            {"completion_time": mock.ANY},
+        ]
+        mock_create_status_for_job.assert_called_once_with(
+            job_id,
+            granule_id,
+            glacier_bucket,
+            files,
+            db_queue_url,
+        )
+        mock_restore_object.assert_has_calls(
+            [
+                call(
+                    mock_s3,
+                    file_name_0,
+                    restore_expire_days,
+                    glacier_bucket,
+                    1,
+                    job_id,
+                    retrieval_type,
+                ),
+                call(
+                    mock_s3,
+                    file_name_0,
+                    restore_expire_days,
+                    glacier_bucket,
+                    2,
+                    job_id,
+                    retrieval_type,
+                ),
+            ]
+        )
         self.assertEqual(2, mock_restore_object.call_count)
-        mock_update_status_for_file.assert_has_calls([
-            call(job_id, granule_id, file_name_0, request_files.shared_recovery.OrcaStatus.PENDING.value, None,
-                  db_queue_url)])
+        mock_update_status_for_file.assert_has_calls(
+            [
+                call(
+                    job_id,
+                    granule_id,
+                    file_name_0,
+                    request_files.shared_recovery.OrcaStatus.PENDING.value,
+                    None,
+                    db_queue_url,
+                )
+            ]
+        )
         self.assertEqual(1, mock_update_status_for_file.call_count)
         mock_sleep.assert_called_once_with(retry_sleep_secs)
 
-    @patch('request_files.shared_recovery.create_status_for_job')
-    @patch('request_files.shared_recovery.update_status_for_file')
-    @patch('time.sleep')
-    @patch('request_files.restore_object')
-    @patch('cumulus_logger.CumulusLogger.error')
-    def test_process_granule_client_errors_retries_until_cap(self,
-                                                             mock_logger_error: MagicMock,
-                                                             mock_restore_object: MagicMock,
-                                                             mock_sleep: MagicMock,
-                                                             mock_update_status_for_file: MagicMock,
-                                                             mock_create_status_for_job: MagicMock):
+    @patch("request_files.shared_recovery.create_status_for_job")
+    @patch("request_files.shared_recovery.update_status_for_file")
+    @patch("time.sleep")
+    @patch("request_files.restore_object")
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_process_granule_client_errors_retries_until_cap(
+        self,
+        mock_logger_error: MagicMock,
+        mock_restore_object: MagicMock,
+        mock_sleep: MagicMock,
+        mock_update_status_for_file: MagicMock,
+        mock_create_status_for_job: MagicMock,
+    ):
         mock_s3 = Mock()
-        max_retries = randint(3, 20)
+        max_retries = randint(3, 20) # nosec
         glacier_bucket = uuid.uuid4().__str__()
-        retry_sleep_secs = randint(0, 99999)
+        retry_sleep_secs = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
+        restore_expire_days = randint(0, 99999) # nosec
         granule_id = uuid.uuid4().__str__()
         file_name_0 = uuid.uuid4().__str__()
         dest_bucket_0 = uuid.uuid4().__str__()
@@ -573,53 +776,94 @@ class TestRequestFiles(unittest.TestCase):
                     request_files.FILE_KEY_KEY: file_name_0,
                     request_files.FILE_DEST_BUCKET_KEY: dest_bucket_0,
                     request_files.FILE_SUCCESS_KEY: False,
-                    request_files.FILE_ERROR_MESSAGE_KEY: ''
+                    request_files.FILE_ERROR_MESSAGE_KEY: "",
                 }
-            ]
+            ],
         }
 
-        mock_restore_object.side_effect = ClientError({}, '')
+        mock_restore_object.side_effect = ClientError({}, "")
 
         try:
-            request_files.process_granule(mock_s3, granule, glacier_bucket, restore_expire_days, max_retries,
-                                          retry_sleep_secs, retrieval_type, job_id, db_queue_url)
-            self.fail('Error not Raised.')
+            request_files.process_granule(
+                mock_s3,
+                granule,
+                glacier_bucket,
+                restore_expire_days,
+                max_retries,
+                retry_sleep_secs,
+                retrieval_type,
+                job_id,
+                db_queue_url,
+            )
+            self.fail("Error not Raised.")
         except request_files.RestoreRequestError:
-            self.assertFalse(granule[request_files.GRANULE_RECOVER_FILES_KEY][0][request_files.FILE_SUCCESS_KEY])
+            self.assertFalse(
+                granule[request_files.GRANULE_RECOVER_FILES_KEY][0][
+                    request_files.FILE_SUCCESS_KEY
+                ]
+            )
+            files = [
+                {"filename": mock.ANY},
+                {"key_path": mock.ANY},
+                {"restore_destination": mock.ANY},
+                {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
+                {"error_message": None},
+                {"request_time": mock.ANY},
+                {"last_update": mock.ANY},
+                {"completion_time": mock.ANY},
+            ]
+            mock_create_status_for_job.assert_called_once_with(
+                job_id,
+                granule_id,
+                glacier_bucket,
+                files,
+                db_queue_url,
+            )
 
-            mock_create_status_for_job.assert_called_once_with(job_id, granule_id, glacier_bucket,
-                                                                      files, #TBD
-                                                                      db_queue_url,
-                                                                      )
-
-            mock_restore_object.assert_has_calls([
-                call(
-                    mock_s3,
-                    file_name_0, restore_expire_days, glacier_bucket,
-                    1,
-                    job_id,
-                    retrieval_type
-                ),
-                call(
-                    mock_s3,
-                    file_name_0, restore_expire_days, glacier_bucket,
-                    2,
-                    job_id,
-                    retrieval_type
-                ),
-                call(
-                    mock_s3,
-                    file_name_0, restore_expire_days, glacier_bucket,
-                    3,
-                    job_id,
-                    retrieval_type
-                )
-            ])
+            mock_restore_object.assert_has_calls(
+                [
+                    call(
+                        mock_s3,
+                        file_name_0,
+                        restore_expire_days,
+                        glacier_bucket,
+                        1,
+                        job_id,
+                        retrieval_type,
+                    ),
+                    call(
+                        mock_s3,
+                        file_name_0,
+                        restore_expire_days,
+                        glacier_bucket,
+                        2,
+                        job_id,
+                        retrieval_type,
+                    ),
+                    call(
+                        mock_s3,
+                        file_name_0,
+                        restore_expire_days,
+                        glacier_bucket,
+                        3,
+                        job_id,
+                        retrieval_type,
+                    ),
+                ]
+            )
             self.assertEqual(max_retries + 1, mock_restore_object.call_count)
-            mock_update_status_for_file.assert_has_calls([
-                call(job_id, granule_id, file_name_0,  request_files.shared_recovery.OrcaStatus.FAILED.value,
-                     None,
-                     db_queue_url)])
+            mock_update_status_for_file.assert_has_calls(
+                [
+                    call(
+                        job_id,
+                        granule_id,
+                        file_name_0,
+                        request_files.shared_recovery.OrcaStatus.FAILED.value,
+                        mock.ANY,
+                        db_queue_url,
+                    )
+                ]
+            )
             self.assertEqual(1, mock_update_status_for_file.call_count)
             mock_sleep.assert_has_calls([call(retry_sleep_secs)] * max_retries)
 
@@ -633,7 +877,9 @@ class TestRequestFiles(unittest.TestCase):
         self.assertTrue(result)
 
     def test_object_exists_client_error_raised(self):
-        expected_error = ClientError({'Error': {'Code': 'Teapot', 'Message': 'test'}}, '')
+        expected_error = ClientError(
+            {"Error": {"Code": "Teapot", "Message": "test"}}, ""
+        )
         mock_s3_cli = Mock()
         mock_s3_cli.head_object.side_effect = expected_error
         glacier_bucket = uuid.uuid4().__str__()
@@ -641,12 +887,14 @@ class TestRequestFiles(unittest.TestCase):
 
         try:
             request_files.object_exists(mock_s3_cli, glacier_bucket, file_key)
-            self.fail('Error not raised.')
+            self.fail("Error not raised.")
         except ClientError as err:
             self.assertEqual(expected_error, err)
 
     def test_object_exists_NotFound_returns_false(self):
-        expected_error = ClientError({'Error': {'Code': '404', 'Message': 'Not Found'}}, '')
+        expected_error = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, ""
+        )
         mock_s3_cli = Mock()
         mock_s3_cli.head_object.side_effect = expected_error
         glacier_bucket = uuid.uuid4().__str__()
@@ -655,119 +903,163 @@ class TestRequestFiles(unittest.TestCase):
         result = request_files.object_exists(mock_s3_cli, glacier_bucket, file_key)
         self.assertFalse(result)
 
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_restore_object_happy_path(self,
-                                       mock_logger_info: MagicMock):
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_restore_object_happy_path(self, mock_logger_info: MagicMock):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
+        restore_expire_days = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
         mock_s3_cli = Mock()
 
-        request_files.restore_object(mock_s3_cli, key, restore_expire_days, glacier_bucket, randint(0, 99999),
-                                     uuid.uuid4().__str__(), retrieval_type)
+        request_files.restore_object(
+            mock_s3_cli,
+            key,
+            restore_expire_days,
+            glacier_bucket,
+            randint(0, 99999), # nosec
+            uuid.uuid4().__str__(),
+            retrieval_type,
+        )
 
-        mock_s3_cli.restore_object.assert_called_once_with(Bucket=glacier_bucket,
-                                                           Key=key,
-                                                           RestoreRequest={
-                                                               'Days': restore_expire_days,
-                                                               'GlacierJobParameters': {
-                                                                   'Tier': retrieval_type}})
+        mock_s3_cli.restore_object.assert_called_once_with(
+            Bucket=glacier_bucket,
+            Key=key,
+            RestoreRequest={
+                "Days": restore_expire_days,
+                "GlacierJobParameters": {"Tier": retrieval_type},
+            },
+        )
 
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_restore_object_client_error_raises(self,
-                                                mock_logger_info: MagicMock):
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_restore_object_client_error_raises(self, mock_logger_info: MagicMock):
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
+        restore_expire_days = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
-        expected_error = ClientError({}, '')
+        expected_error = ClientError({}, "")
         mock_s3_cli = Mock()
         mock_s3_cli.restore_object.side_effect = expected_error
 
         try:
-            request_files.restore_object(mock_s3_cli, key, restore_expire_days, glacier_bucket, 1, job_id,
-                                         retrieval_type)
-            self.fail('Error not Raised.')
+            request_files.restore_object(
+                mock_s3_cli,
+                key,
+                restore_expire_days,
+                glacier_bucket,
+                1,
+                job_id,
+                retrieval_type,
+            )
+            self.fail("Error not Raised.")
         except ClientError as error:
             self.assertEqual(expected_error, error)
-            mock_s3_cli.restore_object.assert_called_once_with(Bucket=glacier_bucket,
-                                                               Key=key,
-                                                               RestoreRequest={
-                                                                   'Days': restore_expire_days,
-                                                                   'GlacierJobParameters': {
-                                                                       'Tier': retrieval_type}})
+            mock_s3_cli.restore_object.assert_called_once_with(
+                Bucket=glacier_bucket,
+                Key=key,
+                RestoreRequest={
+                    "Days": restore_expire_days,
+                    "GlacierJobParameters": {"Tier": retrieval_type},
+                },
+            )
 
     # noinspection PyUnusedLocal
-    @patch('cumulus_logger.CumulusLogger.error')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_restore_object_client_error_last_attempt_logs_and_raises(self,
-                                                                      mock_logger_info: MagicMock,
-                                                                      mock_logger_error: MagicMock):
+    @patch("cumulus_logger.CumulusLogger.error")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_restore_object_client_error_last_attempt_logs_and_raises(
+        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
+    ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
+        restore_expire_days = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
-        expected_error = ClientError({}, '')
+        expected_error = ClientError({}, "")
         mock_s3_cli = Mock()
         mock_s3_cli.restore_object.side_effect = expected_error
 
         try:
-            request_files.restore_object(mock_s3_cli, key, restore_expire_days, glacier_bucket, 2,
-                                         uuid.uuid4().__str__(), retrieval_type)
-            self.fail('Error not Raised.')
+            request_files.restore_object(
+                mock_s3_cli,
+                key,
+                restore_expire_days,
+                glacier_bucket,
+                2,
+                uuid.uuid4().__str__(),
+                retrieval_type,
+            )
+            self.fail("Error not Raised.")
         except ClientError as error:
             self.assertEqual(expected_error, error)
-            mock_s3_cli.restore_object.assert_called_once_with(Bucket=glacier_bucket,
-                                                               Key=key,
-                                                               RestoreRequest={
-                                                                   'Days': restore_expire_days,
-                                                                   'GlacierJobParameters': {
-                                                                       'Tier': retrieval_type}})
+            mock_s3_cli.restore_object.assert_called_once_with(
+                Bucket=glacier_bucket,
+                Key=key,
+                RestoreRequest={
+                    "Days": restore_expire_days,
+                    "GlacierJobParameters": {"Tier": retrieval_type},
+                },
+            )
 
     # noinspection PyUnusedLocal
-    @patch('cumulus_logger.CumulusLogger.error')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_restore_object_log_to_db_fails_does_not_halt(self,
-                                                          mock_logger_info: MagicMock,
-                                                          mock_logger_error: MagicMock):
+    @patch("cumulus_logger.CumulusLogger.error")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_restore_object_log_to_db_fails_does_not_halt(
+        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
+    ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999)
+        restore_expire_days = randint(0, 99999) # nosec
         retrieval_type = uuid.uuid4().__str__()
         mock_s3_cli = Mock()
 
-        request_files.restore_object(mock_s3_cli, key, restore_expire_days, glacier_bucket, randint(0, 99999),
-                                     uuid.uuid4().__str__(), retrieval_type)
+        request_files.restore_object(
+            mock_s3_cli,
+            key,
+            restore_expire_days,
+            glacier_bucket,
+            randint(0, 99999), # nosec
+            uuid.uuid4().__str__(),
+            retrieval_type,
+        )
 
-        mock_s3_cli.restore_object.assert_called_once_with(Bucket=glacier_bucket,
-                                                           Key=key,
-                                                           RestoreRequest={
-                                                               'Days': restore_expire_days,
-                                                               'GlacierJobParameters': {
-                                                                   'Tier': retrieval_type}})
+        mock_s3_cli.restore_object.assert_called_once_with(
+            Bucket=glacier_bucket,
+            Key=key,
+            RestoreRequest={
+                "Days": restore_expire_days,
+                "GlacierJobParameters": {"Tier": retrieval_type},
+            },
+        )
 
     # The below are legacy tests that don't strictly check request_files.py on its own. Remove/adjust as needed.
-    @patch('request_files.task')
-    def test_handler_happy_path(self,
-                                mock_task: MagicMock
-                                ):
+    @patch("request_files.task")
+    def test_handler_happy_path(self, mock_task: MagicMock):
         """
         Tests that between the handler and CMA, input is translated into what task expects.
         """
         input_event = create_handler_event()
-        expected_task_input = {"input": input_event["payload"],
-                               "config": {"glacier-bucket": "podaac-sndbx-cumulus-glacier"}}
+        expected_task_input = {
+            "input": input_event["payload"],
+            "config": {"glacier-bucket": "podaac-sndbx-cumulus-glacier"},
+        }
         mock_task.return_value = {
-            "granules": [{"granuleId": "some_granule_id",
-                          "recover_files": [{"key": "some_key", "dest_bucket": "some_bucket", "success": True}]}],
-            "job_id": "some_job_id"
+            "granules": [
+                {
+                    "granuleId": "some_granule_id",
+                    "recover_files": [
+                        {
+                            "key": "some_key",
+                            "dest_bucket": "some_bucket",
+                            "success": True,
+                        }
+                    ],
+                }
+            ],
+            "job_id": "some_job_id",
         }
         result = request_files.handler(input_event, self.context)
         mock_task.assert_called_once_with(expected_task_input, self.context)
 
-        self.assertEqual(mock_task.return_value, result['payload'])
+        self.assertEqual(mock_task.return_value, result["payload"])
 
     @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
@@ -849,10 +1141,30 @@ class TestRequestFiles(unittest.TestCase):
         builds a list of expected files
         """
         return [
-            {'key': FILE1, 'dest_bucket': PROTECTED_BUCKET, 'success': True, 'err_msg': ''},
-            {'key': FILE2, 'dest_bucket': PROTECTED_BUCKET, 'success': True, 'err_msg': ''},
-            {'key': FILE3, 'dest_bucket': PUBLIC_BUCKET, 'success': True, 'err_msg': ''},
-            {'key': FILE4, 'dest_bucket': PUBLIC_BUCKET, 'success': True, 'err_msg': ''}
+            {
+                "key": FILE1,
+                "dest_bucket": PROTECTED_BUCKET,
+                "success": True,
+                "err_msg": "",
+            },
+            {
+                "key": FILE2,
+                "dest_bucket": PROTECTED_BUCKET,
+                "success": True,
+                "err_msg": "",
+            },
+            {
+                "key": FILE3,
+                "dest_bucket": PUBLIC_BUCKET,
+                "success": True,
+                "err_msg": "",
+            },
+            {
+                "key": FILE4,
+                "dest_bucket": PUBLIC_BUCKET,
+                "success": True,
+                "err_msg": "",
+            },
         ]
 
     @staticmethod
@@ -861,56 +1173,35 @@ class TestRequestFiles(unittest.TestCase):
         Builds a list of expected keys
         """
         return [
-            {
-                'dest_bucket': PROTECTED_BUCKET,
-                'key': FILE1
-            },
-            {
-                'dest_bucket': PROTECTED_BUCKET,
-                'key': FILE2
-            },
-            {
-                'dest_bucket': PUBLIC_BUCKET,
-                'key': FILE3
-            },
-            {
-                'dest_bucket': PUBLIC_BUCKET,
-                'key': FILE4
-            },
+            {"dest_bucket": PROTECTED_BUCKET, "key": FILE1},
+            {"dest_bucket": PROTECTED_BUCKET, "key": FILE2},
+            {"dest_bucket": PUBLIC_BUCKET, "key": FILE3},
+            {"dest_bucket": PUBLIC_BUCKET, "key": FILE4},
         ]
 
     # todo: single_query is not called in code. Replace with higher-level checks.
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.error')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_one_granule_1_file_db_error(self,
-                                              mock_logger_info: MagicMock,
-                                              mock_logger_error: MagicMock,
-                                              mock_boto3_client: MagicMock,
-                                              mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.error")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_one_granule_1_file_db_error(
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test one file for one granule - db error inserting status
         """
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         input_event = {
-            "input": {
-                "granules": [
-                    {
-                        "granuleId": granule_id,
-                        "keys": [
-                            KEY1
-                        ]
-                    }
-                ]
-            },
-            "config": {
-                "glacier-bucket": "my-dr-fake-glacier-bucket"
-            },
-            'job_id': uuid.uuid4().__str__()
+            "input": {"granules": [{"granuleId": granule_id, "keys": [KEY1]}]},
+            "config": {"glacier-bucket": "my-dr-fake-glacier-bucket"},
+            "job_id": uuid.uuid4().__str__(),
         }
 
-        mock_s3_cli = mock_boto3_client('s3')
+        mock_s3_cli = mock_boto3_client("s3")
         mock_s3_cli.restore_object.side_effect = [None]
         mock_post_entry_to_queue.side_effect = [Exception("mock insert failed error")]
         try:
@@ -927,28 +1218,33 @@ class TestRequestFiles(unittest.TestCase):
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         exp_event = {
             "input": {
-                "granules": [{"granuleId": granule_id,
-                              "keys": [KEY1]},
-                             {"granuleId": granule_id,
-                              "keys": [KEY2]}]},
+                "granules": [
+                    {"granuleId": granule_id, "keys": [KEY1]},
+                    {"granuleId": granule_id, "keys": [KEY2]},
+                ]
+            },
             "config": {"glacier-bucket": "my-bucket"},
-            'job_id': uuid.uuid4().__str__()
+            "job_id": uuid.uuid4().__str__(),
         }
 
-        exp_err = "request_files can only accept 1 granule in the list. This input contains 2"
+        exp_err = (
+            "request_files can only accept 1 granule in the list. This input contains 2"
+        )
         try:
             request_files.task(exp_event, self.context)
             self.fail("RestoreRequestError expected")
         except request_files.RestoreRequestError as roe:
             self.assertEqual(exp_err, str(roe))
 
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_file_not_in_glacier(self,
-                                      mock_logger_info: MagicMock,
-                                      mock_boto3_client: MagicMock,
-                                      mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_file_not_in_glacier(
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test a file that is not in glacier.
         # todo: Expand test descriptions.
@@ -957,38 +1253,41 @@ class TestRequestFiles(unittest.TestCase):
         file1 = "MOD09GQ___006/2017/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.xyz"
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         event = {
-            'input': {
-                "granules":
-                    [{"granuleId": granule_id, "keys": [{"key": file1, "dest_bucket": dest_bucket}]}],
-                'job_id': uuid.uuid4()
+            "input": {
+                "granules": [
+                    {
+                        "granuleId": granule_id,
+                        "keys": [{"key": file1, "dest_bucket": dest_bucket}],
+                    }
+                ],
+                "job_id": uuid.uuid4(),
             },
-            "config": {"glacier-bucket": "my-bucket"}
+            "config": {"glacier-bucket": "my-bucket"},
         }
-        mock_s3_cli = mock_boto3_client('s3')
+        mock_s3_cli = mock_boto3_client("s3")
         # todo: Verify the below with a real-world db. If not the same, fix request_files.object_exists
-        mock_s3_cli.head_object.side_effect = [ClientError({'Error': {'Code': '404', 'Message': 'Not Found'}}, 'head_object')]
+        mock_s3_cli.head_object.side_effect = [
+            ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}}, "head_object"
+            )
+        ]
         result = request_files.task(event, self.context)
 
         # todo: Kill all of this,
         #  or at least use the actual bucket values for the individual files instead of copy/paste.
         expected_granules = {
-            'granules': [
+            "granules": [
                 {
-                    'granuleId': granule_id,
-                    'keys': [
-                        {
-                            'dest_bucket': dest_bucket,
-                            'key': file1
-                        }
-                    ],
-                    'recover_files': []
+                    "granuleId": granule_id,
+                    "keys": [{"dest_bucket": dest_bucket, "key": file1}],
+                    "recover_files": [],
                 }
             ],
-            'job_id': event['input']['job_id']
+            "job_id": event["input"]["job_id"],
         }
         self.assertEqual(expected_granules, result)
-        mock_boto3_client.assert_called_with('s3')
-        mock_s3_cli.head_object.assert_called_with(Bucket='my-bucket', Key=file1)
+        mock_boto3_client.assert_called_with("s3")
+        mock_s3_cli.head_object.assert_called_with(Bucket="my-bucket", Key=file1)
 
     @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
@@ -1204,11 +1503,25 @@ class TestRequestFiles(unittest.TestCase):
         builds list of expected files for test case
         """
         return [
-            {'key': FILE1, 'dest_bucket': PROTECTED_BUCKET, 'success': True, 'err_msg': ''},
-            {'key': FILE3, 'dest_bucket': PUBLIC_BUCKET, 'success': False,
-             'err_msg': 'An error occurred (NoSuchKey) when calling the restore_object '
-                        'operation: Unknown'},
-            {'key': FILE4, 'dest_bucket': PUBLIC_BUCKET, 'success': True, 'err_msg': ''}
+            {
+                "key": FILE1,
+                "dest_bucket": PROTECTED_BUCKET,
+                "success": True,
+                "err_msg": "",
+            },
+            {
+                "key": FILE3,
+                "dest_bucket": PUBLIC_BUCKET,
+                "success": False,
+                "err_msg": "An error occurred (NoSuchKey) when calling the restore_object "
+                "operation: Unknown",
+            },
+            {
+                "key": FILE4,
+                "dest_bucket": PUBLIC_BUCKET,
+                "success": True,
+                "err_msg": "",
+            },
         ]
 
     @staticmethod
@@ -1217,9 +1530,9 @@ class TestRequestFiles(unittest.TestCase):
         builds list of expected files for test case
         """
         return [
-            {'key': FILE1, 'dest_bucket': PROTECTED_BUCKET},
-            {'key': FILE3, 'dest_bucket': PUBLIC_BUCKET},
-            {'key': FILE4, 'dest_bucket': PUBLIC_BUCKET}
+            {"key": FILE1, "dest_bucket": PROTECTED_BUCKET},
+            {"key": FILE3, "dest_bucket": PUBLIC_BUCKET},
+            {"key": FILE4, "dest_bucket": PUBLIC_BUCKET},
         ]
 
     # todo: single_query is not called in code. Replace with higher-level checks.
@@ -1365,5 +1678,5 @@ class TestRequestFiles(unittest.TestCase):
         validate(result)
 
 
-if __name__ == '__main__':
-    unittest.main(argv=['start'])
+if __name__ == "__main__":
+    unittest.main(argv=["start"])

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -11,6 +11,7 @@ from random import randint, uniform
 from unittest import mock
 from unittest.mock import patch, MagicMock, call, Mock
 from test.request_helpers import LambdaContextMock, create_handler_event
+
 # noinspection PyPackageRequirements
 import fastjsonschema as fastjsonschema
 from botocore.exceptions import ClientError
@@ -69,10 +70,10 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
         }
-        max_retries = randint(0, 99999) # nosec
-        retry_sleep_secs = uniform(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
+        retry_sleep_secs = uniform(0, 99999)  # nosec
         retrieval_type = "Bulk"
-        exp_days = randint(0, 99999) # nosec
+        exp_days = randint(0, 99999)  # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
@@ -116,9 +117,9 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
         }
-        retry_sleep_secs = uniform(0, 99999) # nosec
+        retry_sleep_secs = uniform(0, 99999)  # nosec
         retrieval_type = "Bulk"
-        exp_days = randint(0, 99999) # nosec
+        exp_days = randint(0, 99999)  # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
@@ -159,9 +160,9 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
         }
-        max_retries = randint(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
         retrieval_type = "Bulk"
-        exp_days = randint(0, 99999) # nosec
+        exp_days = randint(0, 99999)  # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
         os.environ["DB_QUEUE_URL"] = db_queue_url
 
@@ -202,9 +203,9 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
         }
-        max_retries = randint(0, 99999) # nosec
-        retry_sleep_secs = uniform(0, 99999) # nosec
-        exp_days = randint(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
+        retry_sleep_secs = uniform(0, 99999)  # nosec
+        exp_days = randint(0, 99999)  # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
         os.environ["DB_QUEUE_URL"] = db_queue_url
 
@@ -247,10 +248,10 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
         }
-        max_retries = randint(0, 99999) # nosec
-        retry_sleep_secs = uniform(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
+        retry_sleep_secs = uniform(0, 99999)  # nosec
         retrieval_type = "Nope"
-        exp_days = randint(0, 99999) # nosec
+        exp_days = randint(0, 99999)  # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
@@ -294,8 +295,8 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
         }
-        max_retries = randint(0, 99999) # nosec
-        retry_sleep_secs = uniform(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
+        retry_sleep_secs = uniform(0, 99999)  # nosec
         retrieval_type = "Bulk"
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
@@ -336,10 +337,10 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket
             },
         }
-        max_retries = randint(0, 99999) # nosec
-        retry_sleep_secs = uniform(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
+        retry_sleep_secs = uniform(0, 99999)  # nosec
         retrieval_type = "Bulk"
-        exp_days = randint(0, 99999) # nosec
+        exp_days = randint(0, 99999)  # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
         job_id = uuid.uuid4()
 
@@ -388,10 +389,10 @@ class TestRequestFiles(unittest.TestCase):
         os.environ[
             request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY
         ] = glacier_bucket
-        max_retries = randint(0, 99999) # nosec
-        retry_sleep_secs = uniform(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
+        retry_sleep_secs = uniform(0, 99999)  # nosec
         retrieval_type = "Bulk"
-        exp_days = randint(0, 99999) # nosec
+        exp_days = randint(0, 99999)  # nosec
         db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
 
         os.environ["DB_QUEUE_URL"] = db_queue_url
@@ -429,10 +430,10 @@ class TestRequestFiles(unittest.TestCase):
         try:
             request_files.inner_task(
                 {request_files.EVENT_CONFIG_KEY: dict()},
-                randint(0, 99999), # nosec
-                randint(0, 99999), # nosec
+                randint(0, 99999),  # nosec
+                randint(0, 99999),  # nosec
                 uuid.uuid4().__str__(),
-                randint(0, 99999), # nosec
+                randint(0, 99999),  # nosec
                 "https://db.queue.url",
             )
             self.fail("Error not raised.")
@@ -500,10 +501,10 @@ class TestRequestFiles(unittest.TestCase):
                 request_files.INPUT_JOB_ID_KEY: job_id,
             },
         }
-        max_retries = randint(0, 99999) # nosec
-        retry_sleep_secs = randint(0, 99999) # nosec
+        max_retries = randint(0, 99999)  # nosec
+        retry_sleep_secs = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         mock_s3_cli = mock_boto3_client("s3")
 
         # noinspection PyUnusedLocal
@@ -548,21 +549,23 @@ class TestRequestFiles(unittest.TestCase):
             result,
         )
 
-    @patch('request_files.shared_recovery.create_status_for_job')
-    @patch('request_files.shared_recovery.update_status_for_file')
-    @patch('time.sleep')
-    @patch('request_files.restore_object')
-    def test_process_granule_minimal_path(self,
-                                          mock_restore_object: MagicMock,
-                                          mock_sleep: MagicMock,
-                                          mock_update_status_for_file: MagicMock,
-                                          mock_create_status_for_job: MagicMock):
+    @patch("request_files.shared_recovery.create_status_for_job")
+    @patch("request_files.shared_recovery.update_status_for_file")
+    @patch("time.sleep")
+    @patch("request_files.restore_object")
+    def test_process_granule_minimal_path(
+        self,
+        mock_restore_object: MagicMock,
+        mock_sleep: MagicMock,
+        mock_update_status_for_file: MagicMock,
+        mock_create_status_for_job: MagicMock,
+    ):
         mock_s3 = Mock()
-        max_retries = randint(10, 999) # nosec
+        max_retries = randint(10, 999)  # nosec
         glacier_bucket = uuid.uuid4().__str__()
-        retry_sleep_secs = randint(0, 99999) # nosec
+        retry_sleep_secs = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         granule_id = uuid.uuid4().__str__()
         file_name_0 = uuid.uuid4().__str__()
         dest_bucket_0 = uuid.uuid4().__str__()
@@ -578,27 +581,42 @@ class TestRequestFiles(unittest.TestCase):
                     request_files.FILE_KEY_KEY: file_name_0,
                     request_files.FILE_DEST_BUCKET_KEY: dest_bucket_0,
                     request_files.FILE_SUCCESS_KEY: False,
-                    request_files.FILE_ERROR_MESSAGE_KEY: ''
+                    request_files.FILE_ERROR_MESSAGE_KEY: "",
                 },
                 {
                     request_files.FILE_KEY_KEY: file_name_1,
                     request_files.FILE_DEST_BUCKET_KEY: dest_bucket_1,
                     request_files.FILE_SUCCESS_KEY: False,
-                    request_files.FILE_ERROR_MESSAGE_KEY: ''
-                }
-            ]
+                    request_files.FILE_ERROR_MESSAGE_KEY: "",
+                },
+            ],
         }
 
-        request_files.process_granule(mock_s3, granule, glacier_bucket, restore_expire_days, max_retries,
-                                      retry_sleep_secs, retrieval_type, job_id, db_queue_url)
+        request_files.process_granule(
+            mock_s3,
+            granule,
+            glacier_bucket,
+            restore_expire_days,
+            max_retries,
+            retry_sleep_secs,
+            retrieval_type,
+            job_id,
+            db_queue_url,
+        )
 
-        self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][0][request_files.FILE_SUCCESS_KEY])
-        self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][1][request_files.FILE_SUCCESS_KEY])
+        self.assertTrue(
+            granule[request_files.GRANULE_RECOVER_FILES_KEY][0][
+                request_files.FILE_SUCCESS_KEY
+            ]
+        )
+        self.assertTrue(
+            granule[request_files.GRANULE_RECOVER_FILES_KEY][1][
+                request_files.FILE_SUCCESS_KEY
+            ]
+        )
 
         files_0 = [
-            {
-                "filename": file_name_0
-            },
+            {"filename": file_name_0},
             {"key_path": file_name_0},
             {"restore_destination": dest_bucket_0},
             {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
@@ -609,9 +627,7 @@ class TestRequestFiles(unittest.TestCase):
         ]
 
         files_1 = [
-            {
-                "filename": file_name_1
-            },
+            {"filename": file_name_1},
             {"key_path": file_name_1},
             {"restore_destination": dest_bucket_1},
             {"status_id": request_files.shared_recovery.OrcaStatus.PENDING.value},
@@ -620,34 +636,57 @@ class TestRequestFiles(unittest.TestCase):
             {"last_update": mock.ANY},
             {"completion_time": mock.ANY},
         ]
-        
-        mock_create_status_for_job.assert_has_calls([
-            call(job_id, granule_id, glacier_bucket, files_0, db_queue_url),
-            call(job_id, granule_id, glacier_bucket, files_1, db_queue_url)])
 
+        mock_create_status_for_job.assert_has_calls(
+            [
+                call(job_id, granule_id, glacier_bucket, files_0, db_queue_url),
+                call(job_id, granule_id, glacier_bucket, files_1, db_queue_url),
+            ]
+        )
 
-        mock_restore_object.assert_has_calls([
-            call(
-                mock_s3,
-                file_name_0, restore_expire_days, glacier_bucket,
-                1,
-                job_id,
-                retrieval_type
-            ),
-            call(
-                mock_s3,
-                file_name_1, restore_expire_days, glacier_bucket,
-                1,
-                job_id,
-                retrieval_type
-            )
-        ])
+        mock_restore_object.assert_has_calls(
+            [
+                call(
+                    mock_s3,
+                    file_name_0,
+                    restore_expire_days,
+                    glacier_bucket,
+                    1,
+                    job_id,
+                    retrieval_type,
+                ),
+                call(
+                    mock_s3,
+                    file_name_1,
+                    restore_expire_days,
+                    glacier_bucket,
+                    1,
+                    job_id,
+                    retrieval_type,
+                ),
+            ]
+        )
         self.assertEqual(2, mock_restore_object.call_count)
-        mock_update_status_for_file.assert_has_calls([
-            call(job_id, granule_id, file_name_0, request_files.shared_recovery.OrcaStatus.PENDING,
-                 None,db_queue_url),
-            call(job_id, granule_id, file_name_1, request_files.shared_recovery.OrcaStatus.PENDING,
-                None,db_queue_url,)])
+        mock_update_status_for_file.assert_has_calls(
+            [
+                call(
+                    job_id,
+                    granule_id,
+                    file_name_0,
+                    request_files.shared_recovery.OrcaStatus.PENDING,
+                    None,
+                    db_queue_url,
+                ),
+                call(
+                    job_id,
+                    granule_id,
+                    file_name_1,
+                    request_files.shared_recovery.OrcaStatus.PENDING,
+                    None,
+                    db_queue_url,
+                ),
+            ]
+        )
         self.assertEqual(2, mock_update_status_for_file.call_count)
         mock_sleep.assert_not_called()
 
@@ -665,9 +704,9 @@ class TestRequestFiles(unittest.TestCase):
         mock_s3 = Mock()
         max_retries = 5
         glacier_bucket = uuid.uuid4().__str__()
-        retry_sleep_secs = randint(0, 99999) # nosec
+        retry_sleep_secs = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         granule_id = uuid.uuid4().__str__()
         file_name_0 = uuid.uuid4().__str__()
         dest_bucket_0 = uuid.uuid4().__str__()
@@ -774,11 +813,11 @@ class TestRequestFiles(unittest.TestCase):
         mock_create_status_for_job: MagicMock,
     ):
         mock_s3 = Mock()
-        max_retries = randint(3, 20) # nosec
+        max_retries = randint(3, 20)  # nosec
         glacier_bucket = uuid.uuid4().__str__()
-        retry_sleep_secs = randint(0, 99999) # nosec
+        retry_sleep_secs = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         granule_id = uuid.uuid4().__str__()
         file_name_0 = uuid.uuid4().__str__()
         dest_bucket_0 = uuid.uuid4().__str__()
@@ -916,7 +955,7 @@ class TestRequestFiles(unittest.TestCase):
     def test_restore_object_happy_path(self, mock_logger_info: MagicMock):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
         mock_s3_cli = Mock()
 
@@ -925,7 +964,7 @@ class TestRequestFiles(unittest.TestCase):
             key,
             restore_expire_days,
             glacier_bucket,
-            randint(0, 99999), # nosec
+            randint(0, 99999),  # nosec
             uuid.uuid4().__str__(),
             retrieval_type,
         )
@@ -944,7 +983,7 @@ class TestRequestFiles(unittest.TestCase):
         job_id = uuid.uuid4().__str__()
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
         expected_error = ClientError({}, "")
         mock_s3_cli = Mock()
@@ -980,7 +1019,7 @@ class TestRequestFiles(unittest.TestCase):
     ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
         expected_error = ClientError({}, "")
         mock_s3_cli = Mock()
@@ -1016,7 +1055,7 @@ class TestRequestFiles(unittest.TestCase):
     ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99999) # nosec
+        restore_expire_days = randint(0, 99999)  # nosec
         retrieval_type = uuid.uuid4().__str__()
         mock_s3_cli = Mock()
 
@@ -1025,7 +1064,7 @@ class TestRequestFiles(unittest.TestCase):
             key,
             restore_expire_days,
             glacier_bucket,
-            randint(0, 99999), # nosec
+            randint(0, 99999),  # nosec
             uuid.uuid4().__str__(),
             retrieval_type,
         )
@@ -1070,13 +1109,15 @@ class TestRequestFiles(unittest.TestCase):
 
         self.assertEqual(mock_task.return_value, result["payload"])
 
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_one_granule_4_files_success(self,
-                                              mock_logger_info: MagicMock,
-                                              mock_boto3_client: MagicMock,
-                                              mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_one_granule_4_files_success(
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test four files for one granule - successful
         """
@@ -1084,62 +1125,62 @@ class TestRequestFiles(unittest.TestCase):
         files = [KEY1, KEY2, KEY3, KEY4]
         input_event = {
             "input": {
-                "granules": [
-                    {
-                        "granuleId": granule_id,
-                        "keys": files
-                    }
-                ],
-                'job_id': uuid.uuid4().__str__()
+                "granules": [{"granuleId": granule_id, "keys": files}],
+                "job_id": uuid.uuid4().__str__(),
             },
-            "config": {
-                "glacier-bucket": "my-dr-fake-glacier-bucket"
-            }
+            "config": {"glacier-bucket": "my-dr-fake-glacier-bucket"},
         }
 
-        mock_s3_cli = mock_boto3_client('s3')
-        mock_s3_cli.restore_object.side_effect = [None,
-                                                  None,
-                                                  None,
-                                                  None
-                                                  ]
+        mock_s3_cli = mock_boto3_client("s3")
+        mock_s3_cli.restore_object.side_effect = [None, None, None, None]
 
         result = request_files.task(input_event, self.context)
 
-        mock_boto3_client.assert_has_calls([call('s3')])
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE1)
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE2)
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE3)
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE4)
-        restore_req_exp = {'Days': 5, 'GlacierJobParameters': {'Tier': 'Standard'}}
+        mock_boto3_client.assert_has_calls([call("s3")])
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE1
+        )
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE2
+        )
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE3
+        )
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE4
+        )
+        restore_req_exp = {"Days": 5, "GlacierJobParameters": {"Tier": "Standard"}}
 
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE1,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE2,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE3,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
         mock_s3_cli.restore_object.assert_called_with(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE4,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
 
         exp_gran = {
-            'granuleId': granule_id,
-            'keys': self.get_expected_keys(),
-            'recover_files': self.get_expected_files()
+            "granuleId": granule_id,
+            "keys": self.get_expected_keys(),
+            "recover_files": self.get_expected_files(),
         }
-        exp_granules = {'granules': [exp_gran], 'job_id': input_event['input']['job_id']}
+        exp_granules = {
+            "granules": [exp_gran],
+            "job_id": input_event["input"]["job_id"],
+        }
 
         self.assertEqual(exp_granules, result)
         mock_post_entry_to_queue.assert_called()  # called 4 times # todo: No..?
@@ -1298,143 +1339,167 @@ class TestRequestFiles(unittest.TestCase):
         mock_boto3_client.assert_called_with("s3")
         mock_s3_cli.head_object.assert_called_with(Bucket="my-bucket", Key=file1)
 
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    def test_task_no_retries_env_var(self,
-                                     mock_boto3_client: MagicMock,
-                                     mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    def test_task_no_retries_env_var(
+        self, mock_boto3_client: MagicMock, mock_post_entry_to_queue: MagicMock
+    ):
         """
         Test environment var RESTORE_REQUEST_RETRIES not set - use default.
         """
-        del os.environ['RESTORE_REQUEST_RETRIES']
+        del os.environ["RESTORE_REQUEST_RETRIES"]
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         # todo: Reduce string copy/paste for test values here and elsewhere.
         event = {
             "input": {
-                "granules":
-                    [{"granuleId": granule_id, "keys": [KEY1]}],
-                request_files.INPUT_JOB_ID_KEY: uuid.uuid4().__str__()
-            }, "config": {"glacier-bucket": "some_bucket"}
+                "granules": [{"granuleId": granule_id, "keys": [KEY1]}],
+                request_files.INPUT_JOB_ID_KEY: uuid.uuid4().__str__(),
+            },
+            "config": {"glacier-bucket": "some_bucket"},
         }
 
-        mock_s3_cli = mock_boto3_client('s3')
+        mock_s3_cli = mock_boto3_client("s3")
         mock_s3_cli.restore_object.side_effect = [None]
 
         exp_granules = {
-            'granules': [
+            "granules": [
                 {
-                    'granuleId': granule_id,
-                    'keys': [{'key': FILE1, 'dest_bucket': PROTECTED_BUCKET}],
-                    'recover_files': [{'key': FILE1, 'dest_bucket': PROTECTED_BUCKET, 'success': True, 'err_msg': ''}]
+                    "granuleId": granule_id,
+                    "keys": [{"key": FILE1, "dest_bucket": PROTECTED_BUCKET}],
+                    "recover_files": [
+                        {
+                            "key": FILE1,
+                            "dest_bucket": PROTECTED_BUCKET,
+                            "success": True,
+                            "err_msg": "",
+                        }
+                    ],
                 }
             ],
-            request_files.INPUT_JOB_ID_KEY: event['input']['job_id']
+            request_files.INPUT_JOB_ID_KEY: event["input"]["job_id"],
         }
         result = request_files.task(event, self.context)
-        os.environ['RESTORE_REQUEST_RETRIES'] = '2'  # todo: This test claims 'no_retries'
+        os.environ[
+            "RESTORE_REQUEST_RETRIES"
+        ] = "2"  # todo: This test claims 'no_retries'
         self.assertEqual(exp_granules, result)
 
-        mock_boto3_client.assert_called_with('s3')
-        mock_s3_cli.head_object.assert_called_with(Bucket='some_bucket',
-                                                   Key=FILE1)
-        restore_req_exp = {'Days': 5, 'GlacierJobParameters': {'Tier': 'Standard'}}
+        mock_boto3_client.assert_called_with("s3")
+        mock_s3_cli.head_object.assert_called_with(Bucket="some_bucket", Key=FILE1)
+        restore_req_exp = {"Days": 5, "GlacierJobParameters": {"Tier": "Standard"}}
         mock_s3_cli.restore_object.assert_called_with(
-            Bucket='some_bucket',
-            Key=FILE1,
-            RestoreRequest=restore_req_exp)
+            Bucket="some_bucket", Key=FILE1, RestoreRequest=restore_req_exp
+        )
         mock_post_entry_to_queue.assert_called()
 
     # todo: single_query is not called in code. Replace with higher-level checks.
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_no_expire_days_env_var(self,
-                                         mock_logger_info: MagicMock,
-                                         mock_boto3_client: MagicMock,
-                                         mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_no_expire_days_env_var(
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test environment var RESTORE_EXPIRE_DAYS not set - use default.
         """
-        del os.environ['RESTORE_EXPIRE_DAYS']
-        os.environ['RESTORE_RETRIEVAL_TYPE'] = 'Expedited'
+        del os.environ["RESTORE_EXPIRE_DAYS"]
+        os.environ["RESTORE_RETRIEVAL_TYPE"] = "Expedited"
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         event = {
             "config": {"glacier-bucket": "some_bucket"},
             "input": {
                 "granules": [{"granuleId": granule_id, "keys": [KEY1]}],
-                'job_id': uuid.uuid4().__str__()
-            }
+                "job_id": uuid.uuid4().__str__(),
+            },
         }
 
-        mock_s3_cli = mock_boto3_client('s3')
+        mock_s3_cli = mock_boto3_client("s3")
         # mock_s3_cli.head_object = Mock()  # todo: Look into why this line was in so many tests without asserts.
         mock_s3_cli.restore_object.side_effect = [None]
         exp_granules = {
-            'granules': [
+            "granules": [
                 {
-                    'granuleId': granule_id,
-                    'keys': [{'key': FILE1, 'dest_bucket': PROTECTED_BUCKET}],
-                    'recover_files': [{'key': FILE1, 'dest_bucket': PROTECTED_BUCKET, 'success': True, 'err_msg': ''}]
+                    "granuleId": granule_id,
+                    "keys": [{"key": FILE1, "dest_bucket": PROTECTED_BUCKET}],
+                    "recover_files": [
+                        {
+                            "key": FILE1,
+                            "dest_bucket": PROTECTED_BUCKET,
+                            "success": True,
+                            "err_msg": "",
+                        }
+                    ],
                 }
             ],
-            'job_id': event['input']['job_id']
+            "job_id": event["input"]["job_id"],
         }
 
         result = request_files.task(event, self.context)
         self.assertEqual(exp_granules, result)
-        os.environ['RESTORE_EXPIRE_DAYS'] = '3'  # todo: Why is this set here?
-        del os.environ['RESTORE_RETRIEVAL_TYPE']
-        mock_boto3_client.assert_called_with('s3')
-        mock_s3_cli.head_object.assert_called_with(Bucket='some_bucket',
-                                                   Key=FILE1)
-        restore_req_exp = {'Days': 5, 'GlacierJobParameters': {'Tier': 'Expedited'}}
+        os.environ["RESTORE_EXPIRE_DAYS"] = "3"  # todo: Why is this set here?
+        del os.environ["RESTORE_RETRIEVAL_TYPE"]
+        mock_boto3_client.assert_called_with("s3")
+        mock_s3_cli.head_object.assert_called_with(Bucket="some_bucket", Key=FILE1)
+        restore_req_exp = {"Days": 5, "GlacierJobParameters": {"Tier": "Expedited"}}
         mock_s3_cli.restore_object.assert_called_with(
-            Bucket='some_bucket',
-            Key=FILE1,
-            RestoreRequest=restore_req_exp)
+            Bucket="some_bucket", Key=FILE1, RestoreRequest=restore_req_exp
+        )
         self.assertEqual(2, mock_post_entry_to_queue.call_count)
 
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.error')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_client_error_one_file(self,
-                                        mock_logger_info: MagicMock,
-                                        mock_logger_error: MagicMock,
-                                        mock_boto3_client: MagicMock,
-                                        mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.error")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_client_error_one_file(
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test retries for restore error for one file.
         """
         event = {
             "config": {"glacier-bucket": "some_bucket"},
             "input": {
-                "granules": [{"granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
-                              "keys": [KEY1]}]},
-            'job_id': uuid.uuid4().__str__()
+                "granules": [
+                    {
+                        "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                        "keys": [KEY1],
+                    }
+                ]
+            },
+            "job_id": uuid.uuid4().__str__(),
         }
 
-        os.environ['RESTORE_RETRY_SLEEP_SECS'] = '.5'  # todo: This is not reset between tests
-        mock_s3_cli = mock_boto3_client('s3')
-        mock_s3_cli.restore_object.side_effect = [ClientError({'Error': {'Code': 'NoSuchBucket'}}, 'restore_object'),
-                                                  ClientError({'Error': {'Code': 'NoSuchBucket'}}, 'restore_object'),
-                                                  ClientError({'Error': {'Code': 'NoSuchBucket'}}, 'restore_object')]
-        os.environ['RESTORE_RETRIEVAL_TYPE'] = 'Standard'  # todo: This is not reset between tests
+        os.environ[
+            "RESTORE_RETRY_SLEEP_SECS"
+        ] = ".5"  # todo: This is not reset between tests
+        mock_s3_cli = mock_boto3_client("s3")
+        mock_s3_cli.restore_object.side_effect = [
+            ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
+            ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
+            ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
+        ]
+        os.environ[
+            "RESTORE_RETRIEVAL_TYPE"
+        ] = "Standard"  # todo: This is not reset between tests
 
         exp_gran = {
-            'granuleId': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321',
-            'keys': [
+            "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+            "keys": [{"key": FILE1, "dest_bucket": PROTECTED_BUCKET}],
+            "recover_files": [
                 {
-                    'key': FILE1,
-                    'dest_bucket': PROTECTED_BUCKET
+                    "key": FILE1,
+                    "dest_bucket": PROTECTED_BUCKET,
+                    "success": False,
+                    "err_msg": "An error occurred (NoSuchBucket) when calling the restore_object operation: Unknown",
                 }
             ],
-            'recover_files': [
-                {
-                    'key': FILE1, 'dest_bucket': PROTECTED_BUCKET, 'success': False,
-                    'err_msg': 'An error occurred (NoSuchBucket) when calling the restore_object operation: Unknown'
-                }
-            ]
         }
         exp_err = f"One or more files failed to be requested. {exp_gran}"
         try:
@@ -1442,26 +1507,26 @@ class TestRequestFiles(unittest.TestCase):
             self.fail("RestoreRequestError expected")
         except request_files.RestoreRequestError as err:
             self.assertEqual(exp_err, str(err))
-        del os.environ['RESTORE_RETRY_SLEEP_SECS']
-        del os.environ['RESTORE_RETRIEVAL_TYPE']
-        mock_boto3_client.assert_called_with('s3')
-        mock_s3_cli.head_object.assert_called_with(Bucket='some_bucket',
-                                                   Key=FILE1)
-        restore_req_exp = {'Days': 5, 'GlacierJobParameters': {'Tier': 'Standard'}}
+        del os.environ["RESTORE_RETRY_SLEEP_SECS"]
+        del os.environ["RESTORE_RETRIEVAL_TYPE"]
+        mock_boto3_client.assert_called_with("s3")
+        mock_s3_cli.head_object.assert_called_with(Bucket="some_bucket", Key=FILE1)
+        restore_req_exp = {"Days": 5, "GlacierJobParameters": {"Tier": "Standard"}}
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='some_bucket',
-            Key=FILE1,
-            RestoreRequest=restore_req_exp)
+            Bucket="some_bucket", Key=FILE1, RestoreRequest=restore_req_exp
+        )
 
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.error')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_client_error_3_times(self,
-                                       mock_logger_info: MagicMock,
-                                       mock_logger_error: MagicMock,
-                                       mock_boto3_client: MagicMock,
-                                       mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.error")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_client_error_3_times(
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test three files, two successful, one errors on all retries and fails.
         """
@@ -1469,26 +1534,24 @@ class TestRequestFiles(unittest.TestCase):
 
         event = {
             "config": {"glacier-bucket": "some_bucket"},
-            'job_id': uuid.uuid4().__str__()}
+            "job_id": uuid.uuid4().__str__(),
+        }
         gran = {"granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321", "keys": keys}
 
-        event["input"] = {
-            "granules": [gran]}
-        mock_s3_cli = mock_boto3_client('s3')
-        mock_s3_cli.restore_object.side_effect = [None,
-                                                  ClientError({'Error': {'Code': 'NoSuchBucket'}},
-                                                              'restore_object'),
-                                                  None,
-                                                  ClientError({'Error': {'Code': 'NoSuchBucket'}},
-                                                              'restore_object'),
-                                                  ClientError({'Error': {'Code': 'NoSuchKey'}},
-                                                              'restore_object')
-                                                  ]
+        event["input"] = {"granules": [gran]}
+        mock_s3_cli = mock_boto3_client("s3")
+        mock_s3_cli.restore_object.side_effect = [
+            None,
+            ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
+            None,
+            ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
+            ClientError({"Error": {"Code": "NoSuchKey"}}, "restore_object"),
+        ]
 
         exp_gran = {
-            'granuleId': gran["granuleId"],
-            'keys': self.get_exp_keys_3_errs(),
-            'recover_files': self.get_exp_files_3_errs()
+            "granuleId": gran["granuleId"],
+            "keys": self.get_exp_keys_3_errs(),
+            "recover_files": self.get_exp_files_3_errs(),
         }
         exp_err = f"One or more files failed to be requested. {exp_gran}"
         try:
@@ -1497,13 +1560,13 @@ class TestRequestFiles(unittest.TestCase):
         except request_files.RestoreRequestError as err:
             self.assertEqual(exp_err, str(err))
 
-        mock_boto3_client.assert_called_with('s3')
-        mock_s3_cli.head_object.assert_any_call(Bucket='some_bucket',
-                                                Key=FILE1)
+        mock_boto3_client.assert_called_with("s3")
+        mock_s3_cli.head_object.assert_any_call(Bucket="some_bucket", Key=FILE1)
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='some_bucket',
+            Bucket="some_bucket",
             Key=FILE1,
-            RestoreRequest={'Days': 5, 'GlacierJobParameters': {'Tier': 'Standard'}})
+            RestoreRequest={"Days": 5, "GlacierJobParameters": {"Tier": "Standard"}},
+        )
         mock_post_entry_to_queue.assert_called()  # 5 times # todo: No..?
 
     @staticmethod
@@ -1545,74 +1608,83 @@ class TestRequestFiles(unittest.TestCase):
         ]
 
     # todo: single_query is not called in code. Replace with higher-level checks.
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.error')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_client_error_2_times(self,
-                                       mock_logger_info: MagicMock,
-                                       mock_logger_error: MagicMock,
-                                       mock_boto3_client: MagicMock,
-                                       mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.error")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_client_error_2_times(
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test two files, first successful, second has two errors, then success.
         """
-        event = {
-            "config": {"glacier-bucket": "some_bucket"}
-        }
+        event = {"config": {"glacier-bucket": "some_bucket"}}
         gran = {}
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         gran["granuleId"] = granule_id
         keys = [KEY1, KEY2]
         gran["keys"] = keys
-        event["input"] = {
-            "granules": [gran],
-            'job_id': uuid.uuid4().__str__()
-        }
-        mock_s3_cli = mock_boto3_client('sqs')
+        event["input"] = {"granules": [gran], "job_id": uuid.uuid4().__str__()}
+        mock_s3_cli = mock_boto3_client("sqs")
 
-        mock_s3_cli.restore_object.side_effect = [None,
-                                                  ClientError({'Error': {'Code': 'NoSuchBucket'}},
-                                                              'restore_object'),
-                                                  ClientError({'Error': {'Code': 'NoSuchBucket'}},
-                                                              'restore_object'),
-                                                  None
-                                                  ]
+        mock_s3_cli.restore_object.side_effect = [
+            None,
+            ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
+            ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
+            None,
+        ]
 
         exp_granules = {
-            'granules': [
+            "granules": [
                 {
-                    'granuleId': granule_id,
-                    'keys': [
-                        {'key': FILE1, 'dest_bucket': PROTECTED_BUCKET},
-                        {'key': FILE2, 'dest_bucket': PROTECTED_BUCKET}
+                    "granuleId": granule_id,
+                    "keys": [
+                        {"key": FILE1, "dest_bucket": PROTECTED_BUCKET},
+                        {"key": FILE2, "dest_bucket": PROTECTED_BUCKET},
                     ],
-                    'recover_files': [
-                        {'key': FILE1, 'dest_bucket': PROTECTED_BUCKET, 'success': True, 'err_msg': ''},
-                        {'key': FILE2, 'dest_bucket': PROTECTED_BUCKET, 'success': True, 'err_msg': ''}
-                    ]
+                    "recover_files": [
+                        {
+                            "key": FILE1,
+                            "dest_bucket": PROTECTED_BUCKET,
+                            "success": True,
+                            "err_msg": "",
+                        },
+                        {
+                            "key": FILE2,
+                            "dest_bucket": PROTECTED_BUCKET,
+                            "success": True,
+                            "err_msg": "",
+                        },
+                    ],
                 }
             ],
-            'job_id': event['input']['job_id']
+            "job_id": event["input"]["job_id"],
         }
 
         result = request_files.task(event, self.context)
         self.assertEqual(exp_granules, result)
 
-        mock_boto3_client.assert_has_calls([call('sqs')])
+        mock_boto3_client.assert_has_calls([call("sqs")])
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='some_bucket',
+            Bucket="some_bucket",
             Key=FILE1,
-            RestoreRequest={'Days': 5, 'GlacierJobParameters': {'Tier': 'Standard'}})
+            RestoreRequest={"Days": 5, "GlacierJobParameters": {"Tier": "Standard"}},
+        )
         mock_post_entry_to_queue.assert_called()  # 4 times # todo: No..?
 
-    @patch('request_files.shared_recovery.post_entry_to_queue')
-    @patch('boto3.client')
-    @patch('cumulus_logger.CumulusLogger.info')
-    def test_task_output_json_schema(self,
-                                     mock_logger_info: MagicMock,
-                                     mock_boto3_client: MagicMock,
-                                     mock_post_entry_to_queue: MagicMock):
+    @patch("request_files.shared_recovery.post_entry_to_queue")
+    @patch("boto3.client")
+    @patch("cumulus_logger.CumulusLogger.info")
+    def test_task_output_json_schema(
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
+    ):
         """
         Test four files for one granule - successful. Check against output schema.
         """
@@ -1620,62 +1692,62 @@ class TestRequestFiles(unittest.TestCase):
         files = [KEY1, KEY2, KEY3, KEY4]
         input_event = {
             "input": {
-                "granules": [
-                    {
-                        "granuleId": granule_id,
-                        "keys": files
-                    }
-                ],
-                'job_id': uuid.uuid4().__str__()
+                "granules": [{"granuleId": granule_id, "keys": files}],
+                "job_id": uuid.uuid4().__str__(),
             },
-            "config": {
-                "glacier-bucket": "my-dr-fake-glacier-bucket"
-            }
+            "config": {"glacier-bucket": "my-dr-fake-glacier-bucket"},
         }
 
-        mock_s3_cli = mock_boto3_client('s3')
-        mock_s3_cli.restore_object.side_effect = [None,
-                                                  None,
-                                                  None,
-                                                  None
-                                                  ]
+        mock_s3_cli = mock_boto3_client("s3")
+        mock_s3_cli.restore_object.side_effect = [None, None, None, None]
 
         result = request_files.task(input_event, self.context)
 
-        mock_boto3_client.assert_has_calls([call('s3')])
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE1)
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE2)
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE3)
-        mock_s3_cli.head_object.assert_any_call(Bucket='my-dr-fake-glacier-bucket',
-                                                Key=FILE4)
-        restore_req_exp = {'Days': 5, 'GlacierJobParameters': {'Tier': 'Standard'}}
+        mock_boto3_client.assert_has_calls([call("s3")])
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE1
+        )
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE2
+        )
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE3
+        )
+        mock_s3_cli.head_object.assert_any_call(
+            Bucket="my-dr-fake-glacier-bucket", Key=FILE4
+        )
+        restore_req_exp = {"Days": 5, "GlacierJobParameters": {"Tier": "Standard"}}
 
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE1,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE2,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE3,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
         mock_s3_cli.restore_object.assert_called_with(
-            Bucket='my-dr-fake-glacier-bucket',
+            Bucket="my-dr-fake-glacier-bucket",
             Key=FILE4,
-            RestoreRequest=restore_req_exp)
+            RestoreRequest=restore_req_exp,
+        )
 
         exp_gran = {
-            'granuleId': granule_id,
-            'keys': self.get_expected_keys(),
-            'recover_files': self.get_expected_files()
+            "granuleId": granule_id,
+            "keys": self.get_expected_keys(),
+            "recover_files": self.get_expected_files(),
         }
-        exp_granules = {'granules': [exp_gran], 'job_id': input_event['input']['job_id']}
+        exp_granules = {
+            "granules": [exp_gran],
+            "job_id": input_event["input"]["job_id"],
+        }
 
         self.assertEqual(exp_granules, result)
         mock_post_entry_to_queue.assert_called()  # called 4 times # todo: No..?

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -639,12 +639,31 @@ class TestRequestFiles(unittest.TestCase):
             },
         ]
 
-        mock_create_status_for_job.assert_has_calls(
-            [
-                call(job_id, granule_id, glacier_bucket, files_0, db_queue_url),
-                call(job_id, granule_id, glacier_bucket, files_1, db_queue_url),
+        files_all= [
+            {
+                "filename": file_name_0,
+                "key_path": file_name_0,
+                "restore_destination": dest_bucket_0,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                "error_message": None,
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+                "completion_time": None,
+            },
+
+            {
+                "filename": file_name_1,
+                "key_path": file_name_1,
+                "restore_destination": dest_bucket_1,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                "error_message": None,
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+                "completion_time": None,
+            },
             ]
-        )
+
+        mock_create_status_for_job.assert_called_with(job_id, granule_id, glacier_bucket, files_all, db_queue_url)
 
         mock_restore_object.assert_has_calls(
             [
@@ -1212,7 +1231,7 @@ class TestRequestFiles(unittest.TestCase):
         try:
             result = request_files.task(input_event, self.context)
         except Exception as err:
-            mock_post_entry_to_queue.assert_called_once()
+            mock_post_entry_to_queue.assert_called
             return
         self.fail(f"failed post to status queue should throw exception.")
 

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -434,9 +434,22 @@ class TestRequestFiles(unittest.TestCase):
 
         self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][0][request_files.FILE_SUCCESS_KEY])
         self.assertTrue(granule[request_files.GRANULE_RECOVER_FILES_KEY][1][request_files.FILE_SUCCESS_KEY])
-
+        files = [
+            {
+                "filename": os.path.basename(
+                    granule[GRANULE_RECOVER_FILES_KEY][FILE_KEY_KEY]
+                )
+            },
+            {"key_path": mock.ANY}, #TBD
+            {"restore_destination": mock.ANY}, #TBD
+            {"status_id": shared_recovery.OrcaStatus.PENDING.value},
+            {"error_message": None},
+            {"request_time": mock.ANY},
+            {"last_update": mock.ANY},
+            {"completion_time": None},
+        ]
         mock_create_status_for_job.assert_called_once_with(job_id, granule_id, glacier_bucket,
-                                                                    files, #TBD
+                                                                    files,
                                                                   db_queue_url,
                                                                   )
         mock_restore_object.assert_has_calls([
@@ -867,7 +880,7 @@ class TestRequestFiles(unittest.TestCase):
         ]
 
     # todo: single_query is not called in code. Replace with higher-level checks.
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     @patch('cumulus_logger.CumulusLogger.error')
     @patch('cumulus_logger.CumulusLogger.info')
@@ -929,7 +942,7 @@ class TestRequestFiles(unittest.TestCase):
         except request_files.RestoreRequestError as roe:
             self.assertEqual(exp_err, str(roe))
 
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     @patch('cumulus_logger.CumulusLogger.info')
     def test_task_file_not_in_glacier(self,
@@ -977,7 +990,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_boto3_client.assert_called_with('s3')
         mock_s3_cli.head_object.assert_called_with(Bucket='my-bucket', Key=file1)
 
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     def test_task_no_retries_env_var(self,
                                      mock_boto3_client: MagicMock,
@@ -1024,7 +1037,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_post_entry_to_queue.assert_called()
 
     # todo: single_query is not called in code. Replace with higher-level checks.
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     @patch('cumulus_logger.CumulusLogger.info')
     def test_task_no_expire_days_env_var(self,
@@ -1073,7 +1086,7 @@ class TestRequestFiles(unittest.TestCase):
             RestoreRequest=restore_req_exp)
         self.assertEqual(2, mock_post_entry_to_queue.call_count)
 
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     @patch('cumulus_logger.CumulusLogger.error')
     @patch('cumulus_logger.CumulusLogger.info')
@@ -1132,7 +1145,7 @@ class TestRequestFiles(unittest.TestCase):
             Key=FILE1,
             RestoreRequest=restore_req_exp)
 
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     @patch('cumulus_logger.CumulusLogger.error')
     @patch('cumulus_logger.CumulusLogger.info')
@@ -1210,7 +1223,7 @@ class TestRequestFiles(unittest.TestCase):
         ]
 
     # todo: single_query is not called in code. Replace with higher-level checks.
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     @patch('cumulus_logger.CumulusLogger.error')
     @patch('cumulus_logger.CumulusLogger.info')
@@ -1271,7 +1284,7 @@ class TestRequestFiles(unittest.TestCase):
             RestoreRequest={'Days': 5, 'GlacierJobParameters': {'Tier': 'Standard'}})
         mock_post_entry_to_queue.assert_called()  # 4 times # todo: No..?
 
-    @patch('request_files.post_entry_to_queue')
+    @patch('request_files.shared_recovery.post_entry_to_queue')
     @patch('boto3.client')
     @patch('cumulus_logger.CumulusLogger.info')
     def test_task_output_json_schema(self,


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-170: Use new shared_recovery library in request_files lambda](https://bugs.earthdata.nasa.gov/browse/ORCA-170)

## Changes

* updated bin/build_tasks.sh and bin/run_tests.sh for the request_files.py
* created new folder bin under tasks/request_files
  * added build.sh
  * added run_tests.sh
*    updated tasks/request_files/request_files.py and tasks/request_files/test/unit_tests/test_request_files.py to use the new shared library.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

ran unit tests from tasks/request_files/build.sh and tasks/request_files/run_tests.sh
The build.sh passed and created the request_files.zip file but the run_tests.sh failed.


## What is the current behavior?
out of the 31 unit tests, 8 are failing with the error below.

## Relevant logs and/or screenshots
![image](https://user-images.githubusercontent.com/39888380/119859438-01aa8600-bedb-11eb-9546-ef56af64bf52.png)

