### PR TITLE
Adding changes to request_files lambda to use pip to install shared libraries

### DIFF
--- a/tasks/request_files/bin/build.sh
+++ b/tasks/request_files/bin/build.sh
@@ -82,24 +82,6 @@ check_rc $return_code "ERROR: pip install encountered an error."
 # Install the aws-lambda psycopg2 libraries
 mkdir -p build/psycopg2
 
-## copy the shared_recovery.py
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
-
-mkdir -p build/orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-
-touch build/orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-
-cp ../shared_libraries/recovery/shared_recovery.py build/orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
-
 ##TODO: Adjust build scripts to put shared packages needed under a task/build/packages directory.
 ##      and copy the packages from there.
 if [ ! -d "../package" ]; then

--- a/tasks/request_files/bin/run_tests.sh
+++ b/tasks/request_files/bin/run_tests.sh
@@ -45,23 +45,7 @@ function check_rc () {
       exit 1
   fi
 }
-## copy the shared_recovery.py
-echo "INFO: Copying ORCA shared libraries ..."
-if [ -d orca_shared ]; then
-    rm -rf orca_shared
-fi
 
-mkdir orca_shared
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create orca_shared directory."
-
-touch orca_shared/__init__.py
-let return_code=$?
-check_rc $return_code "ERROR: Unable to create [orca_shared/__init__.py] file"
-
-cp ../shared_libraries/recovery/shared_recovery.py orca_shared/
-let return_code=$?
-check_rc $return_code "ERROR: Unable to copy shared library [orca_shared/shared_recovery.py]"
 
 ## MAIN
 ## -----------------------------------------------------------------------------
@@ -101,6 +85,5 @@ echo "INFO: Cleaning up the environment ..."
 deactivate
 rm -rf venv
 find . -type d -name "__pycache__" -exec rm -rf {} +
-# Remove the shared library
-rm -rf orca_shared
+
 exit 0

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -18,7 +18,7 @@ from botocore.client import BaseClient
 # noinspection PyPackageRequirements
 from botocore.exceptions import ClientError
 from run_cumulus_task import run_cumulus_task
-from orca_shared import shared_recovery
+from orca_shared.recovery import shared_recovery
 
 DEFAULT_RESTORE_EXPIRE_DAYS = 5
 DEFAULT_MAX_REQUEST_RETRIES = 2

--- a/tasks/request_files/requirements-dev.txt
+++ b/tasks/request_files/requirements-dev.txt
@@ -1,6 +1,11 @@
-cumulus-message-adapter-python>=1.1.1
-boto3==1.12.47
-pytest==6.1.2
+## Libraries needed for testing
 coverage==5.3
-psycopg2-binary==2.8.6
+pytest==6.1.2
+
+## Libraries needed for application testing
 fastjsonschema==2.15.0
+psycopg2-binary==2.8.6
+
+## Libraries needed by the application
+boto3~=1.12.47
+../../shared_libraries[recovery] --use-feature=in-tree-build

--- a/tasks/request_files/requirements.txt
+++ b/tasks/request_files/requirements.txt
@@ -1,2 +1,2 @@
-cumulus-message-adapter-python>=1.1.1
-boto3==1.12.47
+boto3~=1.12.47
+../../shared_libraries[recovery] --use-feature=in-tree-build

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -12,7 +12,7 @@ from random import randint, uniform
 from unittest import mock
 from unittest.mock import patch, MagicMock, call, Mock
 
-from orca_shared.shared_recovery import OrcaStatus
+from orca_shared.recovery.shared_recovery import OrcaStatus
 from test.request_helpers import LambdaContextMock, create_handler_event
 
 # noinspection PyPackageRequirements


### PR DESCRIPTION
## Summary of Changes

This is to support ORCA-205 work. This makes some minor updates to the shared libraries and adds changes needed for the request_files Lambda that are needed to use the shared libraries by installing them via pip.

## Changes

* Updated the following files in request_files lambda
    * `bin/build.sh` - Removed shared library copy block
    * `bin/run_tests.sh` -  Removed shared library copy block
    * `tasks/post_copy_request_to_queue/copy_files_to_archive.py` - Updated library import reference
    * `tasks/post_copy_request_to_queue/requirements.txt` and `tasks/post_copy_request_to_queue/requirements-dev.txt` - Added shared library install location

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Validated via run_test.sh script unit tests and performing a build and integration validation test in sandbox.

## Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
    - [x] Manual testing/integration testing passes (if forked)
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
