### PR TITLE
Incorperate shared_library pip install into copy_files_to_archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tasks/copy_files_to_archive/.vscode/.ropeproject/objectdb
 tasks/copy_files_to_archive/htmlcov/
 tasks/copy_to_glacier/htmlcov/
 tasks/package/
+shared_libraries/orca_shared.egg-info/
 private_config.json
 terraform\.tfvars
 \.terraform/

--- a/shared_libraries/README.md
+++ b/shared_libraries/README.md
@@ -13,7 +13,7 @@ available libraries and their purpose.
 - [**recovery**](API.md#orca_shared.recovery) - The recovery library contains several functions used by ORCA recovery workflows.
 
 
-The following sections going into more detail on utilizing these libraries.
+The following sections go into more detail on utilizing the libraries.
 
 - [Installing ORCA Shared Libraries](#installing-orca-shared-libraries) - Information on installing the libraries into your application
 - [Using ORCA Shared Libraries](#using-orca-shared-libraries) - Basic usage and documentation on the shared libraries.

--- a/shared_libraries/requirements.txt
+++ b/shared_libraries/requirements.txt
@@ -29,8 +29,8 @@ cumulus-message-adapter==1.3.0
 cumulus-message-adapter-python==1.2.1
 
 ## Libraries used by database package
-boto3~=1.12.49
+boto3~=1.12.47
 SQLAlchemy==1.4.11
 
 ## Libraries used by recovery package
-# boto3~=1.12.49
+# boto3~=1.12.47

--- a/shared_libraries/setup.py
+++ b/shared_libraries/setup.py
@@ -32,7 +32,7 @@ install_requirements = ["cumulus-message-adapter-python==1.2.1"]
 
 
 # Additional library dependencies
-_dep_boto3 = "boto3~=1.12.49"
+_dep_boto3 = "boto3~=1.12.47"
 _dep_sqlalchemy = "SQLAlchemy==1.4.11"
 
 

--- a/tasks/copy_files_to_archive/bin/build.sh
+++ b/tasks/copy_files_to_archive/bin/build.sh
@@ -101,24 +101,6 @@ cp ../package/awslambda-psycopg2/psycopg2-3.7/* build/psycopg2/
 let return_code=$?
 check_rc $return_code "ERROR: Unable to install psycopg2."
 
-## copy the shared_recovery.py
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
-
-mkdir -p build/orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-
-touch build/orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-
-cp ../shared_libraries/recovery/shared_recovery.py build/orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
-
 ## Copy the lambda files to build
 echo "INFO: Creating the Lambda package ..."
 cp *.py build/

--- a/tasks/copy_files_to_archive/bin/run_tests.sh
+++ b/tasks/copy_files_to_archive/bin/run_tests.sh
@@ -85,6 +85,5 @@ echo "INFO: Cleaning up the environment ..."
 deactivate
 rm -rf venv
 find . -type d -name "__pycache__" -exec rm -rf {} +
-# Remove the shared library
-rm -rf orca_shared
+
 exit 0

--- a/tasks/copy_files_to_archive/bin/run_tests.sh
+++ b/tasks/copy_files_to_archive/bin/run_tests.sh
@@ -45,23 +45,7 @@ function check_rc () {
       exit 1
   fi
 }
-## copy the shared_recovery.py
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
 
-mkdir orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-
-touch orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-
-cp ../shared_libraries/recovery/shared_recovery.py orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
 
 ## MAIN
 ## -----------------------------------------------------------------------------

--- a/tasks/copy_files_to_archive/copy_files_to_archive.py
+++ b/tasks/copy_files_to_archive/copy_files_to_archive.py
@@ -79,8 +79,7 @@ def task(
                     a_file[INPUT_SOURCE_BUCKET_KEY],
                     a_file[INPUT_SOURCE_KEY_KEY],
                     a_file[INPUT_TARGET_BUCKET_KEY],
-                    a_file.get(INPUT_MULTIPART_CHUNKSIZE_MB, None)
-                    or default_multipart_chunksize_mb,
+                    a_file.get(INPUT_MULTIPART_CHUNKSIZE_MB, None) or default_multipart_chunksize_mb,
                     a_file[INPUT_TARGET_KEY_KEY],
                 )
                 if err_msg is None:

--- a/tasks/copy_files_to_archive/copy_files_to_archive.py
+++ b/tasks/copy_files_to_archive/copy_files_to_archive.py
@@ -17,7 +17,7 @@ from botocore.client import BaseClient
 
 # noinspection PyPackageRequirements
 from botocore.exceptions import ClientError
-from orca_shared import shared_recovery
+from orca_shared.recovery import shared_recovery
 from cumulus_logger import CumulusLogger
 
 
@@ -47,11 +47,11 @@ class CopyRequestError(Exception):
 
 
 def task(
-        records: List[Dict[str, Any]],
-        max_retries: int,
-        retry_sleep_secs: float,
-        db_queue_url: str,
-        default_multipart_chunksize_mb: int
+    records: List[Dict[str, Any]],
+    max_retries: int,
+    retry_sleep_secs: float,
+    db_queue_url: str,
+    default_multipart_chunksize_mb: int,
 ) -> None:
     """
     Task called by the handler to perform the work.
@@ -79,7 +79,8 @@ def task(
                     a_file[INPUT_SOURCE_BUCKET_KEY],
                     a_file[INPUT_SOURCE_KEY_KEY],
                     a_file[INPUT_TARGET_BUCKET_KEY],
-                    a_file.get(INPUT_MULTIPART_CHUNKSIZE_MB, None) or default_multipart_chunksize_mb,
+                    a_file.get(INPUT_MULTIPART_CHUNKSIZE_MB, None)
+                    or default_multipart_chunksize_mb,
                     a_file[INPUT_TARGET_KEY_KEY],
                 )
                 if err_msg is None:
@@ -120,7 +121,7 @@ def task(
 
 
 def get_files_from_records(
-        records: List[Dict[str, Any]]
+    records: List[Dict[str, Any]]
 ) -> List[Dict[str, Union[str, bool]]]:
     """
     Parses the input records and returns the files to be restored.
@@ -144,12 +145,12 @@ def get_files_from_records(
 
 
 def copy_object(
-        s3_cli: BaseClient,
-        src_bucket_name: str,
-        src_object_name: str,
-        dest_bucket_name: str,
-        multipart_chunksize_mb: int,
-        dest_object_name: str = None,
+    s3_cli: BaseClient,
+    src_bucket_name: str,
+    src_object_name: str,
+    dest_bucket_name: str,
+    multipart_chunksize_mb: int,
+    dest_object_name: str = None,
 ) -> Optional[str]:
     """Copy an Amazon S3 bucket object
     Args:
@@ -173,7 +174,9 @@ def copy_object(
     # Copy the object
     try:
         s3_cli.copy(
-            copy_source, dest_bucket_name, dest_object_name,
+            copy_source,
+            dest_bucket_name,
+            dest_object_name,
             ExtraArgs={
                 # 'StorageClass': 'GLACIER',
                 # 'MetadataDirective': 'COPY',
@@ -181,7 +184,7 @@ def copy_object(
                 # 'ACL': 'bucket-owner-full-control'
                 # Sets the x-amz-acl URI Request Parameter. Needed for cross-OU copies.
             },
-            Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB)
+            Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB),
         )
     except ClientError as ex:
         LOGGER.error("Client error: {ex}", ex=ex)
@@ -191,7 +194,7 @@ def copy_object(
 
 # noinspection PyUnusedLocal
 def handler(
-        event: Dict[str, Any], context: object
+    event: Dict[str, Any], context: object
 ) -> None:  # pylint: disable-msg=unused-argument
     """Lambda handler. Copies a file from its temporary s3 bucket to the s3 archive.
     If the copy for a file in the request fails, the lambda
@@ -240,6 +243,8 @@ def handler(
     LOGGER.debug("event: {event}", event=event)
     records = event["Records"]
 
-    default_multipart_chunksize_mb = int(os.environ['DEFAULT_MULTIPART_CHUNKSIZE_MB'])
+    default_multipart_chunksize_mb = int(os.environ["DEFAULT_MULTIPART_CHUNKSIZE_MB"])
 
-    task(records, retries, retry_sleep_secs, db_queue_url, default_multipart_chunksize_mb)
+    task(
+        records, retries, retry_sleep_secs, db_queue_url, default_multipart_chunksize_mb
+    )

--- a/tasks/copy_files_to_archive/requirements-dev.txt
+++ b/tasks/copy_files_to_archive/requirements-dev.txt
@@ -2,4 +2,5 @@ boto3==1.12.47
 pytest==6.1.2
 coverage==5.3
 fastjsonschema==2.15.0
-cumulus-message-adapter-python>=1.1.1
+cumulus-message-adapter-python==1.2.1
+../../shared_libraries[recovery] --use-feature=in-tree-build

--- a/tasks/copy_files_to_archive/requirements.txt
+++ b/tasks/copy_files_to_archive/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.12.47
 fastjsonschema==2.15.0
-cumulus-message-adapter-python>=1.1.1
+cumulus-message-adapter-python==1.2.1
+../../shared_libraries[recovery] --use-feature=in-tree-build

--- a/tasks/db_deploy/bin/build.sh
+++ b/tasks/db_deploy/bin/build.sh
@@ -105,29 +105,12 @@ let return_code=$?
 check_rc $return_code "ERROR: Unable to install psycopg2."
 
 
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
-
-mkdir -p build/orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-
-touch build/orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-
-cp ../shared_libraries/database/shared_db.py build/orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_db.py]"
-
-
 ## Copy the lambda files to build
 echo "INFO: Copying the lambda files ..."
 cp *.py build/
 let return_code=$?
 check_rc $return_code "ERROR: Failed to copy lambda files to build directory."
+
 
 ## Copy the lambda files to build
 echo "INFO: Creating the Lambda package ..."

--- a/tasks/db_deploy/bin/run_tests.sh
+++ b/tasks/db_deploy/bin/run_tests.sh
@@ -67,24 +67,6 @@ let return_code=$?
 check_rc $return_code "ERROR: pip install encountered an error."
 
 
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
-
-mkdir orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-
-touch orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-
-cp ../shared_libraries/database/shared_db.py orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_db.py]"
-
-
 ## Get the modules we want to test
 file_list=""
 first_time="1"

--- a/tasks/db_deploy/create_db.py
+++ b/tasks/db_deploy/create_db.py
@@ -5,7 +5,11 @@ Description: Creates the current version on the ORCA database.
 """
 from typing import Dict
 from sqlalchemy.future import Connection
-from orca_shared.shared_db import get_configuration, get_admin_connection, logger
+from orca_shared.database.shared_db import (
+    get_configuration,
+    get_admin_connection,
+    logger,
+)
 from orca_sql import *
 
 

--- a/tasks/db_deploy/db_deploy.py
+++ b/tasks/db_deploy/db_deploy.py
@@ -4,7 +4,11 @@ Name: db_deploy.py
 Description: Performs database installation and migration for the ORCA schema.
 """
 # Imports
-from orca_shared.shared_db import logger, get_configuration, get_admin_connection
+from orca_shared.database.shared_db import (
+    logger,
+    get_configuration,
+    get_admin_connection,
+)
 from sqlalchemy import text
 from sqlalchemy.future import Connection
 from create_db import create_fresh_orca_install
@@ -63,8 +67,10 @@ def task(config: Dict[str, str]) -> None:
     with postgres_admin_engine.connect() as connection:
         # Check if database exists, if not throw an error
         if not app_db_exists(connection):
-            logger.critical("The ORCA database disaster_recovery does not exist, "
-                            "or the server could not be connected to.")
+            logger.critical(
+                "The ORCA database disaster_recovery does not exist, "
+                "or the server could not be connected to."
+            )
             raise Exception("Missing application database.")
 
     # Connect as admin user to disaster_recovery database.

--- a/tasks/db_deploy/migrate_db.py
+++ b/tasks/db_deploy/migrate_db.py
@@ -5,7 +5,7 @@ Description: Migrates the current ORCA schema version to the latest version.
 """
 from typing import Dict
 from orca_sql import *
-from orca_shared.shared_db import get_admin_connection, logger
+from orca_shared.database.shared_db import get_admin_connection, logger
 
 
 def perform_migration(current_schema_version: int, config: Dict[str, str]) -> None:

--- a/tasks/db_deploy/requirements-dev.txt
+++ b/tasks/db_deploy/requirements-dev.txt
@@ -1,11 +1,12 @@
 ## Standard unit test libraries
 pytest==6.1.2
 coverage==5.3
+
 ## Libraries needed for unit tests
-moto==2.0.6
 psycopg2-binary==2.8.6
-## Libraries needed by application
 boto3==1.12.49
-cumulus-message-adapter==1.3.0
-cumulus-message-adapter-python==1.2.1
+moto==2.0.6
+
+## Libraries needed by application
 SQLAlchemy==1.4.11
+../../shared_libraries[recovery] --use-feature=in-tree-build

--- a/tasks/db_deploy/requirements-dev.txt
+++ b/tasks/db_deploy/requirements-dev.txt
@@ -9,4 +9,4 @@ moto==2.0.6
 
 ## Libraries needed by application
 SQLAlchemy==1.4.11
-../../shared_libraries[recovery] --use-feature=in-tree-build
+../../shared_libraries[database] --use-feature=in-tree-build

--- a/tasks/db_deploy/requirements.txt
+++ b/tasks/db_deploy/requirements.txt
@@ -1,4 +1,2 @@
-boto3==1.12.49
-cumulus-message-adapter==1.3.0
-cumulus-message-adapter-python==1.2.1
 SQLAlchemy==1.4.11
+../../shared_libraries[database] --use-feature=in-tree-build

--- a/tasks/db_deploy/test/unit_tests/test_db_deploy.py
+++ b/tasks/db_deploy/test/unit_tests/test_db_deploy.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, call, patch, MagicMock
 from moto import mock_secretsmanager
 import boto3
 import db_deploy
-from orca_shared import shared_db
+from orca_shared.database import shared_db
 from sqlalchemy import text
 
 


### PR DESCRIPTION
## Summary of Changes

This is to support ORCA-205 work. This makes some minor updates to the shared libraries and adds changes needed for the copy_files_to_archive Lambda that are needed to use the shared libraries by installing them via pip.

## Changes

* Updated .gitignore so that build artifacts are ignored when installing the shared libraries
* Updated the following files in shared libraries to fix issues with version mismatches
    * README.md
    * requirements.txt
    * setup.py 
* Updated the following files in copy_files_to_archive lambda
    * `bin/build.sh` - Removed shared library copy block
    * `bin/run_tests.sh` -  Removed shared library copy block
    * `tasks/copy_files_to_archive/copy_files_to_archive.py` - Updated library import reference
    * `tasks/copy_files_to_archive/requirements.txt` and `tasks/copy_files_to_archive/requirements-dev.txt` - Added shared library install location

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Validated via run_test.sh script unit tests and performing a build and integration validation test in sandbox.

## Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
    - [x] Manual testing/integration testing passes (if forked)
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
