### PR TITLE
Removed profiles that were redundant with Cumulus code

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix }, { team = "ORCA", application = "ORCA" })
@@ -30,7 +23,6 @@ module "orca" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile              = var.aws_profile
   buckets                  = var.buckets
   lambda_subnet_ids        = var.lambda_subnet_ids
   permissions_boundary_arn = var.permissions_boundary_arn
@@ -40,8 +32,9 @@ module "orca" {
   workflow_config          = var.workflow_config
 
   ## OPTIONAL
-  region = var.region
-  tags   = local.tags
+  aws_profile = var.aws_profile
+  region      = var.region
+  tags        = local.tags
 
   ## --------------------------
   ## ORCA Variables

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 ## Local Variables
 locals {
   all_bucket_names  = length(var.orca_recovery_buckets) > 0 ? var.orca_recovery_buckets : [for k, v in var.buckets : v.name]

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -1,12 +1,6 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-}
-
-
 variable "buckets" {
   type        = map(object({ name = string, type = string }))
   description = "S3 bucket locations for the various storage types being used."
@@ -22,13 +16,6 @@ variable "permissions_boundary_arn" {
 variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
-}
-
-
-## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
-variable "region" {
-  type        = string
-  description = "AWS region to deploy configuration to."
 }
 
 

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 # Local Variables
 locals {
   tags         = merge(var.tags, { Deployment = var.prefix })
@@ -32,11 +25,9 @@ module "lambda_security_group" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile = var.aws_profile
   prefix      = var.prefix
   vpc_id      = var.vpc_id
   ## OPTIONAL
-  region = var.region
   tags   = local.tags
   ## --------------------------
   ## ORCA Variables
@@ -53,12 +44,10 @@ module "restore_object_arn" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile              = var.aws_profile
   buckets                  = var.buckets
   permissions_boundary_arn = var.permissions_boundary_arn
   prefix                   = var.prefix
   # OPTIONAL
-  region = var.region
   tags   = local.tags
   # --------------------------
   # ORCA Variables

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -1,12 +1,6 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-}
-
-
 variable "buckets" {
   type        = map(object({ name = string, type = string }))
   description = "S3 bucket locations for the various storage types being used."
@@ -34,13 +28,6 @@ variable "prefix" {
 variable "vpc_id" {
   type        = string
   description = "Virtual Private Cloud AWS ID"
-}
-
-
-## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
-variable "region" {
-  type        = string
-  description = "AWS region to deploy configuration to."
 }
 
 

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  profile = var.aws_profile
-  region  = var.region
-}
-
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })
@@ -32,7 +25,6 @@ module "orca_lambdas" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile                       = var.aws_profile
   buckets                           = var.buckets
   lambda_subnet_ids                 = var.lambda_subnet_ids
   permissions_boundary_arn          = var.permissions_boundary_arn
@@ -40,7 +32,6 @@ module "orca_lambdas" {
   vpc_id                            = var.vpc_id
   orca_sqs_staged_recovery_queue_id = module.orca_sqs.orca_sqs_staged_recovery_queue_id
   ## OPTIONAL
-  region = var.region
   tags   = local.tags
 
   ## --------------------------
@@ -80,13 +71,11 @@ module "orca_workflows" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile     = var.aws_profile
   prefix          = var.prefix
   system_bucket   = var.system_bucket
   workflow_config = var.workflow_config
 
   ## OPTIONAL
-  region = var.region
   tags   = local.tags
 
   ## --------------------------
@@ -143,11 +132,9 @@ module "orca_sqs" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile = var.aws_profile
   prefix      = var.prefix
 
   ## OPTIONAL
-  region = var.region
   tags   = local.tags
 
   ## --------------------------

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -1,12 +1,6 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-}
-
-
 variable "buckets" {
   type        = map(object({ name = string, type = string }))
   description = "S3 bucket locations for the various storage types being used."
@@ -56,6 +50,13 @@ variable "workflow_config" {
 
 
 ## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
+variable "aws_profile" {
+  type        = string
+  description = "AWS profile used to deploy the terraform application."
+  default = null
+}
+
+
 variable "region" {
   type        = string
   description = "AWS region to deploy configuration to."

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -53,7 +53,6 @@ variable "workflow_config" {
 variable "aws_profile" {
   type        = string
   description = "AWS profile used to deploy the terraform application."
-  default = null
 }
 
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -9,19 +9,12 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })
   # Ignore aws profile in case this was deployed with CI or in a machine without
   # aws profile defined
-  used_profile = contains([var.aws_profile], "default") ? "" : "--profile ${var.aws_profile}"
+  used_profile = contains(["${var.aws_profile == null ? "" : var.aws_profile}"], "default") ? "" : "--profile ${var.aws_profile}"
 }
 
 

--- a/modules/security_groups/main.tf
+++ b/modules/security_groups/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })

--- a/modules/security_groups/variables.tf
+++ b/modules/security_groups/variables.tf
@@ -1,12 +1,6 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-}
-
-
 variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
@@ -16,13 +10,6 @@ variable "prefix" {
 variable "vpc_id" {
   type        = string
   description = "Virtual Private Cloud AWS ID"
-}
-
-
-## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
-variable "region" {
-  type        = string
-  description = "AWS region to deploy configuration to."
 }
 
 

--- a/modules/sqs/main.tf
+++ b/modules/sqs/main.tf
@@ -8,13 +8,6 @@ terraform {
   }
 }
 
-
-## AWS Provider Settings
-provider "aws" {
-  profile = var.aws_profile
-  region  = var.region
-}
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })

--- a/modules/sqs/variables.tf
+++ b/modules/sqs/variables.tf
@@ -1,22 +1,12 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-}
-
 variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
 }
 
 ## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
-variable "region" {
-  type        = string
-  description = "AWS region to deploy configuration to."
-}
-
 variable "tags" {
   type        = map(string)
   description = "Tags to be applied to resources that support tags."

--- a/modules/workflows/OrcaCopyToGlacierWorkflow/main.tf
+++ b/modules/workflows/OrcaCopyToGlacierWorkflow/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })

--- a/modules/workflows/OrcaCopyToGlacierWorkflow/variables.tf
+++ b/modules/workflows/OrcaCopyToGlacierWorkflow/variables.tf
@@ -1,13 +1,6 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-  default     = null
-}
-
-
 variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
@@ -32,13 +25,6 @@ variable "workflow_config" {
 
 
 ## OPTIONAL
-variable "region" {
-  type        = string
-  description = "AWS region to deploy configuration to."
-  default     = "us-west-2"
-}
-
-
 variable "tags" {
   type        = map(string)
   description = "Tags to be applied to resources that support tags."

--- a/modules/workflows/OrcaRecoveryWorkflow/main.tf
+++ b/modules/workflows/OrcaRecoveryWorkflow/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })

--- a/modules/workflows/OrcaRecoveryWorkflow/variables.tf
+++ b/modules/workflows/OrcaRecoveryWorkflow/variables.tf
@@ -1,13 +1,6 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-  default     = null
-}
-
-
 variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
@@ -32,13 +25,6 @@ variable "workflow_config" {
 
 
 ## OPTIONAL
-variable "region" {
-  type        = string
-  description = "AWS region to deploy configuration to."
-  default     = "us-west-2"
-}
-
-
 variable "tags" {
   type        = map(string)
   description = "Tags to be applied to resources that support tags."

--- a/modules/workflows/main.tf
+++ b/modules/workflows/main.tf
@@ -9,13 +9,6 @@ terraform {
 }
 
 
-## AWS Provider Settings
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
-
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })
@@ -32,9 +25,7 @@ module "orca_recovery_workflow" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile     = var.aws_profile
   prefix          = var.prefix
-  region          = var.region
   system_bucket   = var.system_bucket
   tags            = local.tags
   workflow_config = var.workflow_config
@@ -58,9 +49,7 @@ module "orca_copy_to_glacier_workflow" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile     = var.aws_profile
   prefix          = var.prefix
-  region          = var.region
   system_bucket   = var.system_bucket
   tags            = local.tags
   workflow_config = var.workflow_config

--- a/modules/workflows/variables.tf
+++ b/modules/workflows/variables.tf
@@ -1,12 +1,6 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
-variable "aws_profile" {
-  type        = string
-  description = "AWS profile used to deploy the terraform application."
-}
-
-
 variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
@@ -31,12 +25,6 @@ variable "workflow_config" {
 
 
 ## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
-variable "region" {
-  type        = string
-  description = "AWS region to deploy configuration to."
-}
-
-
 variable "tags" {
   type        = map(string)
   description = "Tags to be applied to resources that support tags."

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,7 @@
 variable "aws_profile" {
   type        = string
   description = "AWS profile used to deploy the terraform application."
+  default = null
 }
 
 

--- a/website/docs/developer/deployment-guide/deploying-from-windows.mdx
+++ b/website/docs/developer/deployment-guide/deploying-from-windows.mdx
@@ -119,7 +119,6 @@ terraform apply
 ```
 
 - In cumulus-tf/terraform.tfvars
-    - Add the line `aws_profile = "default"`
     - Replace 12345 in permissions_boundary_arn with the Account Id.
     - Add to the buckets:
       ```

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -124,10 +124,11 @@ The variables must be set with the proper values in the `terraform.tfvavrs` file
 
 :::note Optional Cumulus Values
 
-aws_profile should be set if using an aws_profile other than `default` for Cumulus' deployment.
+Though optional, it is recommended that you also set the `aws_profile` variable. The
+default value for `aws_profile` is set to `default` for running the `db_deploy` lambda.
 
 Though optional, it is recommended that you also set the `region` variable. The
-default value for `region` is set to `us-west-2` in the ORCA module.
+default value for `region` is set to `us-west-2` for running the `db_deploy` lambda.
 
 The `tags` value automatically adds a *Deployment* tag like the Cumulus
 deployment.

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -58,7 +58,6 @@ module "orca" {
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  aws_profile              = var.aws_profile
   buckets                  = var.buckets
   lambda_subnet_ids        = var.lambda_subnet_ids
   permissions_boundary_arn = var.permissions_boundary_arn
@@ -68,8 +67,9 @@ module "orca" {
   workflow_config          = module.cumulus.workflow_config
 
   ## OPTIONAL
-  region = var.region
-  tags   = var.tags
+  aws_profile = var.aws_profile
+  region      = var.region
+  tags        = var.tags
 
   ## --------------------------
   ## ORCA Variables
@@ -115,7 +115,6 @@ required by the ORCA module. More information about setting these variables can
 be found in the [Cumulus variable definitions](https://github.com/nasa/cumulus/blob/master/tf-modules/cumulus/variables.tf).
 The variables must be set with the proper values in the `terraform.tfvavrs` file.
 
-- aws_profile
 - buckets
 - lambda_subnet_ids
 - permissions_boundary_arn
@@ -124,6 +123,8 @@ The variables must be set with the proper values in the `terraform.tfvavrs` file
 - vpc_id
 
 :::note Optional Cumulus Values
+
+aws_profile should be set if using an aws_profile other than `default` for Cumulus' deployment.
 
 Though optional, it is recommended that you also set the `region` variable. The
 default value for `region` is set to `us-west-2` in the ORCA module.


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-239: Remove provider block from all terraform modules and consolidate to main file.](https://bugs.earthdata.nasa.gov/browse/ORCA-239)

## Changes

* Removed redundant provider blocks.
* Made aws_profile optional.

## Type of change

## How Has This Been Tested?

Deployed to AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [ ] CHANGELOG.md
    - [ ] Testing documentation
    - [ ] Development documentation
    - [ ] User documentation
    - [ ] (Additional here)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests (outlined above)
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets