### PR TITLE
Feature/orca 236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and includes an additional section for migration notes.
 
 ## [Unreleased]
 
+### Changed
+- *ORCA-236* 'aws-profile' is no longer required in terraform.tfvars. Will default to `default`.
 
 ## [v3.0.0] 2021-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and includes an additional section for migration notes.
 ## [Unreleased]
 
 ### Changed
-- *ORCA-236* 'aws-profile' is no longer required in terraform.tfvars. Will default to `default`.
+- *ORCA-236* 'aws_profile' is no longer required in terraform.tfvars. Will default to `default`.
 
 ## [v3.0.0] 2021-07-12
 

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 ## AWS Provider Settings
 provider "aws" {
-  profile = var.aws_profile
+  profile = local.modified_aws_profile
   region  = var.region
 }
 
@@ -19,6 +19,7 @@ provider "aws" {
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })
+  modified_aws_profile = "${var.aws_profile == null ? "default" : var.aws_profile}"
 }
 
 
@@ -32,7 +33,7 @@ module "orca_lambdas" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile                       = var.aws_profile
+  aws_profile                       = local.modified_aws_profile
   buckets                           = var.buckets
   lambda_subnet_ids                 = var.lambda_subnet_ids
   permissions_boundary_arn          = var.permissions_boundary_arn
@@ -80,7 +81,7 @@ module "orca_workflows" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile     = var.aws_profile
+  aws_profile     = local.modified_aws_profile
   prefix          = var.prefix
   system_bucket   = var.system_bucket
   workflow_config = var.workflow_config
@@ -109,7 +110,7 @@ module "orca_rds" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile       = var.aws_profile
+  aws_profile       = local.modified_aws_profile
   lambda_subnet_ids = var.lambda_subnet_ids
   prefix            = var.prefix
 
@@ -143,7 +144,7 @@ module "orca_sqs" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile = var.aws_profile
+  aws_profile = local.modified_aws_profile
   prefix      = var.prefix
 
   ## OPTIONAL

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -4,6 +4,7 @@
 variable "aws_profile" {
   type        = string
   description = "AWS profile used to deploy the terraform application."
+  default = null
 }
 
 

--- a/website/docs/developer/deployment-guide/deploying-from-windows.mdx
+++ b/website/docs/developer/deployment-guide/deploying-from-windows.mdx
@@ -119,7 +119,6 @@ terraform apply
 ```
 
 - In cumulus-tf/terraform.tfvars
-    - Add the line `aws_profile = "default"`
     - Replace 12345 in permissions_boundary_arn with the Account Id.
     - Add to the buckets:
       ```

--- a/website/docs/developer/deployment-guide/deploying-from-windows.mdx
+++ b/website/docs/developer/deployment-guide/deploying-from-windows.mdx
@@ -93,7 +93,7 @@ This application will be used in future steps to authenticate users.
   Make sure that no extension is added.
   :::
 - Open a commandline in the same folder.
-    - Run `docker build -t orca .` and `docker run -it --rm -v pathToYourFolder:/CIRRUS-core orca /bin/bash`
+    - Run `docker volume create aws-creds` to create a persistent volume for your AWS configuration. Then run `docker build -t orca .` and `docker run -it --rm -v aws-creds:/root/.aws -v pathToYourFolder:/CIRRUS-core orca /bin/bash`
     - The commandline should now be inside a docker container.
       ```bash
       cd cumulus-orca-template-deploy/rds-cluster-tf/

--- a/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
+++ b/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
@@ -88,8 +88,8 @@ if necessary.
 
 From the directory of your `cumulus` deployment module (e.g., `cumulus-tf`):
 
-`$ AWS_REGION=<region> \ # e.g. us-west-2`
-    `AWS_PROFILE=<profile> \`
+`$ AWS_REGION=<region> \ # default "us-west-2"`
+    `AWS_PROFILE=<profile> \ # default "default"`
     `terraform apply`
 
 Once you have successfully updated all of your resources, verify that your

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -115,7 +115,6 @@ required by the ORCA module. More information about setting these variables can
 be found in the [Cumulus variable definitions](https://github.com/nasa/cumulus/blob/master/tf-modules/cumulus/variables.tf).
 The variables must be set with the proper values in the `terraform.tfvavrs` file.
 
-- aws_profile
 - buckets
 - lambda_subnet_ids
 - permissions_boundary_arn
@@ -127,6 +126,8 @@ The variables must be set with the proper values in the `terraform.tfvavrs` file
 
 Though optional, it is recommended that you also set the `region` variable. The
 default value for `region` is set to `us-west-2` in the ORCA module.
+
+Similarly, you can overwrite the `default` aws-profile with the `aws_profile` variable.
 
 The `tags` value automatically adds a *Deployment* tag like the Cumulus
 deployment.
@@ -409,7 +410,6 @@ file. The variables must be set with proper values for your environment in the
 
 | Variable                   | Definition                                                                                                                                   | Example Value      |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `aws_profile`              | AWS CLI Profile (configured via `aws configure`) to use for deployment.                                                                      | "default" |
 | `buckets`                  | Mapping of all S3 buckets used by Cumulus and ORCA that contains a S3 `name` and `type`. A bucket with a `type` of **orca** is required.     | `buckets = { orca_default = { name = "PREFIX-orca-primary", type = "orca", ...}}` |
 | `lambda_subnet_ids`        | A list of subnets that the Lambda's and the database have access to for working with Cumulus.                                                | ["subnet-12345", "subnet-abc123"] |
 | `permissions_boundary_arn` | AWS ARN value of the permission boundary for the VPC account.                                                                                | "arn:aws:iam::1234567890:policy/NGAPShRoleBoundary" |
@@ -473,6 +473,7 @@ variables is shown in the table below.
 | `sqs_maximum_message_size`                            | number        | The limit of how many bytes a message can contain before Amazon SQS rejects it.                         | 262144 |
 | `staged_recovery_queue_message_retention_time_seconds`| number        | Number of seconds the staged-recovery-queue fifo SQS retains a message.                                 | 432000 |
 | `status_update_queue_message_retention_time_seconds`  | number        | Number of seconds the status_update_queue fifo SQS retains a message.                                   | 777600 |
+| `aws_profile`                                         | string        | AWS CLI Profile (configured via `aws configure`) to use for deployment.                                 | "default" |
 
 
 ## ORCA Module Outputs


### PR DESCRIPTION
## Summary of Changes

Made `aws_profile` non-required. Will now accept `null`. 

Addresses [ORCA-236: As a developer, I would like to investigate changes needed if the aws_profile variable is not required to better support CI/CD functions.](https://bugs.earthdata.nasa.gov/browse/ORCA-236)

## Changes

* aws_profile will now default to 'default' if not given a value or given a `null` value.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests (unit, integration, ad-hoc, or otherwise) that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run against AWS. Resources stayed where expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Development documentation
    - [x] User documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests (outlined above)
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
