### PR TITLE
Feature/orca 207

### DIFF
--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -17,7 +17,7 @@
             "private-bucket": "{$.meta.buckets.private.name}",
             "internal-bucket": "{$.meta.buckets.internal.name}",
             "file-buckets": "{$.meta.collection.files}",
-            "excludeFileTypes": "{[$.meta.collection.meta.excludeFileTypes]}"
+            "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}"
           }
         }
       },

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -17,7 +17,7 @@
             "private-bucket": "{$.meta.buckets.private.name}",
             "internal-bucket": "{$.meta.buckets.internal.name}",
             "file-buckets": "{$.meta.collection.files}",
-            "exclude_file_types": "{[$.meta.collection.meta.excludeFileTypes]}"
+            "excludeFileTypes": "{[$.meta.collection.meta.excludeFileTypes]}"
           }
         }
       },

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -16,7 +16,8 @@
             "protected-bucket": "{$.meta.buckets.protected.name}",
             "private-bucket": "{$.meta.buckets.private.name}",
             "internal-bucket": "{$.meta.buckets.internal.name}",
-            "file-buckets": "{$.meta.collection.files}"
+            "file-buckets": "{$.meta.collection.files}",
+            "exclude_file_types": "{[$.meta.collection.meta.excludeFileTypes]}"
           }
         }
       },

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -14,8 +14,6 @@ from typing import List
 LOGGER = CumulusLogger(name="ORCA")
 
 EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
-CONFIG_COLLECTION_KEY = 'collection'
-COLLECTION_META_KEY = 'meta'
 
 class ExtractFilePathsError(Exception):
     """Exception to be raised if any errors occur"""
@@ -39,7 +37,7 @@ def task(event, context):    #pylint: disable-msg=unused-argument
     LOGGER.debug("event: {event}", event=event)
     try:
         config = event['config']
-        exclude_file_types = config['exclude_file_types']
+        exclude_file_types = config.get(EXCLUDE_FILE_TYPES_KEY, [])
         if len(exclude_file_types) == 0:
             LOGGER.debug(f"The configuration list {EXCLUDE_FILE_TYPES_KEY} is empty.")
         else:

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -11,7 +11,7 @@ from cumulus_logger import CumulusLogger
 from run_cumulus_task import run_cumulus_task
 from typing import List
 # instantiate Cumulus logger
-LOGGER = CumulusLogger()
+LOGGER = CumulusLogger(name="ORCA")
 
 EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
 CONFIG_COLLECTION_KEY = 'collection'
@@ -39,8 +39,7 @@ def task(event, context):    #pylint: disable-msg=unused-argument
     LOGGER.debug("event: {event}", event=event)
     try:
         config = event['config']
-        collection = config.get(CONFIG_COLLECTION_KEY, {})
-        exclude_file_types = collection.get(COLLECTION_META_KEY, {}).get(EXCLUDE_FILE_TYPES_KEY, [])
+        exclude_file_types = config['exclude_file_types']
         if len(exclude_file_types) == 0:
             LOGGER.debug(f"The configuration list {EXCLUDE_FILE_TYPES_KEY} is empty.")
         else:

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -149,8 +149,7 @@ def should_exclude_files_type(granule_url: str, exclude_file_types: List[str]) -
                 f"The file {granule_url} will not be restored because it matches the excluded file type {file_type}."
             )
             return True
-        else:
-            LOGGER.debug(f"File {granule_url} will be restored")
+    LOGGER.debug(f"File {granule_url} will be restored")
     return False
 
 

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -134,10 +134,10 @@ def should_exclude_files_type(granule_url: str, exclude_file_types: List[str]) -
     for file_type in exclude_file_types:
         # Returns the first instance in the string that matches .ext or None if no match was found.
         if re.search(f"^.*{file_type}$", granule_url) is not None:
-            LOGGER.debug(f"The file {granule_url} will not be restored because it matches the excluded file type {file_type}.")
+            LOGGER.warn(f"The file {granule_url} will not be restored because it matches the excluded file type {file_type}.")
             return True
         else:
-            LOGGER.debug(f"file {granule_url} will be restored")
+            LOGGER.debug(f"File {granule_url} will be restored")
     return False
 
 def handler(event, context):            #pylint: disable-msg=unused-argument

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -10,15 +10,18 @@ import os
 from cumulus_logger import CumulusLogger
 from run_cumulus_task import run_cumulus_task
 from typing import List
+
 # instantiate Cumulus logger
 LOGGER = CumulusLogger(name="ORCA")
 
-EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
+EXCLUDE_FILE_TYPES_KEY = "excludeFileTypes"
+
 
 class ExtractFilePathsError(Exception):
     """Exception to be raised if any errors occur"""
 
-def task(event, context):    #pylint: disable-msg=unused-argument
+
+def task(event, context):  # pylint: disable-msg=unused-argument
     """
     Task called by the handler to perform the work.
 
@@ -36,48 +39,58 @@ def task(event, context):    #pylint: disable-msg=unused-argument
     """
     LOGGER.debug("event: {event}", event=event)
     try:
-        config = event['config']
+        config = event["config"]
         exclude_file_types = config.get(EXCLUDE_FILE_TYPES_KEY, [])
         if len(exclude_file_types) == 0:
             LOGGER.debug(f"The configuration list {EXCLUDE_FILE_TYPES_KEY} is empty.")
         else:
-            LOGGER.debug(f"The configuration {EXCLUDE_FILE_TYPES_KEY} list {exclude_file_types} was found.")
+            LOGGER.debug(
+                f"The configuration {EXCLUDE_FILE_TYPES_KEY} list {exclude_file_types} was found."
+            )
     except KeyError as ke:
-            message = "Key {key} is missing from the event configuration: {config}"
-            LOGGER.error(message, key=ke, config=config)
-            raise KeyError(message.format(key=ke, config=config))
+        message = "Key {key} is missing from the event configuration: {config}"
+        LOGGER.error(message, key=ke, config=config)
+        raise KeyError(message.format(key=ke, config=config))
     result = {}
     try:
         regex_buckets = get_regex_buckets(event)
         level = "event['input']"
         grans = []
-        for ev_granule in event['input']['granules']:
+        for ev_granule in event["input"]["granules"]:
             gran = ev_granule.copy()
             files = []
             level = "event['input']['granules'][]"
-            gran['granuleId'] = ev_granule['granuleId']
-            for afile in ev_granule['files']:
+            gran["granuleId"] = ev_granule["granuleId"]
+            for afile in ev_granule["files"]:
                 level = "event['input']['granules'][]['files']"
-                file_name = os.path.basename(afile['fileName']) if \
-                    re.search('^s3://', afile['fileName']) else afile['fileName']
+                file_name = (
+                    os.path.basename(afile["fileName"])
+                    if re.search("^s3://", afile["fileName"])
+                    else afile["fileName"]
+                )
                 LOGGER.debug(f"Validating file {file_name}")
                 # filtering excludedFileTypes
                 if not should_exclude_files_type(file_name, exclude_file_types):
-                    fkey = afile['key']
+                    fkey = afile["key"]
                     LOGGER.debug(f"Retrieving information for {fkey}")
                     dest_bucket = None
                     for key in regex_buckets:
                         pat = re.compile(key)
                         if pat.match(file_name):
                             dest_bucket = regex_buckets[key]
-                            LOGGER.debug("Found retrieval destination {dest_bucket} for {file}", dest_bucket=dest_bucket, file=file_name)
-                    files.append({'key': fkey, 'dest_bucket': dest_bucket})
-            gran['keys'] = files
+                            LOGGER.debug(
+                                "Found retrieval destination {dest_bucket} for {file}",
+                                dest_bucket=dest_bucket,
+                                file=file_name,
+                            )
+                    files.append({"key": fkey, "dest_bucket": dest_bucket})
+            gran["keys"] = files
             grans.append(gran)
-        result['granules'] = grans
+        result["granules"] = grans
     except KeyError as err:
         raise ExtractFilePathsError(f'KeyError: "{level}[{str(err)}]" is required')
     return result
+
 
 def get_regex_buckets(event):
     """
@@ -96,11 +109,11 @@ def get_regex_buckets(event):
     buckets = {}
     try:
         level = "event['config']"
-        buckets["protected"] = event['config']['protected-bucket']
-        buckets["internal"] = event['config']['internal-bucket']
-        buckets["private"] = event['config']['private-bucket']
-        buckets["public"] = event['config']['public-bucket']
-        file_buckets = event['config']['file-buckets']
+        buckets["protected"] = event["config"]["protected-bucket"]
+        buckets["internal"] = event["config"]["internal-bucket"]
+        buckets["private"] = event["config"]["private-bucket"]
+        buckets["public"] = event["config"]["public-bucket"]
+        file_buckets = event["config"]["file-buckets"]
         # file_buckets example:
         # [{'regex': '.*.h5$', 'sampleFileName': 'L0A_0420.h5', 'bucket': 'protected'},
         # {'regex': '.*.iso.xml$', 'sampleFileName': 'L0A_0420.iso.xml', 'bucket': 'protected'},
@@ -119,6 +132,7 @@ def get_regex_buckets(event):
         raise ExtractFilePathsError(f'KeyError: "{level}[{str(err)}]" is required')
     return regex_buckets
 
+
 def should_exclude_files_type(granule_url: str, exclude_file_types: List[str]) -> bool:
     """
     Tests whether or not file is included in {excludeFileTypes}.
@@ -131,53 +145,56 @@ def should_exclude_files_type(granule_url: str, exclude_file_types: List[str]) -
     for file_type in exclude_file_types:
         # Returns the first instance in the string that matches .ext or None if no match was found.
         if re.search(f"^.*{file_type}$", granule_url) is not None:
-            LOGGER.warn(f"The file {granule_url} will not be restored because it matches the excluded file type {file_type}.")
+            LOGGER.warn(
+                f"The file {granule_url} will not be restored because it matches the excluded file type {file_type}."
+            )
             return True
         else:
             LOGGER.debug(f"File {granule_url} will be restored")
     return False
 
-def handler(event, context):            #pylint: disable-msg=unused-argument
+
+def handler(event, context):  # pylint: disable-msg=unused-argument
     """Lambda handler. Extracts the key's for a granule from an input dict.
 
-        Args:
-            event (dict): A dict with the following keys:
+    Args:
+        event (dict): A dict with the following keys:
 
-                granules (list(dict)): A list of dict with the following keys:
-                    granuleId (string): The id of a granule.
-                    files (list(dict)): list of dict with the following keys:
-                        key (string): The key of the file to be returned.
-                        other dictionary keys may be included, but are not used.
+            granules (list(dict)): A list of dict with the following keys:
+                granuleId (string): The id of a granule.
+                files (list(dict)): list of dict with the following keys:
+                    key (string): The key of the file to be returned.
                     other dictionary keys may be included, but are not used.
+                other dictionary keys may be included, but are not used.
 
-                Example: event: {'granules': [
-                                      {'granuleId': 'granxyz',
-                                       'version": '006',
-                                       'files': [
-                                            {'name': 'file1',
-                                             'key': 'key1',
-                                             'filename': 's3://dr-test-sandbox-protected/file1',
-                                             'type': 'metadata'} ]
-                                       }
-                                    ]
-                                 }
+            Example: event: {'granules': [
+                                  {'granuleId': 'granxyz',
+                                   'version": '006',
+                                   'files': [
+                                        {'name': 'file1',
+                                         'key': 'key1',
+                                         'filename': 's3://dr-test-sandbox-protected/file1',
+                                         'type': 'metadata'} ]
+                                   }
+                                ]
+                             }
 
-            context (Object): None
+        context (Object): None
 
-        Returns:
-            dict: A dict with the following keys:
+    Returns:
+        dict: A dict with the following keys:
 
-                'granules' (list(dict)): list of dict with the following keys:
-                    'granuleId' (string): The id of a granule.
-                    'keys' (list(string)): list of keys for the granule.
+            'granules' (list(dict)): list of dict with the following keys:
+                'granuleId' (string): The id of a granule.
+                'keys' (list(string)): list of keys for the granule.
 
-            Example:
-                {"granules": [{"granuleId": "granxyz",
-                             "keys": ["key1",
-                                           "key2"]}]}
+        Example:
+            {"granules": [{"granuleId": "granxyz",
+                         "keys": ["key1",
+                                       "key2"]}]}
 
-        Raises:
-            ExtractFilePathsError: An error occurred parsing the input.
+    Raises:
+        ExtractFilePathsError: An error occurred parsing the input.
     """
     LOGGER.setMetadata(event, context)
     result = run_cumulus_task(task, event, context)

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
@@ -41,67 +41,83 @@ class TestExtractFilePaths(unittest.TestCase):
         """
         result = extract_filepaths_for_granule.task(self.task_input_event, self.context)
 
-        exp_key1 = {'key': self.task_input_event['input']['granules'][0]['files'][0]['key'],
-                    'dest_bucket': 'sndbx-cumulus-protected'}
-        exp_key2 = {'key': self.task_input_event['input']['granules'][0]['files'][1]['key'],
-                    'dest_bucket': 'sndbx-cumulus-public'}
-        exp_key3 = {'key': self.task_input_event['input']['granules'][0]['files'][2]['key'],
-                    'dest_bucket': None}
-        exp_key4 = {'key': self.task_input_event['input']['granules'][0]['files'][3]['key'],
-                    'dest_bucket': 'sndbx-cumulus-public'}
+        exp_key1 = {
+            "key": self.task_input_event["input"]["granules"][0]["files"][0]["key"],
+            "dest_bucket": "sndbx-cumulus-protected",
+        }
+        exp_key2 = {
+            "key": self.task_input_event["input"]["granules"][0]["files"][1]["key"],
+            "dest_bucket": "sndbx-cumulus-public",
+        }
+        exp_key3 = {
+            "key": self.task_input_event["input"]["granules"][0]["files"][2]["key"],
+            "dest_bucket": None,
+        }
+        exp_key4 = {
+            "key": self.task_input_event["input"]["granules"][0]["files"][3]["key"],
+            "dest_bucket": "sndbx-cumulus-public",
+        }
         exp_gran = {
-            'dataType': 'MOD09GQ_test-jk2-IngestGranuleSuccess-1558420117156',
-            'files': [{'bucket': 'cumulus-test-sandbox-protected',
-                       'duplicate_found': 'True',
-                       'fileName': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5',
-                       'key': 'MOD09GQ___006/2017/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5',
-                       'path': 'jk2-IngestGranuleSuccess-1558420117156-test-data/files',
-                       'size': 1098034,
-                       'type': 'data',
-                       'url_path': '{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, '
-                                   '0, 3)}'},
-                      {'bucket': 'cumulus-test-sandbox-private',
-                       'duplicate_found': 'True',
-                       'fileName': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5.mp',
-                       'key': 'MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5.mp',
-                       'path': 'jk2-IngestGranuleSuccess-1558420117156-test-data/files',
-                       'size': 21708,
-                       'type': 'metadata',
-                       'url_path': '{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, '
-                                   '0, 3)}'},
-                      {'bucket': 'cumulus-test-sandbox-public',
-                       'duplicate_found': 'True',
-                       'fileName': 's3://cumulus-test-sandbox-public/MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321_ndvi.jpg',
-                       'key': 'MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321_ndvi.jpg',
-                       'path': 'jk2-IngestGranuleSuccess-1558420117156-test-data/files',
-                       'size': 9728,
-                       'type': 'browse',
-                       'url_path': '{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, '
-                                   '0, 3)}'},
-                      {'bucket': 'cumulus-test-sandbox-protected-2',
-                       'fileName': 's3://cumulus-test-sandbox-protected-2/MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.json',
-                       'key': 'MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.json',
-                       'name': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.json',
-                       'type': 'metadata',
-                       'url_path': '{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, '
-                                   '0, 3)}'}],
-            'granuleId': self.task_input_event['input']['granules'][0]['granuleId'],
-            'keys': [exp_key1, exp_key2, exp_key3, exp_key4],
-            'version': '006'
+            "dataType": "MOD09GQ_test-jk2-IngestGranuleSuccess-1558420117156",
+            "files": [
+                {
+                    "bucket": "cumulus-test-sandbox-protected",
+                    "duplicate_found": "True",
+                    "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5",
+                    "key": "MOD09GQ___006/2017/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5",
+                    "path": "jk2-IngestGranuleSuccess-1558420117156-test-data/files",
+                    "size": 1098034,
+                    "type": "data",
+                    "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, "
+                    "0, 3)}",
+                },
+                {
+                    "bucket": "cumulus-test-sandbox-private",
+                    "duplicate_found": "True",
+                    "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5.mp",
+                    "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5.mp",
+                    "path": "jk2-IngestGranuleSuccess-1558420117156-test-data/files",
+                    "size": 21708,
+                    "type": "metadata",
+                    "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, "
+                    "0, 3)}",
+                },
+                {
+                    "bucket": "cumulus-test-sandbox-public",
+                    "duplicate_found": "True",
+                    "fileName": "s3://cumulus-test-sandbox-public/MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321_ndvi.jpg",
+                    "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321_ndvi.jpg",
+                    "path": "jk2-IngestGranuleSuccess-1558420117156-test-data/files",
+                    "size": 9728,
+                    "type": "browse",
+                    "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, "
+                    "0, 3)}",
+                },
+                {
+                    "bucket": "cumulus-test-sandbox-protected-2",
+                    "fileName": "s3://cumulus-test-sandbox-protected-2/MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.json",
+                    "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.json",
+                    "name": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.json",
+                    "type": "metadata",
+                    "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, "
+                    "0, 3)}",
+                },
+            ],
+            "granuleId": self.task_input_event["input"]["granules"][0]["granuleId"],
+            "keys": [exp_key1, exp_key2, exp_key3, exp_key4],
+            "version": "006",
         }
 
         exp_grans = [exp_gran]
 
-        exp_result = {
-            'granules': exp_grans
-        }
+        exp_result = {"granules": exp_grans}
         self.assertEqual(exp_result, result)
 
     def test_task_no_granules(self):
         """
         Test no 'granules' key in input event.
         """
-        self.task_input_event['input'].pop('granules', None)
+        self.task_input_event["input"].pop("granules", None)
         exp_err = "KeyError: \"event['input']['granules']\" is required"
         CumulusLogger.error = Mock()
         try:
@@ -114,7 +130,7 @@ class TestExtractFilePaths(unittest.TestCase):
         """
         Test no granuleId in input event.
         """
-        self.task_input_event['input']['granules'][0] = {"files": []}
+        self.task_input_event["input"]["granules"][0] = {"files": []}
 
         exp_err = "KeyError: \"event['input']['granules'][]['granuleId']\" is required"
         CumulusLogger.error = Mock()
@@ -128,9 +144,10 @@ class TestExtractFilePaths(unittest.TestCase):
         """
         Test no files in input event.
         """
-        self.task_input_event['input']['granules'][0].pop('files', None)
-        self.task_input_event['granules'] = [{
-            "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321"}]
+        self.task_input_event["input"]["granules"][0].pop("files", None)
+        self.task_input_event["granules"] = [
+            {"granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321"}
+        ]
 
         exp_err = "KeyError: \"event['input']['granules'][]['files']\" is required"
         try:
@@ -143,24 +160,43 @@ class TestExtractFilePaths(unittest.TestCase):
         """
         Test no key in input event.
         """
-        self.task_input_event['input'].pop('granules', None)
-        self.task_input_event['config']['protected-bucket'] = "my_protected_bucket"
-        self.task_input_event['config']['internal-bucket'] = "my_internal_bucket"
-        self.task_input_event['config']['private-bucket'] = "my_private_bucket"
-        self.task_input_event['config']['public-bucket'] = "my_public_bucket"
-        self.task_input_event['config']['file-buckets'] = (
-            [{'regex': '.*.h5$', 'sampleFileName': 'L_10-420.h5', 'bucket': 'protected'},
-             {'regex': '.*.iso.xml$', 'sampleFileName': 'L_10-420.iso.xml', 'bucket': 'protected'},
-             {'regex': '.*.h5.mp$', 'sampleFileName': 'L_10-420.h5.mp', 'bucket': 'public'},
-             {'regex': '.*.cmr.json$', 'sampleFileName': 'L_10-420.cmr.json', 'bucket': 'public'}])
-        self.task_input_event['input']['granules'] = [{
-            "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
-            "files": [
-                {
-                    "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
-                    "bucket": "cumulus-test-sandbox-protected-2"
-                }]}]
-        exp_err = "KeyError: \"event['input']['granules'][]['files']['key']\" is required"
+        self.task_input_event["input"].pop("granules", None)
+        self.task_input_event["config"]["protected-bucket"] = "my_protected_bucket"
+        self.task_input_event["config"]["internal-bucket"] = "my_internal_bucket"
+        self.task_input_event["config"]["private-bucket"] = "my_private_bucket"
+        self.task_input_event["config"]["public-bucket"] = "my_public_bucket"
+        self.task_input_event["config"]["file-buckets"] = [
+            {"regex": ".*.h5$", "sampleFileName": "L_10-420.h5", "bucket": "protected"},
+            {
+                "regex": ".*.iso.xml$",
+                "sampleFileName": "L_10-420.iso.xml",
+                "bucket": "protected",
+            },
+            {
+                "regex": ".*.h5.mp$",
+                "sampleFileName": "L_10-420.h5.mp",
+                "bucket": "public",
+            },
+            {
+                "regex": ".*.cmr.json$",
+                "sampleFileName": "L_10-420.cmr.json",
+                "bucket": "public",
+            },
+        ]
+        self.task_input_event["input"]["granules"] = [
+            {
+                "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                "files": [
+                    {
+                        "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                        "bucket": "cumulus-test-sandbox-protected-2",
+                    }
+                ],
+            }
+        ]
+        exp_err = (
+            "KeyError: \"event['input']['granules'][]['files']['key']\" is required"
+        )
         try:
             extract_filepaths_for_granule.task(self.task_input_event, self.context)
             self.fail("ExtractFilePathsError expected")
@@ -171,28 +207,73 @@ class TestExtractFilePaths(unittest.TestCase):
         """
         Test with one valid file in input.
         """
-        self.task_input_event['input']['granules'] = [{
-            "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
-            "files": [
-                {
-                    "key":
-                        "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
-                    "bucket": "cumulus-test-sandbox-protected-2",
-                    "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml"
-                }]}]
+        self.task_input_event["input"]["granules"] = [
+            {
+                "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                "files": [
+                    {
+                        "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                        "bucket": "cumulus-test-sandbox-protected-2",
+                        "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                    }
+                ],
+            }
+        ]
         exp_result = {
-            'granules': [
+            "granules": [
                 {
-                    'files': [
+                    "files": [
                         {
-                            'bucket': "cumulus-test-sandbox-protected-2",
-                            'fileName': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml',
-                            'key': 'MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml'
+                            "bucket": "cumulus-test-sandbox-protected-2",
+                            "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                            "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
                         }
                     ],
-                    'keys': [{'key': 'MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml',
-                              'dest_bucket': 'sndbx-cumulus-protected'}],
-                    'granuleId': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321'}]}
+                    "keys": [
+                        {
+                            "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                            "dest_bucket": "sndbx-cumulus-protected",
+                        }
+                    ],
+                    "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                }
+            ]
+        }
+        result = extract_filepaths_for_granule.task(self.task_input_event, self.context)
+        self.assertEqual(exp_result, result)
+
+    def test_exclude_file_type(self):
+        """
+        Tests the exclude file type filtering. The .cmr filetype will be excluded and not show up in the output since the "extract_filepaths_for_granule/test/unit_tests/testevents/task_event.json" includes
+        "excludeFileTypes": [".cmr"]
+        """
+        self.task_input_event["input"]["granules"] = [
+            {
+                "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                "files": [
+                    {
+                        "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr",
+                        "bucket": "cumulus-test-sandbox-protected-2",
+                        "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr",
+                    }
+                ],
+            }
+        ]
+        exp_result = {
+            "granules": [
+                {
+                    "files": [
+                        {
+                            "bucket": "cumulus-test-sandbox-protected-2",
+                            "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr",
+                            "key": "MOD09GQ___006/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr",
+                        }
+                    ],
+                    "keys": [],  # this will be empty since the filetpye is .cmr
+                    "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                }
+            ]
+        }
         result = extract_filepaths_for_granule.task(self.task_input_event, self.context)
         self.assertEqual(exp_result, result)
 
@@ -201,60 +282,82 @@ class TestExtractFilePaths(unittest.TestCase):
         Test with two granules, one key each.
         """
 
-        self.task_input_event['input']['granules'] = \
-            [{"granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
-              "files": [
-                  {
-                      "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
-                      "key": "MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
-                      "bucket": "cumulus-test-sandbox-protected-2"
-                  }
-              ]
-              },
-             {
-                 "granuleId": "MOD09GQ.A0219115.N5aUCG.006.0656338553321",
-                 "files": [
-                     {
-                         "fileName": "MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml",
-                         "key": "MOD/MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml",
-                         "bucket": "cumulus-test-sandbox-protected-2"
-                     }
-                 ]
-             }
-             ]
-        exp_result = {'granules': [
-            {'keys': [{'key': 'MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml',
-                       'dest_bucket': 'sndbx-cumulus-protected'}],
-             'files': [
-                 {
-                     'bucket': 'cumulus-test-sandbox-protected-2',
-                     'fileName': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml',
-                     'key': 'MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml'
-                 }
-             ],
-             'granuleId': 'MOD09GQ.A0219114.N5aUCG.006.0656338553321'},
-            {'keys': [{'key': 'MOD/MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml',
-                       'dest_bucket': 'sndbx-cumulus-protected'}],
-             'files': [
-                 {
-                     'bucket': 'cumulus-test-sandbox-protected-2',
-                     'fileName': 'MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml',
-                     'key': 'MOD/MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml'
-                 }
-             ],
-             'granuleId': 'MOD09GQ.A0219115.N5aUCG.006.0656338553321'}]}
+        self.task_input_event["input"]["granules"] = [
+            {
+                "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                "files": [
+                    {
+                        "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                        "key": "MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                        "bucket": "cumulus-test-sandbox-protected-2",
+                    }
+                ],
+            },
+            {
+                "granuleId": "MOD09GQ.A0219115.N5aUCG.006.0656338553321",
+                "files": [
+                    {
+                        "fileName": "MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml",
+                        "key": "MOD/MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml",
+                        "bucket": "cumulus-test-sandbox-protected-2",
+                    }
+                ],
+            },
+        ]
+        exp_result = {
+            "granules": [
+                {
+                    "keys": [
+                        {
+                            "key": "MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                            "dest_bucket": "sndbx-cumulus-protected",
+                        }
+                    ],
+                    "files": [
+                        {
+                            "bucket": "cumulus-test-sandbox-protected-2",
+                            "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                            "key": "MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.cmr.xml",
+                        }
+                    ],
+                    "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+                },
+                {
+                    "keys": [
+                        {
+                            "key": "MOD/MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml",
+                            "dest_bucket": "sndbx-cumulus-protected",
+                        }
+                    ],
+                    "files": [
+                        {
+                            "bucket": "cumulus-test-sandbox-protected-2",
+                            "fileName": "MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml",
+                            "key": "MOD/MOD09GQ.A0219115.N5aUCG.006.0656338553321.cmr.xml",
+                        }
+                    ],
+                    "granuleId": "MOD09GQ.A0219115.N5aUCG.006.0656338553321",
+                },
+            ]
+        }
 
         result = extract_filepaths_for_granule.task(self.task_input_event, self.context)
         self.assertEqual(exp_result, result)
-# -------------------------------------------------------------------------------------------------
+
+    # -------------------------------------------------------------------------------------------------
     def test_exclude_file_types(self):
         """
         Testing filtering of exclude file types.
         """
-        result_true = extract_filepaths_for_granule.should_exclude_files_type('s3://test-bucket/exclude.xml', ['.xml'])
-        result_false = extract_filepaths_for_granule.should_exclude_files_type('s3://test-bucket/will_not_exclude.cmr', ['.xml', ".met"])
+        result_true = extract_filepaths_for_granule.should_exclude_files_type(
+            "s3://test-bucket/exclude.xml", [".xml"]
+        )
+        result_false = extract_filepaths_for_granule.should_exclude_files_type(
+            "s3://test-bucket/will_not_exclude.cmr", [".xml", ".met"]
+        )
         self.assertEqual(result_true, True)
         self.assertEqual(result_false, False)
 
-if __name__ == '__main__':
-    unittest.main(argv=['start'])
+
+if __name__ == "__main__":
+    unittest.main(argv=["start"])

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
@@ -246,7 +246,15 @@ class TestExtractFilePaths(unittest.TestCase):
 
         result = extract_filepaths_for_granule.task(self.task_input_event, self.context)
         self.assertEqual(exp_result, result)
-
+# -------------------------------------------------------------------------------------------------
+    def test_exclude_file_types(self):
+        """
+        Testing filtering of exclude file types.
+        """
+        result_true = extract_filepaths_for_granule.should_exclude_files_type('s3://test-bucket/exclude.xml', ['.xml'])
+        result_false = extract_filepaths_for_granule.should_exclude_files_type('s3://test-bucket/will_not_exclude.cmr', ['.xml', ".met"])
+        self.assertEqual(result_true, True)
+        self.assertEqual(result_false, False)
 
 if __name__ == '__main__':
     unittest.main(argv=['start'])

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/testevents/task_event.json
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/testevents/task_event.json
@@ -48,19 +48,22 @@
       }
     ]
   },
-  "config": {"glacier-bucket": "sndbx-cumulus-glacier",
-    "protected-bucket": "sndbx-cumulus-protected",
-    "internal-bucket": "sndbx-cumulus-internal",
-    "private-bucket": "sndbx-cumulus-private",
-    "public-bucket": "sndbx-cumulus-public",
-    "file-buckets": [{"regex": ".*.h5$", "sampleFileName": "L0A_HR_RAW_product_0010-of-0420.h5", "bucket": "protected"},
-        {"regex": ".*.cmr.xml$", "sampleFileName": "L0A_HR_RAW_product_0010-of-0420.iso.xml", "bucket": "protected"},
-        {"regex": ".*.h5.mp$", "sampleFileName": "L0A_HR_RAW_product_0001-of-0019.h5.mp", "bucket": "public"},
-        {"regex": ".*.cmr.json$", "sampleFileName": "L0A_HR_RAW_product_0001-of-0019.cmr.json", "bucket": "public"
+    "config": 
+      {
+        "glacier-bucket": "sndbx-cumulus-glacier",
+        "protected-bucket": "sndbx-cumulus-protected",
+        "internal-bucket": "sndbx-cumulus-internal",
+        "private-bucket": "sndbx-cumulus-private",
+        "public-bucket": "sndbx-cumulus-public",
+        "file-buckets": 
+          [{"regex": ".*.h5$", "sampleFileName": "L0A_HR_RAW_product_0010-of-0420.h5", "bucket": "protected"},
+              {"regex": ".*.cmr.xml$", "sampleFileName": "L0A_HR_RAW_product_0010-of-0420.iso.xml", "bucket": "protected"},
+              {"regex": ".*.h5.mp$", "sampleFileName": "L0A_HR_RAW_product_0001-of-0019.h5.mp", "bucket": "public"},
+              {"regex": ".*.cmr.json$", "sampleFileName": "L0A_HR_RAW_product_0001-of-0019.cmr.json", "bucket": "public"
+            }
+          ],
+      "excludeFileTypes": [
+        ".cmr"
+      ]
     }
-],
-    "excludeFileTypes": [
-      ".xml"
-    ]
-}
 }

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/testevents/task_event.json
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/testevents/task_event.json
@@ -58,6 +58,7 @@
         {"regex": ".*.h5.mp$", "sampleFileName": "L0A_HR_RAW_product_0001-of-0019.h5.mp", "bucket": "public"},
         {"regex": ".*.cmr.json$", "sampleFileName": "L0A_HR_RAW_product_0001-of-0019.cmr.json", "bucket": "public"
     }
-]
+],
+      "exclude_file_types": "xml"
 }
 }

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/testevents/task_event.json
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/testevents/task_event.json
@@ -59,6 +59,8 @@
         {"regex": ".*.cmr.json$", "sampleFileName": "L0A_HR_RAW_product_0001-of-0019.cmr.json", "bucket": "public"
     }
 ],
-      "exclude_file_types": "xml"
+    "excludeFileTypes": [
+      ".xml"
+    ]
 }
 }

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -285,10 +285,13 @@ def inner_task(
                     "error_message": message,
                     "request_time": time_stamp,
                     "last_update": time_stamp,
-                    "completion_time": time_stamp
+                    "completion_time": time_stamp,
                 }
                 # Cannot use f"" because of '{}' handling bug in CumulusLogger
-                LOGGER.error("details of the file with failed state that is sent to the DB: {a_file}", a_file= a_file)
+                LOGGER.error(
+                    "details of the file with failed state that is sent to the DB: {a_file}",
+                    a_file=a_file,
+                )
                 files.append(a_file)
         # Create a copy of the granule and add file information in the proper
         # format
@@ -518,6 +521,7 @@ def object_exists(s3_cli: BaseClient, glacier_bucket: str, file_key: str) -> boo
             return False
         raise
         # todo: Online docs suggest we could catch 'S3.Client.exceptions.NoSuchKey instead of deconstructing ClientError
+
 
 def restore_object(
     s3_cli: BaseClient,

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -270,7 +270,7 @@ def inner_task(
                     f"Added {file_key} to the list of files we'll attempt to recover."
                 )
             else:
-                message = f"{file_key} does not exist in S3 bucket"
+                message = f"{file_key} does not exist in {glacier_bucket} bucket"
                 LOGGER.error(message)
                 a_file[FILE_SUCCESS_KEY] = True
                 a_file["status_id"] = shared_recovery.OrcaStatus.FAILED.value

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -438,182 +438,180 @@ class TestRequestFiles(unittest.TestCase):
         except request_files.RestoreRequestError:
             pass
 
-    # @patch("request_files.shared_recovery.create_status_for_job")
-    # @patch("time.sleep")
-    # @patch("request_files.process_granule")
-    # @patch("request_files.object_exists")
-    # @patch("boto3.client")
-    # def test_inner_task_missing_files_do_not_halt(
-    #         self,
-    #         mock_boto3_client: MagicMock,
-    #         mock_object_exists: MagicMock,
-    #         mock_process_granule: MagicMock,
-    #         mock_sleep: MagicMock,
-    #         mock_create_status_for_job: MagicMock,
-    # ):
-    #     """
-    #     A return of 'false' from object_exists should ignore the file and continue.
-    #     """
-    #     glacier_bucket = uuid.uuid4().__str__()
-    #     file_key_0 = uuid.uuid4().__str__()
-    #     file_key_1 = uuid.uuid4().__str__()
-    #     missing_file_key = uuid.uuid4().__str__()
-    #     file_dest_bucket_0 = uuid.uuid4().__str__()
-    #     file_dest_bucket_1 = uuid.uuid4().__str__()
-    #     missing_file_dest_bucket = uuid.uuid4().__str__()
-    #     job_id = uuid.uuid4().__str__()
-    #     granule_id = uuid.uuid4().__str__()
-    #     db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
-    #     file_0 = {
-    #         request_files.FILE_KEY_KEY: file_key_0,
-    #         request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_0,
-    #     }
-    #     expected_file0_output = {
-    #         request_files.FILE_SUCCESS_KEY: False,
-    #         "filename": file_key_0,
-    #         "key_path": file_key_0,
-    #         "restore_destination": file_dest_bucket_0,
-    #         "status_id": OrcaStatus.PENDING.value,
-    #         "request_time": mock.ANY,
-    #         "last_update": mock.ANY,
-    #     }
-    #     file_1 = {
-    #         request_files.FILE_KEY_KEY: file_key_1,
-    #         request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_1,
-    #     }
-    #     expected_file1_output = {
-    #         request_files.FILE_SUCCESS_KEY: False,
-    #         "filename": file_key_1,
-    #         "key_path": file_key_1,
-    #         "restore_destination": file_dest_bucket_1,
-    #         "status_id": OrcaStatus.PENDING.value,
-    #         "request_time": mock.ANY,
-    #         "last_update": mock.ANY,
-    #     }
+    @patch("request_files.shared_recovery.create_status_for_job")
+    @patch("time.sleep")
+    @patch("request_files.process_granule")
+    @patch("request_files.object_exists")
+    @patch("boto3.client")
+    def test_inner_task_missing_files_do_not_halt(
+            self,
+            mock_boto3_client: MagicMock,
+            mock_object_exists: MagicMock,
+            mock_process_granule: MagicMock,
+            mock_sleep: MagicMock,
+            mock_create_status_for_job: MagicMock,
+    ):
+        """
+        A return of 'false' from object_exists should ignore the file and continue.
+        """
+        glacier_bucket = uuid.uuid4().__str__()
+        file_key_0 = uuid.uuid4().__str__()
+        file_key_1 = uuid.uuid4().__str__()
+        missing_file_key = uuid.uuid4().__str__()
+        file_dest_bucket_0 = uuid.uuid4().__str__()
+        file_dest_bucket_1 = uuid.uuid4().__str__()
+        missing_file_dest_bucket = uuid.uuid4().__str__()
+        job_id = uuid.uuid4().__str__()
+        granule_id = uuid.uuid4().__str__()
+        db_queue_url = "http://" + uuid.uuid4().__str__() + ".blah"
+        file_0 = {
+            request_files.FILE_KEY_KEY: file_key_0,
+            request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_0,
+        }
+        expected_file0_output = {
+            request_files.FILE_SUCCESS_KEY: False,
+            "filename": file_key_0,
+            "key_path": file_key_0,
+            "restore_destination": file_dest_bucket_0,
+            "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+            "request_time": mock.ANY,
+            "last_update": mock.ANY,
+        }
+        file_1 = {
+            request_files.FILE_KEY_KEY: file_key_1,
+            request_files.FILE_DEST_BUCKET_KEY: file_dest_bucket_1,
+        }
+        expected_file1_output = {
+            request_files.FILE_SUCCESS_KEY: False,
+            "filename": file_key_1,
+            "key_path": file_key_1,
+            "restore_destination": file_dest_bucket_1,
+            "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+            "request_time": mock.ANY,
+            "last_update": mock.ANY,
+        }
 
-    #     missing_file ={
-    #         request_files.FILE_KEY_KEY: missing_file_key,
-    #         request_files.FILE_DEST_BUCKET_KEY: missing_file_dest_bucket,
-    #     }
+        missing_file ={
+            request_files.FILE_KEY_KEY: missing_file_key,
+            request_files.FILE_DEST_BUCKET_KEY: missing_file_dest_bucket,
+        }
 
-    #     expected_missing_file_output = {
-    #         request_files.FILE_SUCCESS_KEY: False,
-    #         "filename": missing_file_key,
-    #         "key_path": missing_file_key,
-    #         "restore_destination": missing_file_dest_bucket,
-    #         "status_id": OrcaStatus.FAILED.value,
-    #         "error_message": f"{missing_file_key} does not exist in S3 bucket",
-    #         "request_time": mock.ANY,
-    #         "last_update": mock.ANY,
-    #         "completion_time": mock.ANY
-    #     }
-    #     expected_input_granule_files = [expected_file0_output, expected_file1_output, expected_missing_file_output]
-    #     granule = {
-    #         request_files.GRANULE_GRANULE_ID_KEY: granule_id,
-    #         request_files.GRANULE_KEYS_KEY: [
-    #             file_0,
-    #             {
-    #                 request_files.FILE_KEY_KEY: missing_file_key,
-    #                 request_files.FILE_DEST_BUCKET_KEY: missing_file_dest_bucket,
-    #             },
-    #             file_1,
-    #         ],
-    #     }
-    #     expected_input_granule = granule.copy()
-    #     expected_input_granule[
-    #         request_files.GRANULE_RECOVER_FILES_KEY
-    #     ] = expected_input_granule_files
-    #     event = {
-    #         request_files.EVENT_CONFIG_KEY: {
-    #             request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-    #             request_files.CONFIG_JOB_ID_KEY: job_id
-    #         },
-    #         request_files.EVENT_INPUT_KEY: {
-    #             request_files.INPUT_GRANULES_KEY: [granule]
-    #         },
-    #     }
-    #     max_retries = randint(0, 99)  # nosec
-    #     retry_sleep_secs = randint(0, 99)  # nosec
-    #     retrieval_type = uuid.uuid4().__str__()
-    #     restore_expire_days = randint(0, 99)  # nosec
-    #     mock_s3_cli = mock_boto3_client("s3")
+        expected_missing_file_output = {
+            request_files.FILE_SUCCESS_KEY: False,
+            "filename": missing_file_key,
+            "key_path": missing_file_key,
+            "restore_destination": missing_file_dest_bucket,
+            "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+            "request_time": mock.ANY,
+            "last_update": mock.ANY,
+        }
+        expected_input_granule_files = [expected_file0_output, expected_file1_output, expected_missing_file_output]
+        granule = {
+            request_files.GRANULE_GRANULE_ID_KEY: granule_id,
+            request_files.GRANULE_KEYS_KEY: [
+                file_0,
+                file_1,
+                                {
+                request_files.FILE_KEY_KEY: missing_file_key,
+                request_files.FILE_DEST_BUCKET_KEY: missing_file_dest_bucket,
+                },
+            ],
+        }
+        expected_input_granule = granule.copy()
+        expected_input_granule[
+            request_files.GRANULE_RECOVER_FILES_KEY
+        ] = expected_input_granule_files
+        event = {
+            request_files.EVENT_CONFIG_KEY: {
+                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
+                request_files.CONFIG_JOB_ID_KEY: job_id
+            },
+            request_files.EVENT_INPUT_KEY: {
+                request_files.INPUT_GRANULES_KEY: [granule]
+            },
+        }
+        max_retries = randint(0, 99)  # nosec
+        retry_sleep_secs = randint(0, 99)  # nosec
+        retrieval_type = uuid.uuid4().__str__()
+        restore_expire_days = randint(0, 99)  # nosec
+        mock_s3_cli = mock_boto3_client("s3")
 
-    #     # noinspection PyUnusedLocal
-    #     def object_exists_return_func(
-    #             input_s3_cli, input_glacier_bucket, input_file_key
-    #     ):
-    #         return input_file_key in [file_key_0, file_key_1, missing_file_key]
+        # noinspection PyUnusedLocal
+        def object_exists_return_func(
+                input_s3_cli, input_glacier_bucket, input_file_key
+        ):
+            return input_file_key in [file_key_0, file_key_1, missing_file_key]
 
-    #     mock_object_exists.side_effect = object_exists_return_func
+        mock_object_exists.side_effect = object_exists_return_func
 
-    #     result = request_files.inner_task(
-    #         event,
-    #         max_retries,
-    #         retry_sleep_secs,
-    #         retrieval_type,
-    #         restore_expire_days,
-    #         db_queue_url,
-    #     )
+        result = request_files.inner_task(
+            event,
+            max_retries,
+            retry_sleep_secs,
+            retrieval_type,
+            restore_expire_days,
+            db_queue_url,
+        )
 
-    #     files_all = [
-    #         {
-    #             "success": False,
-    #             "filename": file_key_0,
-    #             "key_path": file_key_0,
-    #             "restore_destination": file_dest_bucket_0,
-    #             "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
-    #             "request_time": mock.ANY,
-    #             "last_update": mock.ANY,
-    #         },
-    #         {
-    #             "success": False,
-    #             "filename": file_key_1,
-    #             "key_path": file_key_1,
-    #             "restore_destination": file_dest_bucket_1,
-    #             "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
-    #             "request_time": mock.ANY,
-    #             "last_update": mock.ANY,
-    #         },
-    #         {
-    #             "success": False,
-    #             "filename": missing_file_key,
-    #             "key_path": missing_file_key,
-    #             "restore_destination": missing_file_dest_bucket,
-    #             "status_id": request_files.shared_recovery.OrcaStatus.FAILED.value,
-    #             "error_message": f"{missing_file_key} does not exist in S3 bucket",
-    #             "request_time": mock.ANY,
-    #             "last_update": mock.ANY,
-    #             "completion_time": mock.ANY
-    #     }
-    #     ]
-    #     mock_create_status_for_job.assert_called_once_with(
-    #         job_id, granule_id, glacier_bucket, files_all, db_queue_url
-    #     )
-    #     mock_process_granule.assert_has_calls(
-    #         [
-    #             call(
-    #                 mock_s3_cli,
-    #                 expected_input_granule,
-    #                 glacier_bucket,
-    #                 restore_expire_days,
-    #                 max_retries,
-    #                 retry_sleep_secs,
-    #                 retrieval_type,
-    #                 job_id,
-    #                 db_queue_url,
-    #             )
-    #         ]
-    #     )
-    #     self.assertEqual(
-    #         1, mock_process_granule.call_count
-    #     )  # I'm hoping that we can remove the 'one granule' limit.
-    #     self.assertEqual(
-    #         {
-    #             "granules": [expected_input_granule],
-    #             "asyncOperationId": job_id,
-    #         },
-    #         result,
-    #     )
+        files_all = [
+            {
+                "success": False,
+                "filename": file_key_0,
+                "key_path": file_key_0,
+                "restore_destination": file_dest_bucket_0,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+            },
+            {
+                "success": False,
+                "filename": file_key_1,
+                "key_path": file_key_1,
+                "restore_destination": file_dest_bucket_1,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+            },
+            {
+                "success": False,
+                "filename": missing_file_key,
+                "key_path": missing_file_key,
+                "restore_destination": missing_file_dest_bucket,
+                "status_id": request_files.shared_recovery.OrcaStatus.PENDING.value,
+                # "error_message": f"{missing_file_key} does not exist in S3 bucket",
+                "request_time": mock.ANY,
+                "last_update": mock.ANY,
+                # "completion_time": mock.ANY
+        }
+        ]
+        mock_create_status_for_job.assert_called_once_with(
+            job_id, granule_id, glacier_bucket, files_all, db_queue_url
+        )
+        mock_process_granule.assert_has_calls(
+            [
+                call(
+                    mock_s3_cli,
+                    expected_input_granule,
+                    glacier_bucket,
+                    restore_expire_days,
+                    max_retries,
+                    retry_sleep_secs,
+                    retrieval_type,
+                    job_id,
+                    db_queue_url,
+                )
+            ]
+        )
+        self.assertEqual(
+            1, mock_process_granule.call_count
+        )  # I'm hoping that we can remove the 'one granule' limit.
+        self.assertEqual(
+            {
+                "granules": [expected_input_granule],
+                "asyncOperationId": job_id,
+            },
+            result,
+        )
 
     @patch("time.sleep")
     @patch("request_files.restore_object")

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -503,7 +503,7 @@ class TestRequestFiles(unittest.TestCase):
             "status_id": OrcaStatus.FAILED.value,
             "request_time": mock.ANY,
             "last_update": mock.ANY,
-            "error_message": f"{missing_file_key} does not exist in S3 bucket",
+            "error_message": f"{missing_file_key} does not exist in {glacier_bucket} bucket",
             "completion_time": mock.ANY
         }
 
@@ -570,7 +570,7 @@ class TestRequestFiles(unittest.TestCase):
                 "status_id": OrcaStatus.FAILED.value,
                 "request_time": mock.ANY,
                 "last_update": mock.ANY,
-                "error_message": f"{missing_file_key} does not exist in S3 bucket",
+                "error_message": f"{missing_file_key} does not exist in {glacier_bucket} bucket",
                 "completion_time": mock.ANY
             },
             {
@@ -1294,7 +1294,7 @@ class TestRequestFiles(unittest.TestCase):
                             "key_path": file1,
                             "restore_destination": dest_bucket,
                             "status_id": OrcaStatus.FAILED.value,
-                            "error_message": f"{file1} does not exist in S3 bucket",
+                            "error_message": f"{file1} does not exist in my-bucket bucket",
                             "request_time": mock.ANY,
                             "last_update": mock.ANY,
                             "completion_time": mock.ANY,

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -70,7 +70,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                request_files.CONFIG_JOB_ID_KEY: job_id
+                request_files.CONFIG_JOB_ID_KEY: job_id,
             },
         }
         max_retries = randint(0, 99)  # nosec
@@ -97,7 +97,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id
+                    request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
             max_retries,
@@ -117,7 +117,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                request_files.CONFIG_JOB_ID_KEY: job_id
+                request_files.CONFIG_JOB_ID_KEY: job_id,
             },
         }
         retry_sleep_secs = uniform(0, 99)  # nosec
@@ -140,7 +140,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id
+                    request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
             request_files.DEFAULT_MAX_REQUEST_RETRIES,
@@ -160,7 +160,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                request_files.CONFIG_JOB_ID_KEY: job_id
+                request_files.CONFIG_JOB_ID_KEY: job_id,
             },
         }
         max_retries = randint(0, 99)  # nosec
@@ -183,7 +183,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id
+                    request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
             max_retries,
@@ -203,7 +203,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                request_files.CONFIG_JOB_ID_KEY: job_id
+                request_files.CONFIG_JOB_ID_KEY: job_id,
             },
         }
         max_retries = randint(0, 99)  # nosec
@@ -228,7 +228,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id
+                    request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
             max_retries,
@@ -248,7 +248,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                request_files.CONFIG_JOB_ID_KEY: job_id
+                request_files.CONFIG_JOB_ID_KEY: job_id,
             },
         }
         max_retries = randint(0, 99)  # nosec
@@ -275,7 +275,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id
+                    request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
             max_retries,
@@ -295,7 +295,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                request_files.CONFIG_JOB_ID_KEY: job_id
+                request_files.CONFIG_JOB_ID_KEY: job_id,
             },
         }
         max_retries = randint(0, 99)  # nosec
@@ -318,7 +318,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id
+                    request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
             max_retries,
@@ -337,7 +337,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_event = {
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                request_files.CONFIG_JOB_ID_KEY: None
+                request_files.CONFIG_JOB_ID_KEY: None,
             },
         }
         max_retries = randint(0, 99)  # nosec
@@ -366,7 +366,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id.__str__()
+                    request_files.CONFIG_JOB_ID_KEY: job_id.__str__(),
                 },
             },
             max_retries,
@@ -414,7 +414,7 @@ class TestRequestFiles(unittest.TestCase):
             {
                 request_files.EVENT_CONFIG_KEY: {
                     request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
-                    request_files.CONFIG_JOB_ID_KEY: job_id.__str__()
+                    request_files.CONFIG_JOB_ID_KEY: job_id.__str__(),
                 },
             },
             max_retries,
@@ -491,7 +491,6 @@ class TestRequestFiles(unittest.TestCase):
     #         "last_update": mock.ANY,
     #     }
 
-
     #     missing_file ={
     #         request_files.FILE_KEY_KEY: missing_file_key,
     #         request_files.FILE_DEST_BUCKET_KEY: missing_file_dest_bucket,
@@ -507,7 +506,7 @@ class TestRequestFiles(unittest.TestCase):
     #         "request_time": mock.ANY,
     #         "last_update": mock.ANY,
     #         "completion_time": mock.ANY
-    #     }    
+    #     }
     #     expected_input_granule_files = [expected_file0_output, expected_file1_output, expected_missing_file_output]
     #     granule = {
     #         request_files.GRANULE_GRANULE_ID_KEY: granule_id,
@@ -585,7 +584,7 @@ class TestRequestFiles(unittest.TestCase):
     #             "request_time": mock.ANY,
     #             "last_update": mock.ANY,
     #             "completion_time": mock.ANY
-    #     }  
+    #     }
     #     ]
     #     mock_create_status_for_job.assert_called_once_with(
     #         job_id, granule_id, glacier_bucket, files_all, db_queue_url
@@ -619,7 +618,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("time.sleep")
     @patch("request_files.restore_object")
     def test_process_granule_minimal_path(
-            self, mock_restore_object: MagicMock, mock_sleep: MagicMock
+        self, mock_restore_object: MagicMock, mock_sleep: MagicMock
     ):
         mock_s3 = Mock()
         max_retries = randint(10, 999)  # nosec
@@ -706,7 +705,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("time.sleep")
     @patch("request_files.restore_object")
     def test_process_granule_one_client_error_retries(
-            self, mock_restore_object: MagicMock, mock_sleep: MagicMock
+        self, mock_restore_object: MagicMock, mock_sleep: MagicMock
     ):
         mock_s3 = Mock()
         max_retries = 5
@@ -793,10 +792,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("request_files.restore_object")
     @patch("cumulus_logger.CumulusLogger.error")
     def test_process_granule_client_errors_retries_until_cap(
-            self,
-            mock_logger_error: MagicMock,
-            mock_restore_object: MagicMock,
-            mock_sleep: MagicMock,
+        self,
+        mock_logger_error: MagicMock,
+        mock_restore_object: MagicMock,
+        mock_sleep: MagicMock,
     ):
         mock_s3 = Mock()
         max_retries = randint(3, 20)  # nosec
@@ -980,7 +979,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_restore_object_client_error_last_attempt_logs_and_raises(
-            self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
+        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
     ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
@@ -1016,7 +1015,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_restore_object_log_to_db_fails_does_not_halt(
-            self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
+        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
     ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
@@ -1082,10 +1081,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_one_granule_4_files_success(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test four files for one granule - successful
@@ -1093,11 +1092,11 @@ class TestRequestFiles(unittest.TestCase):
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         files = [KEY1, KEY2, KEY3, KEY4]
         input_event = {
-            "input": {
-                "granules": [{"granuleId": granule_id, "keys": files}]
+            "input": {"granules": [{"granuleId": granule_id, "keys": files}]},
+            "config": {
+                "glacier-bucket": "my-dr-fake-glacier-bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
             },
-            "config": {"glacier-bucket": "my-dr-fake-glacier-bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()}
         }
 
         mock_s3_cli = mock_boto3_client("s3")
@@ -1216,11 +1215,11 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_one_granule_1_file_db_error(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test one file for one granule - db error inserting status
@@ -1228,8 +1227,10 @@ class TestRequestFiles(unittest.TestCase):
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         input_event = {
             "input": {"granules": [{"granuleId": granule_id, "keys": [KEY1]}]},
-            "config": {"glacier-bucket": "my-dr-fake-glacier-bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()}
+            "config": {
+                "glacier-bucket": "my-dr-fake-glacier-bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
+            },
         }
 
         mock_s3_cli = mock_boto3_client("s3")
@@ -1246,10 +1247,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_file_not_in_glacier(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test a file that is not in glacier.
@@ -1267,8 +1268,10 @@ class TestRequestFiles(unittest.TestCase):
                     }
                 ]
             },
-            "config": {"glacier-bucket": "my-bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()},
+            "config": {
+                "glacier-bucket": "my-bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
+            },
         }
         mock_s3_cli = mock_boto3_client("s3")
         # todo: Verify the below with a real-world db. If not the same, fix request_files.object_exists
@@ -1296,7 +1299,7 @@ class TestRequestFiles(unittest.TestCase):
                             "error_message": f"{file1} does not exist in S3 bucket",
                             "request_time": mock.ANY,
                             "last_update": mock.ANY,
-                            "completion_time": mock.ANY
+                            "completion_time": mock.ANY,
                         }
                     ],
                 }
@@ -1310,7 +1313,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("request_files.shared_recovery.post_entry_to_queue")
     @patch("boto3.client")
     def test_task_no_retries_env_var(
-            self, mock_boto3_client: MagicMock, mock_post_entry_to_queue: MagicMock
+        self, mock_boto3_client: MagicMock, mock_post_entry_to_queue: MagicMock
     ):
         """
         Test environment var RESTORE_REQUEST_RETRIES not set - use default.
@@ -1319,11 +1322,11 @@ class TestRequestFiles(unittest.TestCase):
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         # todo: Reduce string copy/paste for test values here and elsewhere.
         event = {
-            "input": {
-                "granules": [{"granuleId": granule_id, "keys": [KEY1]}]
+            "input": {"granules": [{"granuleId": granule_id, "keys": [KEY1]}]},
+            "config": {
+                "glacier-bucket": "some_bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
             },
-            "config": {"glacier-bucket": "some_bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()},
         }
 
         mock_s3_cli = mock_boto3_client("s3")
@@ -1375,10 +1378,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_no_expire_days_env_var(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test environment var RESTORE_EXPIRE_DAYS not set - use default.
@@ -1387,11 +1390,11 @@ class TestRequestFiles(unittest.TestCase):
         os.environ["RESTORE_RETRIEVAL_TYPE"] = "Expedited"
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         event = {
-            "config": {"glacier-bucket": "some_bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()},
-            "input": {
-                "granules": [{"granuleId": granule_id, "keys": [KEY1]}]
+            "config": {
+                "glacier-bucket": "some_bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
             },
+            "input": {"granules": [{"granuleId": granule_id, "keys": [KEY1]}]},
         }
 
         mock_s3_cli = mock_boto3_client("s3")
@@ -1442,18 +1445,20 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_client_error_one_file(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test retries for restore error for one file.
         """
         event = {
-            "config": {"glacier-bucket": "some_bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()},
+            "config": {
+                "glacier-bucket": "some_bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
+            },
             "input": {
                 "granules": [
                     {
@@ -1461,7 +1466,7 @@ class TestRequestFiles(unittest.TestCase):
                         "keys": [KEY1],
                     }
                 ]
-            }
+            },
         }
 
         os.environ[
@@ -1511,11 +1516,11 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_client_error_3_times(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test three files, two successful, one errors on all retries and fails.
@@ -1523,8 +1528,10 @@ class TestRequestFiles(unittest.TestCase):
         keys = [KEY1, KEY3, KEY4]
 
         event = {
-            "config": {"glacier-bucket": "some_bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()}
+            "config": {
+                "glacier-bucket": "some_bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
+            }
         }
         gran = {"granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321", "keys": keys}
 
@@ -1578,7 +1585,7 @@ class TestRequestFiles(unittest.TestCase):
                 "dest_bucket": PUBLIC_BUCKET,
                 "success": False,
                 "err_msg": "An error occurred (NoSuchKey) when calling the restore_object "
-                           "operation: Unknown",
+                "operation: Unknown",
             },
             {
                 "key": FILE4,
@@ -1605,25 +1612,27 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_client_error_2_times(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test two files, first successful, second has two errors, then success.
         """
-        event = {"config": {"glacier-bucket": "some_bucket",
-                            "asyncOperationId": uuid.uuid4().__str__()}}
+        event = {
+            "config": {
+                "glacier-bucket": "some_bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
+            }
+        }
         gran = {}
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         gran["granuleId"] = granule_id
         keys = [KEY1, KEY2]
         gran["keys"] = keys
-        event["input"] = {
-            "granules": [gran]
-        }
+        event["input"] = {"granules": [gran]}
         mock_s3_cli = mock_boto3_client("sqs")
 
         mock_s3_cli.restore_object.side_effect = [
@@ -1686,10 +1695,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_output_json_schema(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test four files for one granule - successful. Check against output schema.
@@ -1697,11 +1706,11 @@ class TestRequestFiles(unittest.TestCase):
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         files = [KEY1, KEY2, KEY3, KEY4]
         input_event = {
-            "input": {
-                "granules": [{"granuleId": granule_id, "keys": files}]
+            "input": {"granules": [{"granuleId": granule_id, "keys": files}]},
+            "config": {
+                "glacier-bucket": "my-dr-fake-glacier-bucket",
+                "asyncOperationId": uuid.uuid4().__str__(),
             },
-            "config": {"glacier-bucket": "my-dr-fake-glacier-bucket",
-                       "asyncOperationId": uuid.uuid4().__str__()},
         }
 
         mock_s3_cli = mock_boto3_client("s3")

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -1255,7 +1255,8 @@ class TestRequestFiles(unittest.TestCase):
         """
         dest_bucket = uuid.uuid4().__str__()
         file1 = "MOD09GQ___006/2017/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.xyz"
-        granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321.xyz"
+        granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
+        filename = "MOD09GQ.A0219114.N5aUCG.006.0656338553321.xyz"
         event = {
             "input": {
                 "granules": [
@@ -1289,7 +1290,7 @@ class TestRequestFiles(unittest.TestCase):
                     "recover_files": [
                         {
                             "success": True,
-                            "filename": granule_id,
+                            "filename": filename,
                             "key_path": file1,
                             "restore_destination": dest_bucket,
                             "status_id": OrcaStatus.FAILED.value,


### PR DESCRIPTION
## Summary of Changes


Addresses [ORCA-207: Update extract_filepaths_for_granule lambda function to provide more info to end users when a file does not exist.](https://bugs.earthdata.nasa.gov/browse/ORCA-207)

## Changes

* updated tasks/request_files/request_files.py and tasks/request_files/test/unit_tests/test_request_files.py to add more logging and a status of "failure" for the file in the ORCA recovery db in case the file is a "excludefiletype"
* updated tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests done using coverage and pytest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Possible fixes
Please provide some suggestions on how to add that regex filtering for "exludeFileTypes" in extract_filepaths_for_granule lambda function
