### PR TITLE
Remove use-feature=in-tree-build

### DIFF
--- a/tasks/copy_files_to_archive/requirements-dev.txt
+++ b/tasks/copy_files_to_archive/requirements-dev.txt
@@ -3,4 +3,4 @@ pytest==6.1.2
 coverage==5.3
 fastjsonschema==2.15.0
 cumulus-message-adapter-python==1.2.1
-../../shared_libraries[recovery] --use-feature=in-tree-build
+../../shared_libraries[recovery]

--- a/tasks/copy_files_to_archive/requirements.txt
+++ b/tasks/copy_files_to_archive/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.12.47
 fastjsonschema==2.15.0
 cumulus-message-adapter-python==1.2.1
-../../shared_libraries[recovery] --use-feature=in-tree-build
+../../shared_libraries[recovery]

--- a/tasks/db_deploy/requirements-dev.txt
+++ b/tasks/db_deploy/requirements-dev.txt
@@ -9,4 +9,4 @@ moto==2.0.6
 
 ## Libraries needed by application
 SQLAlchemy==1.4.11
-../../shared_libraries[database] --use-feature=in-tree-build
+../../shared_libraries[database]

--- a/tasks/db_deploy/requirements.txt
+++ b/tasks/db_deploy/requirements.txt
@@ -1,2 +1,2 @@
 SQLAlchemy==1.4.11
-../../shared_libraries[database] --use-feature=in-tree-build
+../../shared_libraries[database]

--- a/tasks/post_copy_request_to_queue/requirements-dev.txt
+++ b/tasks/post_copy_request_to_queue/requirements-dev.txt
@@ -10,4 +10,4 @@ psycopg2-binary==2.8.6
 ## Application libraries
 cumulus-message-adapter-python==1.2.1
 SQLAlchemy==1.4.11
-../../shared_libraries[all] --use-feature=in-tree-build
+../../shared_libraries[all]

--- a/tasks/post_copy_request_to_queue/requirements.txt
+++ b/tasks/post_copy_request_to_queue/requirements.txt
@@ -1,3 +1,3 @@
 cumulus-message-adapter-python==1.2.1
 SQLAlchemy==1.4.11
-../../shared_libraries[all] --use-feature=in-tree-build
+../../shared_libraries[all]

--- a/tasks/post_to_database/requirements-dev.txt
+++ b/tasks/post_to_database/requirements-dev.txt
@@ -9,4 +9,4 @@ psycopg2-binary==2.8.6
 cumulus-message-adapter-python==1.2.1
 fastjsonschema~=2.15.1
 SQLAlchemy~=1.4.11
-../../shared_libraries[all] --use-feature=in-tree-build
+../../shared_libraries[all]

--- a/tasks/post_to_database/requirements.txt
+++ b/tasks/post_to_database/requirements.txt
@@ -1,4 +1,4 @@
 cumulus-message-adapter-python==1.2.1
 SQLAlchemy~=1.4.11
 fastjsonschema~=2.15.1
-../../shared_libraries[all] --use-feature=in-tree-build
+../../shared_libraries[all]

--- a/tasks/request_files/requirements-dev.txt
+++ b/tasks/request_files/requirements-dev.txt
@@ -8,4 +8,4 @@ psycopg2-binary==2.8.6
 
 ## Libraries needed by the application
 boto3~=1.12.47
-../../shared_libraries[recovery] --use-feature=in-tree-build
+../../shared_libraries[recovery]

--- a/tasks/request_files/requirements.txt
+++ b/tasks/request_files/requirements.txt
@@ -1,2 +1,2 @@
 boto3~=1.12.47
-../../shared_libraries[recovery] --use-feature=in-tree-build
+../../shared_libraries[recovery]


### PR DESCRIPTION
## Summary of Changes

Remove newly outdated pip command. No longer needed, as specified behavior is now the default.

## Changes

* Removed newly outdated pip command.

## How Has This Been Tested?

Passes local and branch build.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets