### PR TITLE
Adding post_to_database change to use pip to install shared libraries.

### DIFF
--- a/tasks/post_to_database/bin/build.sh
+++ b/tasks/post_to_database/bin/build.sh
@@ -62,24 +62,6 @@ if [ $return_code -ne 0 ]; then
   exit 1
 fi
 
-## SHARED LIBS
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
-mkdir -p build/orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-touch build/orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-cp ../shared_libraries/database/shared_db.py build/orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_db.py]"
-cp ../shared_libraries/recovery/shared_recovery.py build/orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
-
 ## Create the virtual env. Remove it if it already exists.
 echo "INFO: Creating virtual environment ..."
 if [ -d venv ]; then

--- a/tasks/post_to_database/bin/run_tests.sh
+++ b/tasks/post_to_database/bin/run_tests.sh
@@ -46,27 +46,6 @@ function check_rc () {
   fi
 }
 
-## copy the shared_recovery.py
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
-
-mkdir orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-
-touch orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-
-cp ../shared_libraries/recovery/shared_recovery.py orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
-
-cp ../shared_libraries/database/shared_db.py orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_db.py]"
 
 ## MAIN
 ## -----------------------------------------------------------------------------
@@ -105,9 +84,6 @@ echo "INFO: Cleaning up the environment ..."
 deactivate
 rm -rf venv
 find . -type d -name "__pycache__" -exec rm -rf {} +
-
-# Remove the shared library
-rm -rf orca_shared
 
 exit 0
 

--- a/tasks/post_to_database/post_to_database.py
+++ b/tasks/post_to_database/post_to_database.py
@@ -13,8 +13,8 @@ from cumulus_logger import CumulusLogger
 from sqlalchemy import text
 from sqlalchemy.future import Engine
 
-from orca_shared import shared_db
-from orca_shared.shared_recovery import RequestMethod, OrcaStatus
+from orca_shared.database import shared_db
+from orca_shared.recovery.shared_recovery import RequestMethod, OrcaStatus
 
 LOGGER = CumulusLogger()
 # Generating schema validators can take time, so do it once and reuse.
@@ -55,38 +55,46 @@ def send_record_to_database(record: Dict[str, Any], engine: Engine) -> None:
                 'RequestMethod' (str): 'post' or 'put', depending on if row should be created or updated respectively.
         engine: The sqlalchemy engine to use for contacting the database.
     """
-    values = json.loads(record['body'])
-    request_method = RequestMethod(record['messageAttributes']['RequestMethod']['stringValue'])
+    values = json.loads(record["body"])
+    request_method = RequestMethod(
+        record["messageAttributes"]["RequestMethod"]["stringValue"]
+    )
     if request_method == RequestMethod.NEW_JOB:
         _NEW_JOB_VALIDATE(values)
-        create_status_for_job_and_files(values['job_id'],
-                                        values['granule_id'],
-                                        values['request_time'],
-                                        values['archive_destination'],
-                                        values['files'],
-                                        engine)
+        create_status_for_job_and_files(
+            values["job_id"],
+            values["granule_id"],
+            values["request_time"],
+            values["archive_destination"],
+            values["files"],
+            engine,
+        )
     elif request_method == RequestMethod.UPDATE_FILE:
         _UPDATE_FILE_VALIDATE(values)
-        update_status_for_file(values['job_id'],
-                               values['granule_id'],
-                               values['filename'],
-                               values['last_update'],
-                               values.get('completion_time', None),
-                               values['status_id'],
-                               values.get('error_message', None),
-                               engine)
+        update_status_for_file(
+            values["job_id"],
+            values["granule_id"],
+            values["filename"],
+            values["last_update"],
+            values.get("completion_time", None),
+            values["status_id"],
+            values.get("error_message", None),
+            engine,
+        )
     else:
         error = ValueError(f"RequestMethod '{request_method.value}' not found.")
         LOGGER.critical(error)
         raise error
 
 
-def create_status_for_job_and_files(job_id: str,
-                                    granule_id: str,
-                                    request_time: str,
-                                    archive_destination: str,
-                                    files: List[Dict[str, Any]],
-                                    engine: Engine) -> None:
+def create_status_for_job_and_files(
+    job_id: str,
+    granule_id: str,
+    request_time: str,
+    archive_destination: str,
+    files: List[Dict[str, Any]],
+    engine: Engine,
+) -> None:
     """
     Posts the entry for the job, followed by individual entries for each file.
 
@@ -110,25 +118,37 @@ def create_status_for_job_and_files(job_id: str,
     job_completion_time = None
     file_parameters = []
     for file in files:
-        if file['status_id'] == OrcaStatus.PENDING.value:
+        if file["status_id"] == OrcaStatus.PENDING.value:
             found_pending = True
-        elif file['status_id'] == OrcaStatus.FAILED.value:
-            file_completion_time = datetime.datetime.fromisoformat(file['completion_time'])
+        elif file["status_id"] == OrcaStatus.FAILED.value:
+            file_completion_time = datetime.datetime.fromisoformat(
+                file["completion_time"]
+            )
             if job_completion_time is None:
                 job_completion_time = file_completion_time
             else:
-                job_completion_time = max(job_completion_time,
-                                          file_completion_time)
+                job_completion_time = max(job_completion_time, file_completion_time)
         else:
-            error = ValueError(f"Status ID '{file['status_id']}' not allowed for new status.")
+            error = ValueError(
+                f"Status ID '{file['status_id']}' not allowed for new status."
+            )
             LOGGER.critical(error)
             raise error
-        file_parameters.append({'job_id': job_id, 'granule_id': granule_id, 'filename': file['filename'],
-                                'key_path': file['key_path'], 'restore_destination': file['restore_destination'],
-                                'multipart_chunksize_mb': file['multipart_chunksize_mb'],
-                                'status_id': file['status_id'], 'error_message': file.get('error_message', None),
-                                'request_time': file['request_time'], 'last_update': file['last_update'],
-                                'completion_time': file.get('completion_time', None)})
+        file_parameters.append(
+            {
+                "job_id": job_id,
+                "granule_id": granule_id,
+                "filename": file["filename"],
+                "key_path": file["key_path"],
+                "restore_destination": file["restore_destination"],
+                "multipart_chunksize_mb": file["multipart_chunksize_mb"],
+                "status_id": file["status_id"],
+                "error_message": file.get("error_message", None),
+                "request_time": file["request_time"],
+                "last_update": file["last_update"],
+                "completion_time": file.get("completion_time", None),
+            }
+        )
 
     if found_pending:
         # Most jobs will be this. Some files are still pending.
@@ -142,26 +162,40 @@ def create_status_for_job_and_files(job_id: str,
     try:
         LOGGER.debug(f"Creating recovery records for job_id {job_id}.")
         with engine.begin() as connection:
-            connection.execute(create_job_sql(),
-                               [{'job_id': job_id, 'granule_id': granule_id, 'status_id': job_status.value,
-                                 'request_time': request_time,
-                                 'completion_time': job_completion_time,
-                                 'archive_destination': archive_destination}])
+            connection.execute(
+                create_job_sql(),
+                [
+                    {
+                        "job_id": job_id,
+                        "granule_id": granule_id,
+                        "status_id": job_status.value,
+                        "request_time": request_time,
+                        "completion_time": job_completion_time,
+                        "archive_destination": archive_destination,
+                    }
+                ],
+            )
             connection.execute(create_file_sql(), file_parameters)
     except Exception as sql_ex:
         # Can't use f"" because of '{}' bug in CumulusLogger.
-        LOGGER.error("Error while creating statuses for job '{job_id}': {sql_ex}", job_id=job_id, sql_ex=sql_ex)
+        LOGGER.error(
+            "Error while creating statuses for job '{job_id}': {sql_ex}",
+            job_id=job_id,
+            sql_ex=sql_ex,
+        )
         raise
 
 
-def update_status_for_file(job_id: str,
-                           granule_id: str,
-                           filename: str,
-                           last_update: str,
-                           completion_time: Optional[str],
-                           status_id: int,
-                           error_message: Optional[str],
-                           engine: Engine) -> None:
+def update_status_for_file(
+    job_id: str,
+    granule_id: str,
+    filename: str,
+    last_update: str,
+    completion_time: Optional[str],
+    status_id: int,
+    error_message: Optional[str],
+    engine: Engine,
+) -> None:
     """
     Updates a given file's status entry, modifying the job if all files for that job have advanced in status.
 
@@ -176,49 +210,68 @@ def update_status_for_file(job_id: str,
 
         engine: The sqlalchemy engine to use for contacting the database.
     """
-    file_parameters = {'status_id': status_id, 'last_update': last_update,
-                       'completion_time': completion_time, 'error_message': error_message,
-                       'job_id': job_id, 'granule_id': granule_id, 'filename': filename}
-    job_parameters = {'job_id': job_id, 'granule_id': granule_id}
+    file_parameters = {
+        "status_id": status_id,
+        "last_update": last_update,
+        "completion_time": completion_time,
+        "error_message": error_message,
+        "job_id": job_id,
+        "granule_id": granule_id,
+        "filename": filename,
+    }
+    job_parameters = {"job_id": job_id, "granule_id": granule_id}
     try:
-        LOGGER.debug(f"Updating status for recovery record job_id {job_id} granule_id {granule_id} and file {filename}." )
+        LOGGER.debug(
+            f"Updating status for recovery record job_id {job_id} granule_id {granule_id} and file {filename}."
+        )
         with engine.begin() as connection:
             connection.execute(update_file_sql(), file_parameters)
             connection.execute(update_job_sql(), job_parameters)
     except Exception as sql_ex:
         # Can't use f"" because of '{}' bug in CumulusLogger.
-        LOGGER.error("Error while creating statuses for job '{job_id}': {sql_ex}", job_id=job_id, sql_ex=sql_ex)
+        LOGGER.error(
+            "Error while creating statuses for job '{job_id}': {sql_ex}",
+            job_id=job_id,
+            sql_ex=sql_ex,
+        )
         raise
 
 
 def create_job_sql():
-    return text("""
+    return text(
+        """
         INSERT INTO recovery_job
             ("job_id", "granule_id", "status_id", "request_time", "completion_time", "archive_destination")
         VALUES
-            (:job_id, :granule_id, :status_id, :request_time, :completion_time, :archive_destination)""")
+            (:job_id, :granule_id, :status_id, :request_time, :completion_time, :archive_destination)"""
+    )
 
 
 def create_file_sql():
-    return text("""
+    return text(
+        """
         INSERT INTO recovery_file
             ("job_id", "granule_id", "filename", "key_path", "restore_destination", "multipart_chunksize_mb", 
             "status_id", "error_message", "request_time", "last_update", "completion_time")
         VALUES
             (:job_id, :granule_id, :filename, :key_path, :restore_destination, :multipart_chunksize_mb, :status_id, 
-            :error_message, :request_time, :last_update, :completion_time)""")
+            :error_message, :request_time, :last_update, :completion_time)"""
+    )
 
 
 def update_file_sql():
-    return text("""
+    return text(
+        """
         UPDATE recovery_file
         SET status_id = :status_id, last_update = :last_update, completion_time = :completion_time,
             error_message = :error_message
-        WHERE job_id = :job_id AND granule_id = :granule_id AND filename = :filename""")
+        WHERE job_id = :job_id AND granule_id = :granule_id AND filename = :filename"""
+    )
 
 
 def update_job_sql():
-    return text("""
+    return text(
+        """
         with granule_status as (
             SELECT
                 job_id,
@@ -246,7 +299,8 @@ def update_job_sql():
         WHERE
             recovery_job.job_id = granule_status.job_id
         AND
-            recovery_job.granule_id = granule_status.granule_id""")
+            recovery_job.granule_id = granule_status.granule_id"""
+    )
 
 
 def handler(event: Dict[str, List], context) -> None:
@@ -276,4 +330,4 @@ def handler(event: Dict[str, List], context) -> None:
 
     db_connect_info = shared_db.get_configuration()
 
-    task(event['Records'], db_connect_info)
+    task(event["Records"], db_connect_info)

--- a/tasks/post_to_database/requirements-dev.txt
+++ b/tasks/post_to_database/requirements-dev.txt
@@ -1,7 +1,12 @@
-boto3~=1.12.47
-pytest==6.1.2
+## Libraries needed for testing
 coverage==5.3
+pytest==6.1.2
+
+## Application libraries needed for testing
 psycopg2-binary==2.8.6
-cumulus-message-adapter-python>=1.1.1
-SQLAlchemy~=1.4.13
+
+## Application libraries
+cumulus-message-adapter-python==1.2.1
 fastjsonschema~=2.15.1
+SQLAlchemy~=1.4.11
+../../shared_libraries[all] --use-feature=in-tree-build

--- a/tasks/post_to_database/requirements.txt
+++ b/tasks/post_to_database/requirements.txt
@@ -1,4 +1,4 @@
-boto3~=1.12.47
-cumulus-message-adapter-python>=1.1.1
-SQLAlchemy~=1.4.13
+cumulus-message-adapter-python==1.2.1
+SQLAlchemy~=1.4.11
 fastjsonschema~=2.15.1
+../../shared_libraries[all] --use-feature=in-tree-build

--- a/tasks/post_to_database/test/unit_tests/test_post_to_database.py
+++ b/tasks/post_to_database/test/unit_tests/test_post_to_database.py
@@ -13,33 +13,39 @@ from unittest.mock import Mock, call, patch, MagicMock
 from fastjsonschema import JsonSchemaValueException
 
 import post_to_database
-from orca_shared.shared_recovery import OrcaStatus
+from orca_shared.recovery.shared_recovery import OrcaStatus
 
 
-class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-instance-attributes
+class TestPostToDatabase(
+    unittest.TestCase
+):  # pylint: disable-msg=too-many-instance-attributes
     """
     TestPostToDatabase.
     """
 
-    @patch('post_to_database.task')
-    @patch('orca_shared.shared_db.get_configuration')
-    @patch('cumulus_logger.CumulusLogger.setMetadata')
-    def test_handler_happy_path(self,
-                                mock_set_metadata: MagicMock,
-                                mock_get_configuration: MagicMock,
-                                mock_task: MagicMock):
+    @patch("post_to_database.task")
+    @patch("orca_shared.database.shared_db.get_configuration")
+    @patch("cumulus_logger.CumulusLogger.setMetadata")
+    def test_handler_happy_path(
+        self,
+        mock_set_metadata: MagicMock,
+        mock_get_configuration: MagicMock,
+        mock_task: MagicMock,
+    ):
         records = Mock()
-        event = {'Records': records}
+        event = {"Records": records}
         context = Mock()
         post_to_database.handler(event, context)
         mock_set_metadata.assert_called_once_with(event, context)
         mock_task.assert_called_once_with(records, mock_get_configuration.return_value)
 
-    @patch('orca_shared.shared_db.get_user_connection')
-    @patch('post_to_database.send_record_to_database')
-    def test_task_happy_path(self,
-                             mock_send_record_to_database: MagicMock,
-                             mock_get_user_connection: MagicMock):
+    @patch("orca_shared.database.shared_db.get_user_connection")
+    @patch("post_to_database.send_record_to_database")
+    def test_task_happy_path(
+        self,
+        mock_send_record_to_database: MagicMock,
+        mock_get_user_connection: MagicMock,
+    ):
         record0 = Mock()
         record1 = Mock()
         records = [record0, record1]
@@ -49,46 +55,58 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
 
         post_to_database.task(records, db_connect_info)
 
-        mock_send_record_to_database.assert_has_calls([call(record0, mock_engine), call(record1, mock_engine)])
+        mock_send_record_to_database.assert_has_calls(
+            [call(record0, mock_engine), call(record1, mock_engine)]
+        )
         self.assertEqual(2, mock_send_record_to_database.call_count)
 
-    @patch('post_to_database.create_status_for_job_and_files')
-    def test_send_record_to_database_create_status_for_job_and_files(self,
-                                                                     mock_create_status_for_job_and_files: MagicMock):
+    @patch("post_to_database.create_status_for_job_and_files")
+    def test_send_record_to_database_create_status_for_job_and_files(
+        self, mock_create_status_for_job_and_files: MagicMock
+    ):
         job_id = uuid.uuid4().__str__()
         granule_id = uuid.uuid4().__str__()
         request_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
         archive_destination = uuid.uuid4().__str__()
-        files = [{
-            'filename': uuid.uuid4().__str__(), 'key_path': uuid.uuid4().__str__(),
-            'restore_destination': uuid.uuid4().__str__(), 'status_id': 1,
-            'request_time': datetime.datetime.now(datetime.timezone.utc).isoformat(),
-            'last_update': datetime.datetime.now(datetime.timezone.utc).isoformat(),
-            'multipart_chunksize_mb': random.randint(1, 10000)
-        }]
+        files = [
+            {
+                "filename": uuid.uuid4().__str__(),
+                "key_path": uuid.uuid4().__str__(),
+                "restore_destination": uuid.uuid4().__str__(),
+                "status_id": 1,
+                "request_time": datetime.datetime.now(
+                    datetime.timezone.utc
+                ).isoformat(),
+                "last_update": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "multipart_chunksize_mb": random.randint(1, 10000),
+            }
+        ]
 
         values = {
             "job_id": job_id,
             "granule_id": granule_id,
             "request_time": request_time,
             "archive_destination": archive_destination,
-            "files": files
+            "files": files,
         }
         request_method = post_to_database.RequestMethod.NEW_JOB
         mock_engine = Mock()
         record = {
-            'body': json.dumps(values, indent=4),
-            'messageAttributes': {'RequestMethod': {'stringValue': request_method.value.__str__()}}
+            "body": json.dumps(values, indent=4),
+            "messageAttributes": {
+                "RequestMethod": {"stringValue": request_method.value.__str__()}
+            },
         }
 
         post_to_database.send_record_to_database(record, mock_engine)
 
-        mock_create_status_for_job_and_files.assert_called_once_with(job_id, granule_id, request_time,
-                                                                     archive_destination,
-                                                                     files, mock_engine)
+        mock_create_status_for_job_and_files.assert_called_once_with(
+            job_id, granule_id, request_time, archive_destination, files, mock_engine
+        )
 
     def test_send_record_to_database_create_status_for_job_and_files_errors_for_missing_properties(
-            self):
+        self,
+    ):
         """
         No missing properties should be allowed
         """
@@ -96,19 +114,23 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
         granule_id = uuid.uuid4().__str__()
         request_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
         archive_destination = uuid.uuid4().__str__()
-        files = [{
-            'filename': uuid.uuid4().__str__(), 'key_path': uuid.uuid4().__str__(),
-            'restore_destination': uuid.uuid4().__str__(), 'status_id': 1,
-            'request_time': datetime.datetime.utcnow().isoformat(),
-            'last_update': datetime.datetime.utcnow().isoformat(),
-            'multipart_chunksize_mb': None
-        }]
+        files = [
+            {
+                "filename": uuid.uuid4().__str__(),
+                "key_path": uuid.uuid4().__str__(),
+                "restore_destination": uuid.uuid4().__str__(),
+                "status_id": 1,
+                "request_time": datetime.datetime.utcnow().isoformat(),
+                "last_update": datetime.datetime.utcnow().isoformat(),
+                "multipart_chunksize_mb": None,
+            }
+        ]
         values = {
             "job_id": job_id,
             "granule_id": granule_id,
             "request_time": request_time,
             "archive_destination": archive_destination,
-            "files": files
+            "files": files,
         }
         request_method = post_to_database.RequestMethod.NEW_JOB
         mock_engine = Mock()
@@ -117,8 +139,10 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
             input_values = values.copy()
             input_values.pop(key)
             record = {
-                'body': json.dumps(input_values, indent=4),
-                'messageAttributes': {'RequestMethod': {'stringValue': request_method.value.__str__()}}
+                "body": json.dumps(input_values, indent=4),
+                "messageAttributes": {
+                    "RequestMethod": {"stringValue": request_method.value.__str__()}
+                },
             }
             schema_error_raised = False
             try:
@@ -127,11 +151,14 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
                 schema_error_raised = True
 
             if not schema_error_raised:
-                self.fail(f"Key '{key}' schema_error_raised was '{schema_error_raised}'.")
+                self.fail(
+                    f"Key '{key}' schema_error_raised was '{schema_error_raised}'."
+                )
 
-    @patch('post_to_database.update_status_for_file')
-    def test_send_record_to_database_update_status_for_file(self,
-                                                            mock_update_status_for_file: MagicMock):
+    @patch("post_to_database.update_status_for_file")
+    def test_send_record_to_database_update_status_for_file(
+        self, mock_update_status_for_file: MagicMock
+    ):
         job_id = uuid.uuid4().__str__()
         granule_id = uuid.uuid4().__str__()
         filename = uuid.uuid4().__str__()
@@ -146,28 +173,38 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
             "last_update": last_update,
             "status_id": status_id,
             "completion_time": completion_time,
-            "error_message": error_message
+            "error_message": error_message,
         }
         request_method = post_to_database.RequestMethod.UPDATE_FILE
         mock_engine = Mock()
         record = {
-            'body': json.dumps(values, indent=4),
-            'messageAttributes': {'RequestMethod': {'stringValue': request_method.value.__str__()}}
+            "body": json.dumps(values, indent=4),
+            "messageAttributes": {
+                "RequestMethod": {"stringValue": request_method.value.__str__()}
+            },
         }
 
         post_to_database.send_record_to_database(record, mock_engine)
 
-        mock_update_status_for_file.assert_called_once_with(job_id, granule_id, filename, last_update, completion_time,
-                                                            status_id, error_message, mock_engine)
+        mock_update_status_for_file.assert_called_once_with(
+            job_id,
+            granule_id,
+            filename,
+            last_update,
+            completion_time,
+            status_id,
+            error_message,
+            mock_engine,
+        )
 
-    @patch('post_to_database.update_status_for_file')
+    @patch("post_to_database.update_status_for_file")
     def test_send_record_to_database_update_status_for_file_defaults_for_missing_properties(
-            self,
-            mock_update_status_for_file: MagicMock):
+        self, mock_update_status_for_file: MagicMock
+    ):
         """
         Missing completion time and error_message are fine.
         """
-        expected_defaults = {'completion_time': None, 'error_message': None}
+        expected_defaults = {"completion_time": None, "error_message": None}
 
         job_id = uuid.uuid4().__str__()
         granule_id = uuid.uuid4().__str__()
@@ -183,7 +220,7 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
             "last_update": last_update,
             "status_id": status_id,
             "completion_time": completion_time,
-            "error_message": error_message
+            "error_message": error_message,
         }
         request_method = post_to_database.RequestMethod.UPDATE_FILE
         mock_engine = Mock()
@@ -192,8 +229,10 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
             input_values = values.copy()
             input_values.pop(key)
             record = {
-                'body': json.dumps(input_values, indent=4),
-                'messageAttributes': {'RequestMethod': {'stringValue': request_method.value.__str__()}}
+                "body": json.dumps(input_values, indent=4),
+                "messageAttributes": {
+                    "RequestMethod": {"stringValue": request_method.value.__str__()}
+                },
             }
             schema_error_raised = False
             try:
@@ -202,25 +241,34 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
                 schema_error_raised = True
 
             if schema_error_raised == expected_defaults.keys().__contains__(key):
-                self.fail(f"Key '{key}' schema_error_raised was '{schema_error_raised}'.")
+                self.fail(
+                    f"Key '{key}' schema_error_raised was '{schema_error_raised}'."
+                )
             if expected_defaults.keys().__contains__(key):
                 expected_values = values.copy()
                 # noinspection PyTypeChecker
                 expected_values[key] = expected_defaults[key]
-                expected_values['engine'] = mock_engine
-                mock_update_status_for_file.assert_has_calls([call(expected_values['job_id'],
-                                                                   expected_values['granule_id'],
-                                                                   expected_values['filename'],
-                                                                   expected_values['last_update'],
-                                                                   expected_values['completion_time'],
-                                                                   expected_values['status_id'],
-                                                                   expected_values['error_message'], mock_engine)])
+                expected_values["engine"] = mock_engine
+                mock_update_status_for_file.assert_has_calls(
+                    [
+                        call(
+                            expected_values["job_id"],
+                            expected_values["granule_id"],
+                            expected_values["filename"],
+                            expected_values["last_update"],
+                            expected_values["completion_time"],
+                            expected_values["status_id"],
+                            expected_values["error_message"],
+                            mock_engine,
+                        )
+                    ]
+                )
 
-    @patch('post_to_database.create_file_sql')
-    @patch('post_to_database.create_job_sql')
-    def test_create_status_for_job_and_files_happy_path(self,
-                                                        mock_create_job_sql: MagicMock,
-                                                        mock_create_file_sql: MagicMock):
+    @patch("post_to_database.create_file_sql")
+    @patch("post_to_database.create_job_sql")
+    def test_create_status_for_job_and_files_happy_path(
+        self, mock_create_job_sql: MagicMock, mock_create_file_sql: MagicMock
+    ):
         job_id = uuid.uuid4().__str__()
         granule_id = uuid.uuid4().__str__()
         request_time = uuid.uuid4().__str__()
@@ -242,25 +290,25 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
         completion_time1 = datetime.datetime.utcnow().isoformat()
         files = [
             {
-                'status_id': OrcaStatus.PENDING.value,
-                'filename': filename0,
-                'key_path': key_path0,
-                'restore_destination': restore_destination0,
-                'request_time': request_time0,
-                'last_update': last_update0,
-                'multipart_chunksize_mb': multipart_chunksize_mb0
+                "status_id": OrcaStatus.PENDING.value,
+                "filename": filename0,
+                "key_path": key_path0,
+                "restore_destination": restore_destination0,
+                "request_time": request_time0,
+                "last_update": last_update0,
+                "multipart_chunksize_mb": multipart_chunksize_mb0,
             },
             {
-                'status_id': OrcaStatus.FAILED.value,
-                'filename': filename1,
-                'key_path': key_path1,
-                'restore_destination': restore_destination1,
-                'request_time': request_time1,
-                'last_update': last_update1,
-                'error_message': error_message1,
-                'completion_time': completion_time1,
-                'multipart_chunksize_mb': multipart_chunksize_mb1
-            }
+                "status_id": OrcaStatus.FAILED.value,
+                "filename": filename1,
+                "key_path": key_path1,
+                "restore_destination": restore_destination1,
+                "request_time": request_time1,
+                "last_update": last_update1,
+                "error_message": error_message1,
+                "completion_time": completion_time1,
+                "multipart_chunksize_mb": multipart_chunksize_mb1,
+            },
         ]
 
         mock_engine = Mock()
@@ -270,45 +318,65 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
         mock_engine.begin.return_value.__enter__.return_value = mock_connection
         mock_engine.begin.return_value.__exit__ = Mock()
 
-        post_to_database.create_status_for_job_and_files(job_id, granule_id, request_time, archive_destination,
-                                                         files, mock_engine)
+        post_to_database.create_status_for_job_and_files(
+            job_id, granule_id, request_time, archive_destination, files, mock_engine
+        )
 
-        mock_connection.execute.assert_has_calls([
-            call(
-                mock_create_job_sql.return_value,
-                [{'job_id': job_id, 'granule_id': granule_id, 'status_id': OrcaStatus.PENDING.value,
-                  'request_time': request_time, 'completion_time': None,
-                  'archive_destination': archive_destination}]
-            ),
-            call(
-                mock_create_file_sql.return_value,
-                [
-                    {
-                        'job_id': job_id, 'granule_id': granule_id, 'filename': filename0,
-                        'key_path': key_path0, 'restore_destination': restore_destination0,
-                        'multipart_chunksize_mb': multipart_chunksize_mb0,
-                        'status_id': OrcaStatus.PENDING.value, 'error_message': None,
-                        'request_time': request_time0, 'last_update': last_update0,
-                        'completion_time': None
-                    },
-                    {
-                        'job_id': job_id, 'granule_id': granule_id, 'filename': filename1,
-                        'key_path': key_path1, 'restore_destination': restore_destination1,
-                        'multipart_chunksize_mb': multipart_chunksize_mb1,
-                        'status_id': OrcaStatus.FAILED.value, 'error_message': error_message1,
-                        'request_time': request_time1, 'last_update': last_update1,
-                        'completion_time': completion_time1
-                    }]
-            )
-        ])
+        mock_connection.execute.assert_has_calls(
+            [
+                call(
+                    mock_create_job_sql.return_value,
+                    [
+                        {
+                            "job_id": job_id,
+                            "granule_id": granule_id,
+                            "status_id": OrcaStatus.PENDING.value,
+                            "request_time": request_time,
+                            "completion_time": None,
+                            "archive_destination": archive_destination,
+                        }
+                    ],
+                ),
+                call(
+                    mock_create_file_sql.return_value,
+                    [
+                        {
+                            "job_id": job_id,
+                            "granule_id": granule_id,
+                            "filename": filename0,
+                            "key_path": key_path0,
+                            "restore_destination": restore_destination0,
+                            "multipart_chunksize_mb": multipart_chunksize_mb0,
+                            "status_id": OrcaStatus.PENDING.value,
+                            "error_message": None,
+                            "request_time": request_time0,
+                            "last_update": last_update0,
+                            "completion_time": None,
+                        },
+                        {
+                            "job_id": job_id,
+                            "granule_id": granule_id,
+                            "filename": filename1,
+                            "key_path": key_path1,
+                            "restore_destination": restore_destination1,
+                            "multipart_chunksize_mb": multipart_chunksize_mb1,
+                            "status_id": OrcaStatus.FAILED.value,
+                            "error_message": error_message1,
+                            "request_time": request_time1,
+                            "last_update": last_update1,
+                            "completion_time": completion_time1,
+                        },
+                    ],
+                ),
+            ]
+        )
         self.assertEqual(2, mock_connection.execute.call_count)
 
-    @patch('post_to_database.create_file_sql')
-    @patch('post_to_database.create_job_sql')
-    def test_create_status_for_job_and_files_all_files_failed(self,
-                                                              mock_create_job_sql: MagicMock,
-                                                              mock_create_file_sql: MagicMock
-                                                              ):
+    @patch("post_to_database.create_file_sql")
+    @patch("post_to_database.create_job_sql")
+    def test_create_status_for_job_and_files_all_files_failed(
+        self, mock_create_job_sql: MagicMock, mock_create_file_sql: MagicMock
+    ):
         """
         If all files failed, job should be marked as such.
         """
@@ -344,38 +412,38 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
         multipart_chunksize_mb2 = random.randint(1, 10000)
         files = [
             {
-                'status_id': OrcaStatus.FAILED.value,
-                'filename': filename0,
-                'key_path': key_path0,
-                'restore_destination': restore_destination0,
-                'request_time': request_time0,
-                'last_update': last_update0,
-                'error_message': error_message0,
-                'completion_time': completion_time0,
-                'multipart_chunksize_mb': multipart_chunksize_mb0
+                "status_id": OrcaStatus.FAILED.value,
+                "filename": filename0,
+                "key_path": key_path0,
+                "restore_destination": restore_destination0,
+                "request_time": request_time0,
+                "last_update": last_update0,
+                "error_message": error_message0,
+                "completion_time": completion_time0,
+                "multipart_chunksize_mb": multipart_chunksize_mb0,
             },
             {
-                'status_id': OrcaStatus.FAILED.value,
-                'filename': filename1,
-                'key_path': key_path1,
-                'restore_destination': restore_destination1,
-                'request_time': request_time1,
-                'last_update': last_update1,
-                'error_message': error_message1,
-                'completion_time': completion_time1,
-                'multipart_chunksize_mb': multipart_chunksize_mb1
+                "status_id": OrcaStatus.FAILED.value,
+                "filename": filename1,
+                "key_path": key_path1,
+                "restore_destination": restore_destination1,
+                "request_time": request_time1,
+                "last_update": last_update1,
+                "error_message": error_message1,
+                "completion_time": completion_time1,
+                "multipart_chunksize_mb": multipart_chunksize_mb1,
             },
             {
-                'status_id': OrcaStatus.FAILED.value,
-                'filename': filename2,
-                'key_path': key_path2,
-                'restore_destination': restore_destination2,
-                'request_time': request_time2,
-                'last_update': last_update2,
-                'error_message': error_message2,
-                'completion_time': completion_time2,
-                'multipart_chunksize_mb': multipart_chunksize_mb2
-            }
+                "status_id": OrcaStatus.FAILED.value,
+                "filename": filename2,
+                "key_path": key_path2,
+                "restore_destination": restore_destination2,
+                "request_time": request_time2,
+                "last_update": last_update2,
+                "error_message": error_message2,
+                "completion_time": completion_time2,
+                "multipart_chunksize_mb": multipart_chunksize_mb2,
+            },
         ]
 
         mock_engine = Mock()
@@ -385,46 +453,71 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
         mock_engine.begin.return_value.__enter__.return_value = mock_connection
         mock_engine.begin.return_value.__exit__ = Mock()
 
-        post_to_database.create_status_for_job_and_files(job_id, granule_id, request_time, archive_destination,
-                                                         files, mock_engine)
+        post_to_database.create_status_for_job_and_files(
+            job_id, granule_id, request_time, archive_destination, files, mock_engine
+        )
 
-        mock_connection.execute.assert_has_calls([
-            call(
-                mock_create_job_sql.return_value,
-                [{'job_id': job_id, 'granule_id': granule_id, 'status_id': OrcaStatus.FAILED.value,
-                  'request_time': request_time, 'completion_time': completion_time2.__str__(),
-                  'archive_destination': archive_destination}]
-            ),
-            call(
-                mock_create_file_sql.return_value,
-                [
-                    {
-                        'job_id': job_id, 'granule_id': granule_id, 'filename': filename0,
-                        'key_path': key_path0, 'restore_destination': restore_destination0,
-                        'multipart_chunksize_mb': multipart_chunksize_mb0,
-                        'status_id': OrcaStatus.FAILED.value, 'error_message': error_message0,
-                        'request_time': request_time0, 'last_update': last_update0,
-                        'completion_time': completion_time0
-                    },
-                    {
-                        'job_id': job_id, 'granule_id': granule_id, 'filename': filename1,
-                        'key_path': key_path1, 'restore_destination': restore_destination1,
-                        'multipart_chunksize_mb': multipart_chunksize_mb1,
-                        'status_id': OrcaStatus.FAILED.value, 'error_message': error_message1,
-                        'request_time': request_time1, 'last_update': last_update1,
-                        'completion_time': completion_time1
-                    },
-                    {
-                        'job_id': job_id, 'granule_id': granule_id, 'filename': filename2,
-                        'key_path': key_path2, 'restore_destination': restore_destination2,
-                        'multipart_chunksize_mb': multipart_chunksize_mb2,
-                        'status_id': OrcaStatus.FAILED.value, 'error_message': error_message2,
-                        'request_time': request_time2, 'last_update': last_update2,
-                        'completion_time': completion_time2
-                    }
-                ]
-            )
-        ])
+        mock_connection.execute.assert_has_calls(
+            [
+                call(
+                    mock_create_job_sql.return_value,
+                    [
+                        {
+                            "job_id": job_id,
+                            "granule_id": granule_id,
+                            "status_id": OrcaStatus.FAILED.value,
+                            "request_time": request_time,
+                            "completion_time": completion_time2.__str__(),
+                            "archive_destination": archive_destination,
+                        }
+                    ],
+                ),
+                call(
+                    mock_create_file_sql.return_value,
+                    [
+                        {
+                            "job_id": job_id,
+                            "granule_id": granule_id,
+                            "filename": filename0,
+                            "key_path": key_path0,
+                            "restore_destination": restore_destination0,
+                            "multipart_chunksize_mb": multipart_chunksize_mb0,
+                            "status_id": OrcaStatus.FAILED.value,
+                            "error_message": error_message0,
+                            "request_time": request_time0,
+                            "last_update": last_update0,
+                            "completion_time": completion_time0,
+                        },
+                        {
+                            "job_id": job_id,
+                            "granule_id": granule_id,
+                            "filename": filename1,
+                            "key_path": key_path1,
+                            "restore_destination": restore_destination1,
+                            "multipart_chunksize_mb": multipart_chunksize_mb1,
+                            "status_id": OrcaStatus.FAILED.value,
+                            "error_message": error_message1,
+                            "request_time": request_time1,
+                            "last_update": last_update1,
+                            "completion_time": completion_time1,
+                        },
+                        {
+                            "job_id": job_id,
+                            "granule_id": granule_id,
+                            "filename": filename2,
+                            "key_path": key_path2,
+                            "restore_destination": restore_destination2,
+                            "multipart_chunksize_mb": multipart_chunksize_mb2,
+                            "status_id": OrcaStatus.FAILED.value,
+                            "error_message": error_message2,
+                            "request_time": request_time2,
+                            "last_update": last_update2,
+                            "completion_time": completion_time2,
+                        },
+                    ],
+                ),
+            ]
+        )
         self.assertEqual(2, mock_connection.execute.call_count)
 
     def test_create_status_for_job_and_files_bad_status_id(self):
@@ -449,28 +542,28 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
                 continue
             files = [
                 {
-                    'status_id': OrcaStatus.STAGED.value,
-                    'filename': filename0,
-                    'key_path': key_path0,
-                    'restore_destination': restore_destination0,
-                    'request_time': request_time0,
-                    'last_update': last_update0,
-                    'error_message': error_message0,
-                    'completion_time': completion_time0,
-                    'multipart_chunksize_mb': random.randint(1, 10000)
+                    "status_id": OrcaStatus.STAGED.value,
+                    "filename": filename0,
+                    "key_path": key_path0,
+                    "restore_destination": restore_destination0,
+                    "request_time": request_time0,
+                    "last_update": last_update0,
+                    "error_message": error_message0,
+                    "completion_time": completion_time0,
+                    "multipart_chunksize_mb": random.randint(1, 10000),
                 }
             ]
 
             with self.assertRaises(ValueError):
-                post_to_database.create_status_for_job_and_files(job_id, granule_id, request_time, archive_destination,
-                                                                 files, Mock())
+                post_to_database.create_status_for_job_and_files(
+                    job_id, granule_id, request_time, archive_destination, files, Mock()
+                )
 
-    @patch('post_to_database.update_file_sql')
-    @patch('post_to_database.update_job_sql')
-    def test_update_status_for_file_happy_path(self,
-                                               mock_update_job_sql: MagicMock,
-                                               mock_update_file_sql: MagicMock
-                                               ):
+    @patch("post_to_database.update_file_sql")
+    @patch("post_to_database.update_job_sql")
+    def test_update_status_for_file_happy_path(
+        self, mock_update_job_sql: MagicMock, mock_update_file_sql: MagicMock
+    ):
         job_id = uuid.uuid4().__str__()
         granule_id = uuid.uuid4().__str__()
         filename = uuid.uuid4().__str__()
@@ -486,18 +579,34 @@ class TestPostToDatabase(unittest.TestCase):  # pylint: disable-msg=too-many-ins
         mock_engine.begin.return_value.__enter__.return_value = mock_connection
         mock_engine.begin.return_value.__exit__ = Mock()
 
-        post_to_database.update_status_for_file(job_id, granule_id, filename, last_update, completion_time, status_id,
-                                                error_message, mock_engine)
-        mock_connection.execute.assert_has_calls([
-            call(
-                mock_update_file_sql.return_value,
-                {'status_id': status_id, 'last_update': last_update, 'completion_time': completion_time,
-                 'error_message': error_message, 'job_id': job_id, 'granule_id': granule_id,
-                 'filename': filename}
-            ),
-            call(
-                mock_update_job_sql.return_value,
-                {'job_id': job_id, 'granule_id': granule_id}
-            )
-        ])
+        post_to_database.update_status_for_file(
+            job_id,
+            granule_id,
+            filename,
+            last_update,
+            completion_time,
+            status_id,
+            error_message,
+            mock_engine,
+        )
+        mock_connection.execute.assert_has_calls(
+            [
+                call(
+                    mock_update_file_sql.return_value,
+                    {
+                        "status_id": status_id,
+                        "last_update": last_update,
+                        "completion_time": completion_time,
+                        "error_message": error_message,
+                        "job_id": job_id,
+                        "granule_id": granule_id,
+                        "filename": filename,
+                    },
+                ),
+                call(
+                    mock_update_job_sql.return_value,
+                    {"job_id": job_id, "granule_id": granule_id},
+                ),
+            ]
+        )
         self.assertEqual(2, mock_connection.execute.call_count)


### PR DESCRIPTION
## Summary of Changes

This is to support ORCA-205 work. This makes some minor updates to the shared libraries and adds changes needed for the post_to_database Lambda that are needed to use the shared libraries by installing them via pip.

## Changes

* Updated the following files in post_to_database lambda
    * `bin/build.sh` - Removed shared library copy block
    * `bin/run_tests.sh` -  Removed shared library copy block
    * `tasks/post_copy_request_to_queue/copy_files_to_archive.py` - Updated library import reference
    * `tasks/post_copy_request_to_queue/requirements.txt` and `tasks/post_copy_request_to_queue/requirements-dev.txt` - Added shared library install location

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Validated via run_test.sh script unit tests and performing a build and integration validation test in sandbox.

## Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
    - [x] Manual testing/integration testing passes (if forked)
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
