### PR TITLE
Switched request_status_for_job to new DB lib with retries

### DIFF
--- a/shared_libraries/API.md
+++ b/shared_libraries/API.md
@@ -50,7 +50,7 @@ Environment Variables:
     AWS_REGION (str): AWS reserved runtime variable used to set boto3 client region.
 
 Parameter Store:
-    <prefix>-orca-db-login-secret (string): The json string containing all the admin and user db login info.
+    <prefix>-orca-db-login-secret (string): The json string containing all the db login info.
 ```
 
 **Arguments**:
@@ -129,7 +129,8 @@ Decorator takes arguments to adjust number of retries and backoff strategy.
 # orca\_shared.recovery.shared\_recovery
 
 Name: shared_recovery.py
-Description: Shared library that combines common functions and classes needed for recovery operations.
+Description: Shared library that combines common functions and classes needed for
+             recovery operations.
 
 <a id="orca_shared.recovery.shared_recovery.RequestMethod"></a>
 
@@ -207,7 +208,8 @@ def update_status_for_file(job_id: str, granule_id: str, filename: str, orca_sta
 ```
 
 Creates update information for a file's status entry, and posts to queue.
-Queue entry will be rejected by post_to_database if status for job_id + granule_id + filename does not exist.
+Queue entry will be rejected by post_to_database if status for
+job_id + granule_id + filename does not exist.
 
 **Arguments**:
 
@@ -231,7 +233,7 @@ Posts messages to an SQS queue.
 **Arguments**:
 
 - `new_data` - A dictionary representing the column/value pairs to write to the DB table.
-- `request_method` - The method action for the database lambda to take when posting to the SQS queue.
+- `request_method` - The action for the database lambda to take when posting to the SQS queue.
 - `db_queue_url` - The SQS queue URL defined by AWS.
 
 **Raises**:

--- a/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule_unit.py
+++ b/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule_unit.py
@@ -327,8 +327,6 @@ class TestRequestStatusForGranuleUnit(
             Mock()
         )  # required for "with", but untestable.
 
-        row = Mock()
-
         result = request_status_for_granule.get_most_recent_job_id_for_granule(
             granule_id, mock_engine
         )

--- a/tasks/request_status_for_job/README.md
+++ b/tasks/request_status_for_job/README.md
@@ -66,29 +66,33 @@ FUNCTIONS
                 'requestId' (str)
                 'message' (str)
     
-    get_granule_status_entries_for_job(job_id: str, db_connect_info: Dict) -> List[Dict[str, Any]]
-        Gets the orca_recoveryjob status entry for the associated job_id.
+    get_granule_status_entries_for_job(job_id: str, engine: sqlalchemy.future.engine.Engine) -> List[Dict[str, Any]]
+        Gets the recovery_job status entry for the associated job_id.
         
         Args:
             job_id: The unique asyncOperationId of the recovery job to retrieve status for.
-            db_connect_info: The {database} defined db_connect_info.
+            engine: The sqlalchemy engine to use for contacting the database.
         
         Returns: A list of dicts with the following keys:
             'granule_id' (str)
             'status' (str): pending|staged|success|failed
     
-    get_status_totals_for_job(job_id: str, db_connect_info: Dict) -> Dict[str, int]
-        Gets the number of orca_recoveryjobs for the given job_id for each possible status value.
+    get_granule_status_entries_for_job_sql() -> <function text at 0x000001AB3E3E5940>
+    
+    get_status_totals_for_job(job_id: str, engine: sqlalchemy.future.engine.Engine) -> Dict[str, int]
+        Gets the number of recovery_job for the given job_id for each possible status value.
         
         Args:
             job_id: The unique id of the recovery job to retrieve status for.
-            db_connect_info: The database defined db_connect_info.
+            engine: The sqlalchemy engine to use for contacting the database.
         
         Returns: A dictionary with the following keys:
             'pending' (int)
             'staged' (int)
             'success' (int)
             'failed' (int)
+    
+    get_status_totals_for_job_sql() -> <function text at 0x000001AB3E3E5940>
     
     handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]
         Entry point for the request_status_for_job Lambda.
@@ -97,13 +101,7 @@ FUNCTIONS
                 asyncOperationId: The unique asyncOperationId of the recovery job.
             context: An object provided by AWS Lambda. Used for context tracking.
         
-        Environment Vars: See requests_db.py's get_dbconnect_info for further details.
-            'DATABASE_PORT' (int): Defaults to 5432
-            'DATABASE_NAME' (str)
-            'DATABASE_USER' (str)
-            'PREFIX' (str)
-            '{prefix}-drdb-host' (str, secretsmanager)
-            '{prefix}-drdb-user-pass' (str, secretsmanager)
+        Environment Vars: See shared_db.py's get_configuration for further details.
         
         Returns: A Dict with the following keys:
             asyncOperationId (str): The unique ID of the asyncOperation.

--- a/tasks/request_status_for_job/request_status_for_job.py
+++ b/tasks/request_status_for_job/request_status_for_job.py
@@ -1,10 +1,10 @@
 from http import HTTPStatus
 from typing import Dict, Any, List
 
-import database
-import requests_db
 from cumulus_logger import CumulusLogger
-from requests_db import DatabaseError
+from orca_shared.database import shared_db
+from sqlalchemy import text
+from sqlalchemy.future import Engine
 
 INPUT_JOB_ID_KEY = "asyncOperationId"
 
@@ -40,7 +40,10 @@ def task(job_id: str, db_connect_info: Dict, request_id: str) -> Dict[str, Any]:
     """
     if job_id is None or len(job_id) == 0:
         raise ValueError(f"job_id must be set to a non-empty value.")
-    status_entries = get_granule_status_entries_for_job(job_id, db_connect_info)
+
+    engine = shared_db.get_user_connection(db_connect_info)
+
+    status_entries = get_granule_status_entries_for_job(job_id, engine)
     if len(status_entries) == 0:
         return create_http_error_dict(
             "NotFound",
@@ -49,7 +52,7 @@ def task(job_id: str, db_connect_info: Dict, request_id: str) -> Dict[str, Any]:
             f"No granules found for job id '{job_id}'.",
         )
 
-    status_totals = get_status_totals_for_job(job_id, db_connect_info)
+    status_totals = get_status_totals_for_job(job_id, engine)
     return {
         OUTPUT_JOB_ID_KEY: job_id,
         OUTPUT_JOB_STATUS_TOTALS_KEY: status_totals,
@@ -57,50 +60,68 @@ def task(job_id: str, db_connect_info: Dict, request_id: str) -> Dict[str, Any]:
     }
 
 
+@shared_db.retry_operational_error()
 def get_granule_status_entries_for_job(
-    job_id: str, db_connect_info: Dict
+    job_id: str, engine: Engine
 ) -> List[Dict[str, Any]]:
     """
     Gets the recovery_job status entry for the associated job_id.
 
     Args:
         job_id: The unique asyncOperationId of the recovery job to retrieve status for.
-        db_connect_info: The {database} defined db_connect_info.
+        engine: The sqlalchemy engine to use for contacting the database.
 
     Returns: A list of dicts with the following keys:
         'granule_id' (str)
         'status' (str): pending|staged|success|failed
 
     """
-    sql = f"""
-            SELECT
-                granule_id as "{OUTPUT_GRANULE_ID_KEY}",
-                recovery_status.value AS "{OUTPUT_STATUS_KEY}"
-            FROM
-                recovery_job
-            JOIN recovery_status ON recovery_job.status_id=recovery_status.id
-            WHERE
-                job_id = %s
-            """
-
     try:
-        rows = database.single_query(sql, db_connect_info, (job_id,))
-    except database.DbError as err:
+        with engine.begin() as connection:
+            results = connection.execute(
+                get_granule_status_entries_for_job_sql(),
+                [{"job_id": job_id}],
+            )
+    except Exception as err:
         # Can't use f"" because of '{}' bug in CumulusLogger.
         LOGGER.error("DbError: {err}", err=str(err))
-        raise DatabaseError(str(err))
-    result = database.result_to_json(rows)
-    return result
+        raise
+
+    rows = []
+    for row in results:
+        rows.append(
+            {
+                OUTPUT_GRANULE_ID_KEY: row[OUTPUT_GRANULE_ID_KEY],
+                OUTPUT_STATUS_KEY: row[OUTPUT_STATUS_KEY],
+            }
+        )
+    return rows
 
 
-def get_status_totals_for_job(job_id: str, db_connect_info: Dict) -> Dict[str, int]:
+def get_granule_status_entries_for_job_sql() -> text:
+    return text(
+        f"""
+                SELECT
+                    granule_id as "{OUTPUT_GRANULE_ID_KEY}",
+                    recovery_status.value AS "{OUTPUT_STATUS_KEY}"
+                FROM
+                    recovery_job
+                JOIN recovery_status ON recovery_job.status_id=recovery_status.id
+                WHERE
+                    job_id = :job_id
+                """
+    )
+
+
+@shared_db.retry_operational_error()
+def get_status_totals_for_job(job_id: str, engine: Engine) -> Dict[str, int]:
     # noinspection SpellCheckingInspection
     """
     Gets the number of recovery_job for the given job_id for each possible status value.
 
     Args:
         job_id: The unique id of the recovery job to retrieve status for.
-        db_connect_info: The database defined db_connect_info.
+        engine: The sqlalchemy engine to use for contacting the database.
 
     Returns: A dictionary with the following keys:
         'pending' (int)
@@ -108,28 +129,36 @@ def get_status_totals_for_job(job_id: str, db_connect_info: Dict) -> Dict[str, i
         'success' (int)
         'failed' (int)
     """
-    # noinspection SpellCheckingInspection
-    sql = f"""
-            with granule_status_count AS (
-                SELECT status_id
-                    , count(*) as total
-                FROM recovery_job
-                WHERE job_id = %s
-                GROUP BY status_id
-            )
-            SELECT value
-                , coalesce(total, 0) as total
-            FROM recovery_status os
-            LEFT JOIN granule_status_count gsc ON (gsc.status_id = os.id)"""
-
     try:
-        rows = database.single_query(sql, db_connect_info, (job_id,))
-    except database.DbError as err:
+        with engine.begin() as connection:
+            results = connection.execute(
+                get_status_totals_for_job_sql(),
+                [{"job_id": job_id}],
+            )
+    except Exception as err:
         # Can't use f"" because of '{}' bug in CumulusLogger.
         LOGGER.error("DbError: {err}", err=str(err))
-        raise DatabaseError(str(err))
-    totals = {row["value"]: row["total"] for row in rows}
+        raise
+
+    totals = {row["value"]: row["total"] for row in results}
     return totals
+
+
+def get_status_totals_for_job_sql() -> text:
+    return text(
+        f"""
+                with granule_status_count AS (
+                    SELECT status_id
+                        , count(*) as total
+                    FROM recovery_job
+                    WHERE job_id = :job_id
+                    GROUP BY status_id
+                )
+                SELECT value
+                    , coalesce(total, 0) as total
+                FROM recovery_status os
+                LEFT JOIN granule_status_count gsc ON (gsc.status_id = os.id)"""
+    )
 
 
 def create_http_error_dict(
@@ -155,7 +184,7 @@ def create_http_error_dict(
         "httpStatus": http_status_code,
         "requestId": request_id,
         # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-        "message": message.replace("{", "{{").replace("}", "}}")
+        "message": message.replace("{", "{{").replace("}", "}}"),
     }
 
 
@@ -167,13 +196,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             asyncOperationId: The unique asyncOperationId of the recovery job.
         context: An object provided by AWS Lambda. Used for context tracking.
 
-    Environment Vars: See requests_db.py's get_dbconnect_info for further details.
-        'DATABASE_PORT' (int): Defaults to 5432
-        'DATABASE_NAME' (str)
-        'DATABASE_USER' (str)
-        'PREFIX' (str)
-        '{prefix}-drdb-host' (str, secretsmanager)
-        '{prefix}-drdb-user-pass' (str, secretsmanager)
+    Environment Vars: See shared_db.py's get_configuration for further details.
 
     Returns: A Dict with the following keys:
         asyncOperationId (str): The unique ID of the asyncOperation.
@@ -189,23 +212,23 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         Or, if an error occurs, see create_http_error_dict
             400 if asyncOperationId is missing. 500 if an error occurs when querying the database.
     """
-    LOGGER.setMetadata(event, context)
-
-    job_id = event.get(INPUT_JOB_ID_KEY, None)
-    if job_id is None or len(job_id) == 0:
-        return create_http_error_dict(
-            "BadRequest",
-            HTTPStatus.BAD_REQUEST,
-            context.aws_request_id,
-            f"{INPUT_JOB_ID_KEY} must be set to a non-empty value.",
-        )
-    db_connect_info = requests_db.get_dbconnect_info()
     try:
+        LOGGER.setMetadata(event, context)
+
+        job_id = event.get(INPUT_JOB_ID_KEY, None)
+        if job_id is None or len(job_id) == 0:
+            return create_http_error_dict(
+                "BadRequest",
+                HTTPStatus.BAD_REQUEST,
+                context.aws_request_id,
+                f"{INPUT_JOB_ID_KEY} must be set to a non-empty value.",
+            )
+        db_connect_info = shared_db.get_configuration()
         return task(job_id, db_connect_info, context.aws_request_id)
-    except DatabaseError as db_error:
+    except Exception as error:
         return create_http_error_dict(
             "InternalServerError",
             HTTPStatus.INTERNAL_SERVER_ERROR,
             context.aws_request_id,
-            db_error.__str__(),
+            error.__str__(),
         )

--- a/tasks/request_status_for_job/requirements-dev.txt
+++ b/tasks/request_status_for_job/requirements-dev.txt
@@ -1,7 +1,6 @@
-../dr_dbutils/dist/dr_dbutils-1.0.tar.gz
-../pg_utils/dist/pg_utils-1.0.tar.gz
-boto3==1.16.9
-cumulus-message-adapter-python>=1.1.1
+cumulus-message-adapter-python==1.2.1
+SQLAlchemy==1.4.11
+../../shared_libraries[database]
 fastjsonschema==2.15.0
 pytest==6.1.2
 coverage==5.3

--- a/tasks/request_status_for_job/requirements.txt
+++ b/tasks/request_status_for_job/requirements.txt
@@ -1,3 +1,3 @@
-../dr_dbutils/dist/dr_dbutils-1.0.tar.gz
-../pg_utils/dist/pg_utils-1.0.tar.gz
-cumulus-message-adapter-python>=1.1.1
+cumulus-message-adapter-python==1.2.1
+SQLAlchemy==1.4.11
+../../shared_libraries[database]

--- a/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job_unit.py
+++ b/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job_unit.py
@@ -3,16 +3,15 @@ Name: test_request_status_for_job_unit.py
 
 Description:  Unit tests for request_status_for_job.py.
 """
+import copy
 import json
 import unittest
 import uuid
 from http import HTTPStatus
 from unittest import mock
 from unittest.mock import patch, MagicMock, Mock
-
-import database
 import fastjsonschema as fastjsonschema
-import requests_db
+import sqlalchemy
 
 import request_status_for_job
 
@@ -26,7 +25,7 @@ class TestRequestStatusForJobUnit(
 
     # noinspection PyPep8Naming
     @patch("request_status_for_job.task")
-    @patch("requests_db.get_dbconnect_info")
+    @patch("orca_shared.database.shared_db.get_configuration")
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     def test_handler_happy_path(
         self,
@@ -50,7 +49,7 @@ class TestRequestStatusForJobUnit(
         self.assertEqual(mock_task.return_value, result)
 
     # noinspection PyPep8Naming
-    @patch("requests_db.get_dbconnect_info")
+    @patch("orca_shared.database.shared_db.get_configuration")
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     def test_handler_missing_job_id_returns_error_code(
         self, mock_setMetadata: MagicMock, mock_get_dbconnect_info: MagicMock
@@ -64,14 +63,16 @@ class TestRequestStatusForJobUnit(
         self.assertEqual(HTTPStatus.BAD_REQUEST, result["httpStatus"])
 
     # noinspection PyPep8Naming
+    @patch("cumulus_logger.CumulusLogger.error")
     @patch("request_status_for_job.task")
-    @patch("requests_db.get_dbconnect_info")
+    @patch("orca_shared.database.shared_db.get_configuration")
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     def test_handler_database_error_returns_error_code(
         self,
         mock_setMetadata: MagicMock,
         mock_get_dbconnect_info: MagicMock,
         mock_task: MagicMock,
+        mock_cumulus_logger_error: MagicMock,
     ):
         """
         If database error is raised, it should be caught and returned in a dictionary.
@@ -80,16 +81,18 @@ class TestRequestStatusForJobUnit(
 
         event = {request_status_for_job.INPUT_JOB_ID_KEY: job_id}
         context = Mock()
-        mock_task.side_effect = requests_db.DatabaseError()
+        mock_task.side_effect = sqlalchemy.exc.OperationalError
         result = request_status_for_job.handler(event, context)
         self.assertEqual(HTTPStatus.INTERNAL_SERVER_ERROR, result["httpStatus"])
 
+    @patch("orca_shared.database.shared_db.get_user_connection")
     @patch("request_status_for_job.get_granule_status_entries_for_job")
     @patch("request_status_for_job.get_status_totals_for_job")
     def test_task_happy_path(
         self,
         mock_get_status_totals_for_job: MagicMock,
         mock_get_granule_status_entries_for_job: MagicMock,
+        mock_get_user_connection: MagicMock,
     ):
         """
         Basic path with all information present.
@@ -102,10 +105,13 @@ class TestRequestStatusForJobUnit(
 
         result = request_status_for_job.task(job_id, db_connect_info, request_id)
 
+        mock_get_user_connection.assert_called_once_with(db_connect_info)
         mock_get_granule_status_entries_for_job.assert_called_once_with(
-            job_id, db_connect_info
+            job_id, mock_get_user_connection.return_value
         )
-        mock_get_status_totals_for_job.assert_called_once_with(job_id, db_connect_info)
+        mock_get_status_totals_for_job.assert_called_once_with(
+            job_id, mock_get_user_connection.return_value
+        )
 
         self.assertEqual(
             {
@@ -116,12 +122,14 @@ class TestRequestStatusForJobUnit(
             result,
         )
 
+    @patch("orca_shared.database.shared_db.get_user_connection")
     @patch("request_status_for_job.create_http_error_dict")
     @patch("request_status_for_job.get_granule_status_entries_for_job")
     def test_task_no_granules_found_for_job_returns_error(
         self,
         mock_get_granule_status_entries_for_job: MagicMock,
         mock_create_http_error_dict: MagicMock,
+        mock_get_user_connection: MagicMock,
     ):
         """
         If no recovery_job entries exist for the given job_id, return 404.
@@ -132,8 +140,9 @@ class TestRequestStatusForJobUnit(
 
         result = request_status_for_job.task(job_id, db_connect_info, request_id)
 
+        mock_get_user_connection.assert_called_once_with(db_connect_info)
         mock_get_granule_status_entries_for_job.assert_called_once_with(
-            job_id, db_connect_info
+            job_id, mock_get_user_connection.return_value
         )
         mock_create_http_error_dict.assert_called_once_with(
             "NotFound", HTTPStatus.NOT_FOUND, request_id, mock.ANY
@@ -141,107 +150,67 @@ class TestRequestStatusForJobUnit(
 
         self.assertEqual(mock_create_http_error_dict.return_value, result)
 
-    @patch("database.result_to_json")
-    @patch("database.single_query")
-    def test_get_granule_status_entries_for_job_happy_path(
-        self, mock_single_query: MagicMock, mock_result_to_json: MagicMock
-    ):
+    @patch("request_status_for_job.get_granule_status_entries_for_job_sql")
+    def test_get_granule_status_entries_for_job_happy_path(self, mock_sql: MagicMock):
         """
         Basic path with all information present.
         """
         job_id = uuid.uuid4().__str__()
 
-        db_connect_info = Mock()
+        expected_result = [
+            {"granule_id": uuid.uuid4().__str__(), "status": uuid.uuid4().__str__()},
+            {"granule_id": uuid.uuid4().__str__(), "status": uuid.uuid4().__str__()},
+        ]
+        mock_engine = Mock()
+        mock_engine.begin.return_value = Mock()
+        mock_connection = Mock()
+        mock_connection.execute.return_value = copy.deepcopy(expected_result)
+        mock_engine.begin.return_value.__enter__ = Mock()
+        mock_engine.begin.return_value.__enter__.return_value = mock_connection
+        mock_engine.begin.return_value.__exit__ = (
+            Mock()
+        )  # required for "with", but untestable.
 
         result = request_status_for_job.get_granule_status_entries_for_job(
-            job_id, db_connect_info
+            job_id, mock_engine
         )
 
-        mock_single_query.assert_called_once_with(
-            f"""
-            SELECT
-                granule_id as "{request_status_for_job.OUTPUT_GRANULE_ID_KEY}",
-                recovery_status.value AS "{request_status_for_job.OUTPUT_STATUS_KEY}"
-            FROM
-                recovery_job
-            JOIN recovery_status ON recovery_job.status_id=recovery_status.id
-            WHERE
-                job_id = %s
-            """,
-            db_connect_info,
-            (job_id,),
+        mock_connection.execute.assert_called_once_with(
+            mock_sql.return_value,
+            [{"job_id": job_id}],
         )
-        mock_result_to_json.assert_called_once_with(mock_single_query.return_value)
 
-        self.assertEqual(mock_result_to_json.return_value, result)
+        self.assertEqual(expected_result, result)
 
-    @patch("database.single_query")
-    def test_get_granule_status_entries_for_job_error_wrapped_in_database_error(
-        self, mock_single_query: MagicMock
-    ):
-        """
-        If error is raised when contacting DB, error should be raised as a DatabaseError.
-        """
-        job_id = uuid.uuid4().__str__()
-        db_connect_info = Mock()
-
-        mock_single_query.side_effect = database.DbError()
-
-        with self.assertRaises(request_status_for_job.DatabaseError):
-            request_status_for_job.get_granule_status_entries_for_job(
-                job_id, db_connect_info
-            )
-
-    @patch("database.single_query")
-    def test_get_status_totals_for_job_happy_path(self, mock_single_query: MagicMock):
+    @patch("request_status_for_job.get_status_totals_for_job_sql")
+    def test_get_status_totals_for_job_happy_path(self, mock_sql: MagicMock):
         """
         Basic path with all information present.
         """
         job_id = uuid.uuid4().__str__()
-        db_connect_info = Mock()
 
-        mock_single_query.return_value = [
+        expected_result = [
             {"value": "success", "total": 5},
             {"value": "future_status", "total": 10},
         ]
+        mock_engine = Mock()
+        mock_engine.begin.return_value = Mock()
+        mock_connection = Mock()
+        mock_connection.execute.return_value = copy.deepcopy(expected_result)
+        mock_engine.begin.return_value.__enter__ = Mock()
+        mock_engine.begin.return_value.__enter__.return_value = mock_connection
+        mock_engine.begin.return_value.__exit__ = (
+            Mock()
+        )  # required for "with", but untestable.
 
-        result = request_status_for_job.get_status_totals_for_job(
-            job_id, db_connect_info
-        )
+        result = request_status_for_job.get_status_totals_for_job(job_id, mock_engine)
 
-        mock_single_query.assert_called_once_with(
-            f"""
-            with granule_status_count AS (
-                SELECT status_id
-                    , count(*) as total
-                FROM recovery_job
-                WHERE job_id = %s
-                GROUP BY status_id
-            )
-            SELECT value
-                , coalesce(total, 0) as total
-            FROM recovery_status os
-            LEFT JOIN granule_status_count gsc ON (gsc.status_id = os.id)""",
-            db_connect_info,
-            (job_id,),
+        mock_connection.execute.assert_called_once_with(
+            mock_sql.return_value,
+            [{"job_id": job_id}],
         )
 
         self.assertEqual({"success": 5, "future_status": 10}, result)
-
-    @patch("database.single_query")
-    def test_get_status_totals_for_job_error_wrapped_in_database_error(
-        self, mock_single_query: MagicMock
-    ):
-        """
-        If error is raised when contacting DB, error should be raised as a DatabaseError.
-        """
-        job_id = uuid.uuid4().__str__()
-        db_connect_info = Mock()
-
-        mock_single_query.side_effect = database.DbError()
-
-        with self.assertRaises(request_status_for_job.DatabaseError):
-            request_status_for_job.get_status_totals_for_job(job_id, db_connect_info)
 
     def test_task_job_id_cannot_be_none(self):
         """
@@ -254,8 +223,8 @@ class TestRequestStatusForJobUnit(
         self.fail("Error not raised.")
 
     # Multi-Function Tests:
-    @patch("database.single_query")
-    def test_task_output_json_schema(self, mock_single_query: MagicMock):
+    @patch("orca_shared.database.shared_db.get_user_connection")
+    def test_task_output_json_schema(self, mock_get_user_connection: MagicMock):
         """
         Checks a realistic output against the output.json.
         """
@@ -264,7 +233,10 @@ class TestRequestStatusForJobUnit(
 
         db_connect_info = Mock()
 
-        mock_single_query.side_effect = [
+        mock_engine = Mock()
+        mock_engine.begin.return_value = Mock()
+        mock_connection = Mock()
+        mock_connection.execute.side_effect = [
             # granules
             [
                 {
@@ -284,9 +256,16 @@ class TestRequestStatusForJobUnit(
                 {"value": "failed", "total": 1000},
             ],
         ]
+        mock_engine.begin.return_value.__enter__ = Mock()
+        mock_engine.begin.return_value.__enter__.return_value = mock_connection
+        mock_engine.begin.return_value.__exit__ = (
+            Mock()
+        )  # required for "with", but untestable.
+        mock_get_user_connection.return_value = mock_engine
 
         result = request_status_for_job.task(job_id, db_connect_info, request_id)
 
+        mock_get_user_connection.assert_called_once_with(db_connect_info)
         with open("schemas/output.json", "r") as raw_schema:
             schema = json.loads(raw_schema.read())
 


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-280: Update request_status_for_job to use updated shared_db libraries with retry](https://bugs.earthdata.nasa.gov/browse/ORCA-280)

## Changes

* Switched to new DB lib with retries

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tests pass locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] Development documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets