### PR TITLE
ORCA-151: As a developer, the orca bucket should be configurable at the collection level to better organize data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and includes an additional section for migration notes.
 - *ORCA-227* Added modules/secretsmanager directory that contains terraform code for deploying AWS secretsmanager.
 - *ORCA-177* Added AWS API Gateway in modules/api_gateway/main.tf for the request_status_for_granule and request_status_for_job lambdas.
 - *ORCA-257* orca_catalog_reporting lambda now returns data from actual catalog.
-- *ORCA-151* copy_to_glacier and request_files now accept "orcaDefaultBucketOverride" which can be used on a per-collection basis. If desired, add "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}" to the workflow's task's task_config.
+- *ORCA-151* copy_to_glacier and request_files now accept "orcaDefaultBucketOverride" which can be used on a per-collection basis. If desired, add "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}" to the workflow's task's task_config.
 
 ### Changed
 - *ORCA-297* Default database name is now PREFIX_orca

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and includes an additional section for migration notes.
 - *ORCA-227* Added modules/secretsmanager directory that contains terraform code for deploying AWS secretsmanager.
 - *ORCA-177* Added AWS API Gateway in modules/api_gateway/main.tf for the request_status_for_granule and request_status_for_job lambdas.
 - *ORCA-257* orca_catalog_reporting lambda now returns data from actual catalog.
+- *ORCA-151* copy_to_glacier and request_files now accept "orcaDefaultBucketOverride" which can be used on a per-collection basis. If desired, add "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}" to the workflow's task's task_config.
 
 ### Changed
 - *ORCA-297* Default database name is now PREFIX_orca

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ step to anywhere after the MoveGranule step being sure to change the
                   "distribution_endpoint":"{$.meta.distribution_endpoint}",
                   "files_config":"{$.meta.collection.files}",
                   "multipart_chunksize_mb": "{$.meta.collection.multipart_chunksize_mb"},
-                  "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
+                  "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}"
                   "fileStagingDir":"{$.meta.collection.url_path}",
                   "granuleIdExtraction":"{$.meta.collection.granuleIdExtraction}",
                   "collection":"{$.meta.collection}",

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ step to anywhere after the MoveGranule step being sure to change the
                   "distribution_endpoint":"{$.meta.distribution_endpoint}",
                   "files_config":"{$.meta.collection.files}",
                   "multipart_chunksize_mb": "{$.meta.collection.multipart_chunksize_mb"},
+                  "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
                   "fileStagingDir":"{$.meta.collection.url_path}",
                   "granuleIdExtraction":"{$.meta.collection.granuleIdExtraction}",
                   "collection":"{$.meta.collection}",

--- a/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
+++ b/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
@@ -8,7 +8,8 @@
           "event.$": "$",
           "task_config": {
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
-            "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}"
+            "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
+            "collectionBucket": "{$.meta.collection.meta.orca_bucket}"
           }
         }
       },

--- a/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
+++ b/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
@@ -9,7 +9,7 @@
           "task_config": {
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
             "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
-            "orcaBucketOverride": "{$.meta.collection.meta.orca_bucket}"
+            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
           }
         }
       },

--- a/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
+++ b/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
@@ -9,7 +9,7 @@
           "task_config": {
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
             "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
-            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
+            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}"
           }
         }
       },

--- a/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
+++ b/modules/workflows/OrcaCopyToGlacierWorkflow/orca_copy_to_glacier_workflow.asl.json
@@ -9,7 +9,7 @@
           "task_config": {
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
             "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
-            "collectionBucket": "{$.meta.collection.meta.orca_bucket}"
+            "orcaBucketOverride": "{$.meta.collection.meta.orca_bucket}"
           }
         }
       },

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -53,7 +53,7 @@
             "glacier-bucket": "${orca_default_bucket}",
             "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
-            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
+            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}"
           }
         }
       },

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -13,7 +13,8 @@
           "task_config": {
             "file-buckets": "{$.meta.collection.files}",
             "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
-            "buckets": "{$.meta.buckets}"
+            "buckets": "{$.meta.buckets}",
+            "collectionBucket": "{$.meta.collection.meta.orca_bucket}"
           }
         }
       },
@@ -52,7 +53,8 @@
           "task_config": {
             "glacier-bucket": "${orca_default_bucket}",
             "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
-            "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}"
+            "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
+            "collectionBucket": "{$.meta.collection.meta.orca_bucket}"
           }
         }
       },

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -53,7 +53,7 @@
             "glacier-bucket": "${orca_default_bucket}",
             "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
-            "orcaBucketOverride": "{$.meta.collection.meta.orca_bucket}"
+            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
           }
         }
       },

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -50,7 +50,6 @@
             "FullMessage": true
           },
           "task_config": {
-            "glacier-bucket": "${orca_default_bucket}",
             "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
             "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}"

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -13,8 +13,7 @@
           "task_config": {
             "file-buckets": "{$.meta.collection.files}",
             "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
-            "buckets": "{$.meta.buckets}",
-            "collectionBucket": "{$.meta.collection.meta.orca_bucket}"
+            "buckets": "{$.meta.buckets}"
           }
         }
       },

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -53,7 +53,7 @@
             "glacier-bucket": "${orca_default_bucket}",
             "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
-            "collectionBucket": "{$.meta.collection.meta.orca_bucket}"
+            "orcaBucketOverride": "{$.meta.collection.meta.orca_bucket}"
           }
         }
       },

--- a/tasks/copy_to_glacier/README.md
+++ b/tasks/copy_to_glacier/README.md
@@ -240,7 +240,7 @@ These settings can often be derived from the collection configuration in Cumulus
           "task_config": {
             "multipart_chunksize_mb": "{$.meta.collection.multipart_chunksize_mb"},
             "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
-            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
+            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}"
           }
         }
       },

--- a/tasks/copy_to_glacier/README.md
+++ b/tasks/copy_to_glacier/README.md
@@ -333,7 +333,7 @@ DESCRIPTION
     and copies those files from their current storage location into a staging/glacier location.
 
 FUNCTIONS
-    copy_granule_between_buckets(source_bucket_name: str, source_key: str, destination_bucket: str, destination_key: str, multipart_chunksize_mb: int) -> None
+    copy_granule_between_buckets(source_bucket_name: str, source_key: str, destination_bucket: str, destination_key: str, multipart_chunksize_mb: int) -> Dict[str, str]
         Copies granule from source bucket to destination. Also queries the destination_bucket to get additional metadata file info.
         Args:
             source_bucket_name: The name of the bucket in which the granule is currently located.
@@ -342,15 +342,17 @@ FUNCTIONS
             destination_key: Destination granule path excluding s3://[bucket]/
             multipart_chunksize_mb: The maximum size of chunks to use when copying.
         Returns:
-           A dictionary containing all the file metadata needed for reconciliation with Cumulus with the following keys:
-                  "cumulusArchiveLocation" (str): Cumulus S3 bucket where the file is stored in.
-                  "orcaArchiveLocation" (str): ORCA S3 Glacier bucket that the file object is stored in
-                  "keyPath" (str): Full AWS key path including file name of the file where the file resides in ORCA.
-                  "sizeInBytes" (str): Size of the object in bytes
-                  "version" (str): Latest version of the file in the S3 Glacier bucket
-                  "ingestTime" (str): Date and time the file was originally ingested into ORCA.
-                  "etag" (str): etag of the file object in the AWS S3 Glacier bucket.
-        
+            A dictionary containing all the file metadata needed for reconciliation with Cumulus with the following keys:
+                    "cumulusArchiveLocation" (str): Cumulus S3 bucket where the file is stored in.
+                    "orcaArchiveLocation" (str): ORCA S3 Glacier bucket that the file object is stored in
+                    "keyPath" (str): Full AWS key path including file name of the file where the file resides in ORCA.
+                    "sizeInBytes" (str): Size of the object in bytes
+                    "version" (str): Latest version of the file in the S3 Glacier bucket
+                    "ingestTime" (str): Date and time the file was originally ingested into ORCA.
+                    "etag" (str): etag of the file object in the AWS S3 Glacier bucket.
+    
+    get_default_glacier_bucket_name(config: Dict[str, Any]) -> str
+    
     handler(event: Dict[str, Union[List[str], Dict]], context: object) -> Any
         Lambda handler. Runs a cumulus task that
         Copies the files in {event}['input']
@@ -390,7 +392,7 @@ FUNCTIONS
                 ORCA_DEFAULT_BUCKET (string, required): Name of the default ORCA S3 Glacier bucket.
                     Overridden by bucket specified in config.
                 DEFAULT_MULTIPART_CHUNKSIZE_MB (int, optional): The default maximum size of chunks to use when copying.
-                  Can be overridden by collection config.
+                    Can be overridden by collection config.
                 METADATA_DB_QUEUE_URL (string, required): SQS URL of the metadata queue.
         
         Args:
@@ -408,6 +410,9 @@ DATA
     Dict = typing.Dict
     FILE_BUCKET_KEY = 'bucket'
     FILE_FILEPATH_KEY = 'key'
+    FILE_HASH_KEY = 'checksum'
+    FILE_HASH_TYPE_KEY = 'checksumType'
+    LOGGER = <cumulus_logger.CumulusLogger object>
     List = typing.List
     MB = 1048576
     Union = typing.Union

--- a/tasks/copy_to_glacier/copy_to_glacier.py
+++ b/tasks/copy_to_glacier/copy_to_glacier.py
@@ -106,7 +106,7 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
         default_bucket = config.get(CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY)
     except KeyError:
         # TODO: Change this to a logging statement
-        print(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set.")
+        print(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set. Using ORCA_DEFAULT_BUCKET environment value.")
         default_bucket = None
     if default_bucket is None:
         try:

--- a/tasks/copy_to_glacier/copy_to_glacier.py
+++ b/tasks/copy_to_glacier/copy_to_glacier.py
@@ -13,7 +13,7 @@ from run_cumulus_task import run_cumulus_task
 
 CONFIG_MULTIPART_CHUNKSIZE_MB_KEY = 'multipart_chunksize_mb'
 CONFIG_EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
-CONFIG_ORCA_BUCKET_OVERRIDE_KEY = "orcaBucketOverride"
+CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY = "orcaDefaultBucketOverride"
 
 FILE_FILENAME_KEY = "fileName"
 FILE_BUCKET_KEY = "bucket"
@@ -76,6 +76,7 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
 
         Environment Variables:
             ORCA_DEFAULT_BUCKET (string, required): Name of the default ORCA S3 Glacier bucket.
+                Overridden by bucket specified in config.
             DEFAULT_MULTIPART_CHUNKSIZE_MB (int, optional): The default maximum size of chunks to use when copying.
                 Can be overridden by collection config.
 
@@ -102,10 +103,10 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     #      - collection configuration
     #      - default value in buckets
     try:
-        default_bucket = config.get[CONFIG_ORCA_BUCKET_OVERRIDE_KEY]
+        default_bucket = config.get(CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY)
     except KeyError:
         # TODO: Change this to a logging statement
-        print(f"{CONFIG_ORCA_BUCKET_OVERRIDE_KEY} is not set.")
+        print(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set.")
         default_bucket = None
     if default_bucket is None:
         try:

--- a/tasks/copy_to_glacier/copy_to_glacier.py
+++ b/tasks/copy_to_glacier/copy_to_glacier.py
@@ -137,25 +137,7 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     if exclude_file_types is None:
         exclude_file_types = []
 
-    # TODO: Should look at bucket type orca and check for default
-    #      Should also be flexible enough to handle input precedence order of
-    #      - task input
-    #      - collection configuration
-    #      - default value in buckets
-    try:
-        default_bucket = config[CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY]
-    except KeyError:
-        LOGGER.warning(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set. Using ORCA_DEFAULT_BUCKET environment value.")
-        default_bucket = None
-
-    if default_bucket is None:
-        try:
-            default_bucket = os.environ.get("ORCA_DEFAULT_BUCKET", None)
-            if default_bucket is None or len(default_bucket) == 0:
-                raise KeyError("ORCA_DEFAULT_BUCKET environment variable is not set.")
-        except KeyError:
-            LOGGER.error("ORCA_DEFAULT_BUCKET environment variable is not set.")
-            raise
+    default_bucket = get_default_glacier_bucket_name(config)
 
     multipart_chunksize_mb_str = config.get(CONFIG_MULTIPART_CHUNKSIZE_MB_KEY, None)
     if multipart_chunksize_mb_str is None:
@@ -187,7 +169,7 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     sqs_body["provider"]["providerId"] = config["providerId"]
     sqs_body["collection"]["shortname"] = config["collectionShortname"]
     sqs_body["collection"]["version"] = config["collectionVersion"]
-    # Cumulus currently creates collectionId by concating shortname + ___ + version 
+    # Cumulus currently creates collectionId by concating shortname + ___ + version
     # See https://github.com/nasa/cumulus-dashboard/blob/18a278ee5a1ac5181ec035b3df0665ef5acadcb0/app/src/js/utils/format.js#L342
     sqs_body["collection"]["collectionId"] = (
         config["collectionShortname"] + "___" + config["collectionVersion"]
@@ -200,8 +182,9 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
             granule_data[granuleId] = {"granuleId": granuleId, "files": []}
         # populate the SQS body for granules
         sqs_body["granule"]["cumulusGranuleId"] = granuleId
-        sqs_body["granule"]["cumulusCreateTime"] = \
-            datetime.fromtimestamp(granule["createdAt"] / 1000, timezone.utc).isoformat()
+        sqs_body["granule"]["cumulusCreateTime"] = datetime.fromtimestamp(
+            granule["createdAt"] / 1000, timezone.utc
+        ).isoformat()
         sqs_body["granule"]["executionId"] = config["executionId"]
         sqs_body["granule"]["ingestTime"] = datetime.now(timezone.utc).isoformat()
         sqs_body["granule"]["lastUpdate"] = datetime.now(timezone.utc).isoformat()
@@ -221,14 +204,17 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
                     CONFIG_EXCLUDE_FILE_TYPES_KEY=CONFIG_EXCLUDE_FILE_TYPES_KEY,
                 )
                 continue
-            result = copy_granule_between_buckets(source_bucket_name=file_bucket,
-                                                  source_key=file_filepath,
-                                                  destination_bucket=default_bucket,
-                                                  destination_key=file_filepath,
-                                                  multipart_chunksize_mb=multipart_chunksize_mb,
-                                                  )
+            result = copy_granule_between_buckets(
+                source_bucket_name=file_bucket,
+                source_key=file_filepath,
+                destination_bucket=default_bucket,
+                destination_key=file_filepath,
+                multipart_chunksize_mb=multipart_chunksize_mb,
+            )
 
-            result["name"] = file_filepath.split("/")[-1] # since fileName is no longer available in event
+            result["name"] = file_filepath.split("/")[
+                -1
+            ]  # since fileName is no longer available in event
             result["hash"] = file_hash
             result["hashType"] = file_hash_type
             copied_file_urls.append(file_source_uri)
@@ -246,6 +232,27 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
         sqs_library.post_to_metadata_queue(sqs_body, metadata_queue_url)
 
     return {"granules": granules_list, "copied_to_glacier": copied_file_urls}
+
+
+def get_default_glacier_bucket_name(config: Dict[str, Any]) -> str:
+    try:
+        default_bucket = config[CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY]
+    except KeyError:
+        LOGGER.warning(
+            f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set. Using ORCA_DEFAULT_BUCKET environment value."
+        )
+        default_bucket = None
+
+    if default_bucket is None:
+        try:
+            default_bucket = os.environ.get("ORCA_DEFAULT_BUCKET", None)
+            if default_bucket is None or len(default_bucket) == 0:
+                raise KeyError("ORCA_DEFAULT_BUCKET environment variable is not set.")
+        except KeyError:
+            LOGGER.error("ORCA_DEFAULT_BUCKET environment variable is not set.")
+            raise
+
+    return default_bucket
 
 
 # handler that is provided to aws lambda

--- a/tasks/copy_to_glacier/copy_to_glacier.py
+++ b/tasks/copy_to_glacier/copy_to_glacier.py
@@ -13,6 +13,7 @@ from run_cumulus_task import run_cumulus_task
 
 CONFIG_MULTIPART_CHUNKSIZE_MB_KEY = 'multipart_chunksize_mb'
 CONFIG_EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
+CONFIG_COLLECTION_BUCKET_KEY = 'collectionBucket'
 
 FILE_FILENAME_KEY = "fileName"
 FILE_BUCKET_KEY = "bucket"
@@ -100,14 +101,16 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     #      - task input
     #      - collection configuration
     #      - default value in buckets
-    try:
-        default_bucket = os.environ.get('ORCA_DEFAULT_BUCKET', None)
-        if default_bucket is None or len(default_bucket) == 0:
-            raise KeyError('ORCA_DEFAULT_BUCKET environment variable is not set.')
-    except KeyError:
-        # TODO: Change this to a logging statement
-        print('ORCA_DEFAULT_BUCKET environment variable is not set.')
-        raise
+    default_bucket = config.get(CONFIG_COLLECTION_BUCKET_KEY, None)
+    if default_bucket is None:
+        try:
+            default_bucket = os.environ.get('ORCA_DEFAULT_BUCKET', None)
+            if default_bucket is None or len(default_bucket) == 0:
+                raise KeyError('ORCA_DEFAULT_BUCKET environment variable is not set.')
+        except KeyError:
+            # TODO: Change this to a logging statement
+            print('ORCA_DEFAULT_BUCKET environment variable is not set.')
+            raise
 
     multipart_chunksize_mb_str = config.get(CONFIG_MULTIPART_CHUNKSIZE_MB_KEY, None)
     if multipart_chunksize_mb_str is None:

--- a/tasks/copy_to_glacier/copy_to_glacier.py
+++ b/tasks/copy_to_glacier/copy_to_glacier.py
@@ -13,7 +13,7 @@ from run_cumulus_task import run_cumulus_task
 
 CONFIG_MULTIPART_CHUNKSIZE_MB_KEY = 'multipart_chunksize_mb'
 CONFIG_EXCLUDE_FILE_TYPES_KEY = 'excludeFileTypes'
-CONFIG_COLLECTION_BUCKET_KEY = 'collectionBucket'
+CONFIG_ORCA_BUCKET_OVERRIDE_KEY = "orcaBucketOverride"
 
 FILE_FILENAME_KEY = "fileName"
 FILE_BUCKET_KEY = "bucket"
@@ -101,7 +101,12 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     #      - task input
     #      - collection configuration
     #      - default value in buckets
-    default_bucket = config.get(CONFIG_COLLECTION_BUCKET_KEY, None)
+    try:
+        default_bucket = config.get[CONFIG_ORCA_BUCKET_OVERRIDE_KEY]
+    except KeyError:
+        # TODO: Change this to a logging statement
+        print(f"{CONFIG_ORCA_BUCKET_OVERRIDE_KEY} is not set.")
+        default_bucket = None
     if default_bucket is None:
         try:
             default_bucket = os.environ.get('ORCA_DEFAULT_BUCKET', None)

--- a/tasks/copy_to_glacier/schemas/config.json
+++ b/tasks/copy_to_glacier/schemas/config.json
@@ -16,6 +16,10 @@
     "multipart_chunksize_mb": {
       "type": ["integer", "null"],
       "description": "The collection's maximum size of chunks to use when copying. Defaults to environment variable."
+    },
+    "orcaDefaultBucketOverride": {
+      "type": ["string", "null"],
+      "description": "Overrides the default bucket to copy to in os.environ['ORCA_DEFAULT_BUCKET']."
     }
   }
 }

--- a/tasks/copy_to_glacier/test/unit_tests/test_copy_to_glacier.py
+++ b/tasks/copy_to_glacier/test/unit_tests/test_copy_to_glacier.py
@@ -3,8 +3,6 @@ import json
 import random
 import unittest
 import uuid
-from test.helpers import LambdaContextMock
-from test.unit_tests.ConfigCheck import ConfigCheck
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, call, patch, ANY
 
@@ -12,8 +10,9 @@ import fastjsonschema as fastjsonschema
 from moto import mock_sqs
 
 import copy_to_glacier
-import sqs_library
 from copy_to_glacier import *
+from test.helpers import LambdaContextMock
+from test.unit_tests.ConfigCheck import ConfigCheck
 
 
 class TestCopyToGlacierHandler(TestCase):
@@ -36,7 +35,7 @@ class TestCopyToGlacierHandler(TestCase):
                 "granuleId": "MOD09GQ.A2017025.h21v00.006.2017034065109",
                 "dataType": "MOD09GQ",
                 "version": "006",
-                "createdAt": 628021800000, 
+                "createdAt": 628021800000,
                 "files": [
                     {
                         "path": "MOD09GQ/006",
@@ -57,7 +56,7 @@ class TestCopyToGlacierHandler(TestCase):
                         copy_to_glacier.FILE_BUCKET_KEY: "orca-sandbox-private",
                         "url_path": "MOD09GQ/006",
                         "type": "",
-                        copy_to_glacier.FILE_FILEPATH_KEY: "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf", 
+                        copy_to_glacier.FILE_FILEPATH_KEY: "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
                         "duplicate_found": True,
                         "checksumType": "md5",
                         "checksum": "bogus_checksum_value",
@@ -147,7 +146,7 @@ class TestCopyToGlacierHandler(TestCase):
                             copy_to_glacier.FILE_BUCKET_KEY: uuid.uuid4().__str__(),
                             copy_to_glacier.FILE_FILEPATH_KEY: uuid.uuid4().__str__(),
                         }
-                    ]
+                    ],
                 }
             ],
             "copied_to_glacier": [uuid.uuid4().__str__()],
@@ -175,28 +174,33 @@ class TestCopyToGlacierHandler(TestCase):
         )
         self.assertEqual(not_excluded_flag, False)
 
+    @patch("copy_to_glacier.get_default_glacier_bucket_name")
     @patch("copy_to_glacier.sqs_library.post_to_metadata_queue")
     @patch.dict(
         os.environ,
         {
-            "ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__(),
             "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
             "METADATA_DB_QUEUE_URL": "test",
             "AWS_REGION": "us-west-2",
         },
         clear=True,
     )
-    def test_task_happy_path(self, mock_post_to_queue: MagicMock):
+    def test_task_happy_path(
+        self,
+        mock_post_to_queue: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         Basic path with buckets present.
         """
-        destination_bucket_name = os.environ["ORCA_DEFAULT_BUCKET"]
         content_type = uuid.uuid4().__str__()
         source_bucket_names = [
-            file[copy_to_glacier.FILE_BUCKET_KEY] for file in self.event_granules["granules"][0]["files"]
+            file[copy_to_glacier.FILE_BUCKET_KEY]
+            for file in self.event_granules["granules"][0]["files"]
         ]
         source_keys = [
-            file[copy_to_glacier.FILE_FILEPATH_KEY] for file in self.event_granules["granules"][0]["files"]
+            file[copy_to_glacier.FILE_FILEPATH_KEY]
+            for file in self.event_granules["granules"][0]["files"]
         ]
 
         config_check = ConfigCheck(4 * MB)
@@ -219,17 +223,20 @@ class TestCopyToGlacierHandler(TestCase):
             ]
         }
         s3_cli.list_object_versions = Mock(return_value=file_return_value)
+        config = {
+            "providerId": "test",
+            "executionId": "test-execution-id",
+            "collectionShortname": "MOD09GQ",
+            "collectionVersion": uuid.uuid4().__str__(),
+        }
         event = {
             "input": copy.deepcopy(self.event_granules),
-            "config": {
-                "providerId": "test",
-                "executionId": "test-execution-id",
-                "collectionShortname": "MOD09GQ",
-                "collectionVersion": uuid.uuid4().__str__(),
-            },
+            "config": config,
         }
 
         result = task(copy.deepcopy(event), None)
+
+        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
         with open("schemas/output.json", "r") as raw_schema:
             schema = json.loads(raw_schema.read())
@@ -249,7 +256,7 @@ class TestCopyToGlacierHandler(TestCase):
             copy_calls.append(
                 call(
                     {"Bucket": source_bucket_names[i], "Key": source_keys[i]},
-                    destination_bucket_name,
+                    mock_get_default_glacier_bucket_name.return_value,
                     source_keys[i],
                     ExtraArgs={
                         "StorageClass": "GLACIER",
@@ -286,7 +293,7 @@ class TestCopyToGlacierHandler(TestCase):
                         "cumulusArchiveLocation": event["input"]["granules"][0][
                             "files"
                         ][0]["bucket"],
-                        "orcaArchiveLocation": os.environ["ORCA_DEFAULT_BUCKET"],
+                        "orcaArchiveLocation": mock_get_default_glacier_bucket_name.return_value,
                         "keyPath": event["input"]["granules"][0]["files"][0][
                             copy_to_glacier.FILE_FILEPATH_KEY
                         ],
@@ -294,8 +301,12 @@ class TestCopyToGlacierHandler(TestCase):
                         "version": ANY,
                         "ingestTime": ANY,
                         "etag": ANY,
-                        "name": event["input"]["granules"][0]["files"][0][copy_to_glacier.FILE_FILEPATH_KEY].split("/")[-1],
-                        "hash": event["input"]["granules"][0]["files"][0][copy_to_glacier.FILE_HASH_KEY],
+                        "name": event["input"]["granules"][0]["files"][0][
+                            copy_to_glacier.FILE_FILEPATH_KEY
+                        ].split("/")[-1],
+                        "hash": event["input"]["granules"][0]["files"][0][
+                            copy_to_glacier.FILE_HASH_KEY
+                        ],
                         "hashType": event["input"]["granules"][0]["files"][0][
                             copy_to_glacier.FILE_HASH_TYPE_KEY
                         ],
@@ -304,7 +315,7 @@ class TestCopyToGlacierHandler(TestCase):
                         "cumulusArchiveLocation": event["input"]["granules"][0][
                             "files"
                         ][1]["bucket"],
-                        "orcaArchiveLocation": os.environ["ORCA_DEFAULT_BUCKET"],
+                        "orcaArchiveLocation": mock_get_default_glacier_bucket_name.return_value,
                         "keyPath": event["input"]["granules"][0]["files"][1][
                             copy_to_glacier.FILE_FILEPATH_KEY
                         ],
@@ -312,8 +323,12 @@ class TestCopyToGlacierHandler(TestCase):
                         "version": ANY,
                         "ingestTime": ANY,
                         "etag": ANY,
-                        "name": event["input"]["granules"][0]["files"][1][copy_to_glacier.FILE_FILEPATH_KEY].split("/")[-1],
-                        "hash": event["input"]["granules"][0]["files"][1][copy_to_glacier.FILE_HASH_KEY],
+                        "name": event["input"]["granules"][0]["files"][1][
+                            copy_to_glacier.FILE_FILEPATH_KEY
+                        ].split("/")[-1],
+                        "hash": event["input"]["granules"][0]["files"][1][
+                            copy_to_glacier.FILE_HASH_KEY
+                        ],
                         "hashType": event["input"]["granules"][0]["files"][1][
                             copy_to_glacier.FILE_HASH_TYPE_KEY
                         ],
@@ -322,7 +337,7 @@ class TestCopyToGlacierHandler(TestCase):
                         "cumulusArchiveLocation": event["input"]["granules"][0][
                             "files"
                         ][2]["bucket"],
-                        "orcaArchiveLocation": os.environ["ORCA_DEFAULT_BUCKET"],
+                        "orcaArchiveLocation": mock_get_default_glacier_bucket_name.return_value,
                         "keyPath": event["input"]["granules"][0]["files"][2][
                             copy_to_glacier.FILE_FILEPATH_KEY
                         ],
@@ -330,8 +345,12 @@ class TestCopyToGlacierHandler(TestCase):
                         "version": ANY,
                         "ingestTime": ANY,
                         "etag": ANY,
-                        "name": event["input"]["granules"][0]["files"][2][copy_to_glacier.FILE_FILEPATH_KEY].split("/")[-1],
-                        "hash": event["input"]["granules"][0]["files"][2][copy_to_glacier.FILE_HASH_KEY],
+                        "name": event["input"]["granules"][0]["files"][2][
+                            copy_to_glacier.FILE_FILEPATH_KEY
+                        ].split("/")[-1],
+                        "hash": event["input"]["granules"][0]["files"][2][
+                            copy_to_glacier.FILE_HASH_KEY
+                        ],
                         "hashType": event["input"]["granules"][0]["files"][2][
                             copy_to_glacier.FILE_HASH_TYPE_KEY
                         ],
@@ -340,7 +359,7 @@ class TestCopyToGlacierHandler(TestCase):
                         "cumulusArchiveLocation": event["input"]["granules"][0][
                             "files"
                         ][3]["bucket"],
-                        "orcaArchiveLocation": os.environ["ORCA_DEFAULT_BUCKET"],
+                        "orcaArchiveLocation": mock_get_default_glacier_bucket_name.return_value,
                         "keyPath": event["input"]["granules"][0]["files"][3][
                             copy_to_glacier.FILE_FILEPATH_KEY
                         ],
@@ -348,8 +367,12 @@ class TestCopyToGlacierHandler(TestCase):
                         "version": ANY,
                         "ingestTime": ANY,
                         "etag": ANY,
-                        "name": event["input"]["granules"][0]["files"][0][copy_to_glacier.FILE_FILEPATH_KEY].split("/")[-1],
-                        "hash": event["input"]["granules"][0]["files"][3][copy_to_glacier.FILE_HASH_KEY],
+                        "name": event["input"]["granules"][0]["files"][0][
+                            copy_to_glacier.FILE_FILEPATH_KEY
+                        ].split("/")[-1],
+                        "hash": event["input"]["granules"][0]["files"][3][
+                            copy_to_glacier.FILE_HASH_KEY
+                        ],
                         "hashType": event["input"]["granules"][0]["files"][3][
                             copy_to_glacier.FILE_HASH_TYPE_KEY
                         ],
@@ -375,18 +398,22 @@ class TestCopyToGlacierHandler(TestCase):
         self.assertEqual(expected_granules, result["granules"])
         self.assertIsNone(config_check.bad_config)
 
+    @patch("copy_to_glacier.get_default_glacier_bucket_name")
     @patch("copy_to_glacier.sqs_library.post_to_metadata_queue")
     @patch.dict(
         os.environ,
         {
-            "ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__(),
             "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
             "METADATA_DB_QUEUE_URL": "test",
             "AWS_REGION": "us-west-2",
         },
         clear=True,
     )
-    def test_task_happy_path_multiple_granules(self, mock_post_to_queue: MagicMock):
+    def test_task_happy_path_multiple_granules(
+        self,
+        mock_post_to_queue: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         Happy path for multiple granules in input.
         """
@@ -434,13 +461,14 @@ class TestCopyToGlacierHandler(TestCase):
                 },
             ]
         }
-        destination_bucket_name = os.environ["ORCA_DEFAULT_BUCKET"]
         content_type = uuid.uuid4().__str__()
         source_bucket_names = [
-            file[copy_to_glacier.FILE_BUCKET_KEY] for file in multiple_event_granules["granules"][0]["files"]
+            file[copy_to_glacier.FILE_BUCKET_KEY]
+            for file in multiple_event_granules["granules"][0]["files"]
         ]
         source_keys = [
-            file[copy_to_glacier.FILE_FILEPATH_KEY] for file in multiple_event_granules["granules"][0]["files"]
+            file[copy_to_glacier.FILE_FILEPATH_KEY]
+            for file in multiple_event_granules["granules"][0]["files"]
         ]
 
         config_check = ConfigCheck(4 * MB)
@@ -462,17 +490,20 @@ class TestCopyToGlacierHandler(TestCase):
             ]
         }
         s3_cli.list_object_versions = Mock(return_value=file_return_value)
+        config = {
+            "providerId": "test",
+            "executionId": "test-execution-id",
+            "collectionShortname": "MOD09GQ",
+            "collectionVersion": uuid.uuid4().__str__(),
+        }
         event = {
             "input": copy.deepcopy(multiple_event_granules),
-            "config": {
-                "providerId": "test",
-                "executionId": "test-execution-id",
-                "collectionShortname": "MOD09GQ",
-                "collectionVersion": uuid.uuid4().__str__(),
-            },
+            "config": config,
         }
 
         result = task(event, None)
+
+        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
         with open("schemas/output.json", "r") as raw_schema:
             schema = json.loads(raw_schema.read())
@@ -492,7 +523,7 @@ class TestCopyToGlacierHandler(TestCase):
             copy_calls.append(
                 call(
                     {"Bucket": source_bucket_names[i], "Key": source_keys[i]},
-                    destination_bucket_name,
+                    mock_get_default_glacier_bucket_name.return_value,
                     source_keys[i],
                     ExtraArgs={
                         "StorageClass": "GLACIER",
@@ -512,29 +543,34 @@ class TestCopyToGlacierHandler(TestCase):
         self.assertEqual(s3_cli.list_object_versions.call_count, 2)
         self.assertEqual(multiple_event_granules["granules"], result["granules"])
 
+    @patch("copy_to_glacier.get_default_glacier_bucket_name")
     @patch("copy_to_glacier.sqs_library.post_to_metadata_queue")
     @patch.dict(
         os.environ,
         {
-            "ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__(),
             "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
             "METADATA_DB_QUEUE_URL": "test",
             "AWS_REGION": "us-west-2",
         },
         clear=True,
     )
-    def test_task_overridden_multipart_chunksize(self, mock_post_to_queue: MagicMock):
+    def test_task_overridden_multipart_chunksize(
+        self,
+        mock_post_to_queue: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         If the collection has a different multipart chunksize, it should override the default.
         """
         overridden_multipart_chunksize_mb = 5
-        destination_bucket_name = os.environ["ORCA_DEFAULT_BUCKET"]
         content_type = uuid.uuid4().__str__()
         source_bucket_names = [
-            file[copy_to_glacier.FILE_BUCKET_KEY] for file in self.event_granules["granules"][0]["files"]
+            file[copy_to_glacier.FILE_BUCKET_KEY]
+            for file in self.event_granules["granules"][0]["files"]
         ]
         source_keys = [
-            file[copy_to_glacier.FILE_FILEPATH_KEY] for file in self.event_granules["granules"][0]["files"]
+            file[copy_to_glacier.FILE_FILEPATH_KEY]
+            for file in self.event_granules["granules"][0]["files"]
         ]
 
         config_check = ConfigCheck(overridden_multipart_chunksize_mb * MB)
@@ -557,20 +593,21 @@ class TestCopyToGlacierHandler(TestCase):
             ]
         }
         s3_cli.list_object_versions = Mock(return_value=file_return_value)
+        config = {
+            CONFIG_MULTIPART_CHUNKSIZE_MB_KEY: str(overridden_multipart_chunksize_mb),
+            "providerId": "test",
+            "executionId": "test-execution-id",
+            "collectionShortname": "MOD09GQ",
+            "collectionVersion": uuid.uuid4().__str__(),
+        }
         event = {
             "input": copy.deepcopy(self.event_granules),
-            "config": {
-                CONFIG_MULTIPART_CHUNKSIZE_MB_KEY: str(
-                    overridden_multipart_chunksize_mb
-                ),
-                "providerId": "test",
-                "executionId": "test-execution-id",
-                "collectionShortname": "MOD09GQ",
-                "collectionVersion": uuid.uuid4().__str__(),
-            },
+            "config": config,
         }
 
         result = task(copy.deepcopy(event), None)
+
+        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
         with open("schemas/output.json", "r") as raw_schema:
             schema = json.loads(raw_schema.read())
@@ -590,7 +627,7 @@ class TestCopyToGlacierHandler(TestCase):
             copy_calls.append(
                 call(
                     {"Bucket": source_bucket_names[i], "Key": source_keys[i]},
-                    destination_bucket_name,
+                    mock_get_default_glacier_bucket_name.return_value,
                     source_keys[i],
                     ExtraArgs={
                         "StorageClass": "GLACIER",
@@ -617,95 +654,15 @@ class TestCopyToGlacierHandler(TestCase):
         self.assertEqual(expected_granules, result["granules"])
         self.assertIsNone(config_check.bad_config)
 
+    @patch("copy_to_glacier.get_default_glacier_bucket_name")
     @patch.dict(
         os.environ,
-        {
-            "ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__(),
-            "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
-            "METADATA_DB_QUEUE_URL": "test",
-        },
+        {"DEFAULT_MULTIPART_CHUNKSIZE_MB": "4", "METADATA_DB_QUEUE_URL": "test"},
         clear=True,
     )
-    def test_task_overridden_default_bucket(self):
-        """
-        If the default bucket is overridden, the override should be respected.
-        """
-        destination_bucket_name = uuid.uuid4().__str__()
-        content_type = uuid.uuid4().__str__()
-        source_bucket_names = [
-            file[copy_to_glacier.FILE_BUCKET_KEY] for file in self.event_granules["granules"][0]["files"]
-        ]
-        source_keys = [
-            file[copy_to_glacier.FILE_FILEPATH_KEY] for file in self.event_granules["granules"][0]["files"]
-        ]
-
-        config_check = ConfigCheck(4 * MB)
-
-        # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
-        boto3.client = Mock()
-        s3_cli = boto3.client("s3")
-        s3_cli.copy = Mock(return_value=None)
-        s3_cli.copy.side_effect = config_check.check_multipart_chunksize
-        s3_cli.head_object = Mock(return_value={"ContentType": content_type})
-
-        event = {"input": copy.deepcopy(self.event_granules),
-                 "config": {copy_to_glacier.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: destination_bucket_name}}
-
-        result = task(copy.deepcopy(event), None)
-
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result)
-
-        expected_granules = copy.deepcopy(event["input"]["granules"])
-        self.assertEqual(expected_granules, result["granules"])
-
-        head_object_calls = []
-        copy_calls = []
-        for i in range(0, len(source_bucket_names)):
-            head_object_calls.append(
-                call(Bucket=source_bucket_names[i], Key=source_keys[i])
-            )
-            copy_calls.append(
-                call(
-                    {"Bucket": source_bucket_names[i], "Key": source_keys[i]},
-                    destination_bucket_name,
-                    source_keys[i],
-                    ExtraArgs={
-                        "StorageClass": "GLACIER",
-                        "MetadataDirective": "COPY",
-                        "ContentType": content_type,
-                        "ACL": "bucket-owner-full-control",
-                    },
-                    Config=unittest.mock.ANY,  # Checked by ConfigCheck. Equality checkers do not work.
-                )
-            )
-
-        s3_cli.head_object.assert_has_calls(head_object_calls)
-        s3_cli.copy.assert_has_calls(copy_calls)
-
-        self.assertEqual(s3_cli.head_object.call_count, 4)
-        self.assertEqual(s3_cli.copy.call_count, 4)
-
-        expected_copied_file_urls = [
-            file[copy_to_glacier.FILE_SOURCE_URI_KEY] for file in self.event_granules["granules"][0]["files"]
-        ]
-        self.assertEqual(expected_copied_file_urls, result["copied_to_glacier"])
-        expected_granules = copy.deepcopy(event["input"]["granules"])
-        self.assertEqual(expected_granules, result["granules"])
-        self.assertIsNone(config_check.bad_config)
-
-    @patch.dict(
-        os.environ,
-        {
-            "ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__(),
-            "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
-        },
-        clear=True,
-    )
-    def test_task_empty_granules_list(self):
+    def test_task_empty_granules_list(
+        self, mock_get_default_glacier_bucket_name: MagicMock
+    ):
         """
         Basic path with buckets present.
         """
@@ -715,17 +672,20 @@ class TestCopyToGlacierHandler(TestCase):
         s3_cli.copy = Mock()
         s3_cli.head_object = Mock()
 
+        config = {
+            "providerId": "test",
+            "executionId": "test-execution-id",
+            "collectionShortname": "MOD09GQ",
+            "collectionVersion": uuid.uuid4().__str__(),
+        }
         event = {
             "input": {"granules": []},
-            "config": {
-                "providerId": "test",
-                "executionId": "test-execution-id",
-                "collectionShortname": "MOD09GQ",
-                "collectionVersion": uuid.uuid4().__str__(),
-            },
+            "config": config,
         }
 
         result = task(copy.deepcopy(event), None)
+
+        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
         with open("schemas/output.json", "r") as raw_schema:
             schema = json.loads(raw_schema.read())
@@ -740,27 +700,51 @@ class TestCopyToGlacierHandler(TestCase):
         s3_cli.head_object.assert_not_called()
         s3_cli.copy.assert_not_called()
 
-    @patch.dict(os.environ, {"ORCA_DEFAULT_BUCKET": ""}, clear=True)
-    def test_task_invalid_environment_variable(self):
-        """
-        Checks to make sure an unset or empty environment variable throws an error
-        """
-        content_type = uuid.uuid4().__str__()
+    @patch.dict(
+        os.environ,
+        {"ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__()},
+        clear=True,
+    )
+    def test_get_default_glacier_bucket_name_returns_override_if_present(self):
+        bucket = Mock()
+        result = copy_to_glacier.get_default_glacier_bucket_name(
+            {copy_to_glacier.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: bucket}
+        )
+        self.assertEqual(bucket, result)
 
-        # todo: use 'side_effect' to verify args. It is safer, as current method does not deep-copy args
-        boto3.client = Mock()
-        s3_cli = boto3.client("s3")
-        s3_cli.copy = Mock(return_value=None)
-        s3_cli.head_object = Mock(return_value={"ContentType": content_type})
+    @patch.dict(
+        os.environ,
+        {"ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__()},
+        clear=True,
+    )
+    def test_get_default_glacier_bucket_name_returns_default_bucket_if_none_override(
+        self,
+    ):
+        bucket = os.environ["ORCA_DEFAULT_BUCKET"]
+        result = copy_to_glacier.get_default_glacier_bucket_name(
+            {copy_to_glacier.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None}
+        )
+        self.assertEqual(bucket, result)
 
-        event = {"input": copy.deepcopy(self.event_granules), "config": {}}
-
-        with self.assertRaises(KeyError) as context:
-            task(copy.deepcopy(event), None)
-            self.assertTrue(
-                "ORCA_DEFAULT_BUCKET environment variable is not set."
-                in str(context.exception)
+    def test_no_bucket_raises_error(self):
+        with self.assertRaises(KeyError) as cm:
+            copy_to_glacier.get_default_glacier_bucket_name(
+                {copy_to_glacier.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None}
             )
+
+
+@patch.dict(
+    os.environ,
+    {"ORCA_DEFAULT_BUCKET": uuid.uuid4().__str__()},
+    clear=True,
+)
+def test_get_default_glacier_bucket_name_returns_env_bucket_if_no_other(self):
+    bucket = os.environ["ORCA_DEFAULT_BUCKET"]
+    result = copy_to_glacier.get_default_glacier_bucket_name(
+        {copy_to_glacier.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None}
+    )
+    self.assertEqual(bucket, result)
+
     @patch("time.sleep")
     @patch.dict(os.environ, {"AWS_REGION": "us-west-2"}, clear=True)
     def test_post_to_metadata_queue_happy_path(self, mock_sleep: MagicMock):

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -14,7 +14,6 @@ from typing import List
 LOGGER = CumulusLogger(name="ORCA")
 
 EXCLUDE_FILE_TYPES_KEY = "excludeFileTypes"
-CONFIG_COLLECTION_BUCKET_KEY = 'collectionBucket'
 
 
 class ExtractFilePathsError(Exception):
@@ -55,11 +54,7 @@ def task(event, context):  # pylint: disable-msg=unused-argument
         raise KeyError(message.format(key=ke, config=config))
     result = {}
     try:
-        default_bucket = config.get(CONFIG_COLLECTION_BUCKET_KEY, None)
-        if default_bucket is None:
-            regex_buckets = get_regex_buckets(event)
-        else:
-            regex_buckets = [{"regex": "*", "sampleFileName": "Overridden bucket applies to all files.", "bucket": default_bucket}]
+        regex_buckets = get_regex_buckets(event)
         level = "event['input']"
         grans = []
         for ev_granule in event["input"]["granules"]:

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -14,6 +14,7 @@ from typing import List
 LOGGER = CumulusLogger(name="ORCA")
 
 EXCLUDE_FILE_TYPES_KEY = "excludeFileTypes"
+CONFIG_COLLECTION_BUCKET_KEY = 'collectionBucket'
 
 
 class ExtractFilePathsError(Exception):
@@ -54,7 +55,11 @@ def task(event, context):  # pylint: disable-msg=unused-argument
         raise KeyError(message.format(key=ke, config=config))
     result = {}
     try:
-        regex_buckets = get_regex_buckets(event)
+        default_bucket = config.get(CONFIG_COLLECTION_BUCKET_KEY, None)
+        if default_bucket is None:
+            regex_buckets = get_regex_buckets(event)
+        else:
+            regex_buckets = [{"regex": "*", "sampleFileName": "Overridden bucket applies to all files.", "bucket": default_bucket}]
         level = "event['input']"
         grans = []
         for ev_granule in event["input"]["granules"]:

--- a/tasks/request_files/README.md
+++ b/tasks/request_files/README.md
@@ -281,10 +281,11 @@ FUNCTIONS
 
 DATA
     Any = typing.Any
-    COLLECTION_MULTIPART_CHUNKSIZE_MB_KEY = 'multipart_chunksize_mb'
     CONFIG_COLLECTION_KEY = 'collection'
     CONFIG_GLACIER_BUCKET_KEY = 'glacier-bucket'
     CONFIG_JOB_ID_KEY = 'asyncOperationId'
+    CONFIG_MULTIPART_CHUNKSIZE_MB_KEY = 'multipart_chunksize_mb'
+    CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY = 'orcaDefaultBucketOverride'
     DEFAULT_MAX_REQUEST_RETRIES = 2
     DEFAULT_RESTORE_EXPIRE_DAYS = 5
     DEFAULT_RESTORE_RETRIEVAL_TYPE = 'Standard'

--- a/tasks/request_files/README.md
+++ b/tasks/request_files/README.md
@@ -155,8 +155,8 @@ FUNCTIONS
                 Note that because we are using CumulusMessageAdapter, this may not directly correspond to Lambda input.
                 event: A dict with the following keys:
                     'config' (dict): A dict with the following keys:
-                        'glacier-bucket' (str): The name of the glacier bucket from which the files
-                        will be restored. Defaults to OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY
+                        'orcaDefaultBucketOverride' (str): The name of the glacier bucket from which the files
+                        will be restored.
                         'asyncOperationId' (str): The unique identifier used for tracking requests.
                     'input' (dict): A dict with the following keys:
                         'granules' (list(dict)): A list of dicts with the following keys:
@@ -242,8 +242,8 @@ FUNCTIONS
                 Note that because we are using CumulusMessageAdapter, this may not directly correspond to Lambda input.
                 event: A dict with the following keys:
                     'config' (dict): A dict with the following keys:
-                        'glacier-bucket' (str): The name of the glacier bucket from which the files
-                        will be restored.
+                        'orcaDefaultBucketOverride' (str): The name of the glacier bucket from which the files
+                        will be restored. Defaults to os.environ['ORCA_DEFAULT_BUCKET']
                         'job_id' (str): The unique identifier used for tracking requests. If not present, will be generated.
                     'input' (dict): A dict with the following keys:
                         'granules' (list(dict)): A list of dicts with the following keys:
@@ -282,7 +282,6 @@ FUNCTIONS
 DATA
     Any = typing.Any
     CONFIG_COLLECTION_KEY = 'collection'
-    CONFIG_GLACIER_BUCKET_KEY = 'glacier-bucket'
     CONFIG_JOB_ID_KEY = 'asyncOperationId'
     CONFIG_MULTIPART_CHUNKSIZE_MB_KEY = 'multipart_chunksize_mb'
     CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY = 'orcaDefaultBucketOverride'

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -67,7 +67,7 @@ class RestoreRequestError(Exception):
 
 # noinspection PyUnusedLocal
 def task(
-        event: Dict, context: object
+    event: Dict, context: object
 ) -> Dict[str, Any]:  # pylint: disable-msg=unused-argument
     """
     Pulls information from os.environ, utilizing defaults if needed.
@@ -151,8 +151,11 @@ def task(
     db_queue_url = str(os.environ[OS_ENVIRON_DB_QUEUE_URL_KEY])
 
     # Use the default glacier bucket if none is specified for the collection or otherwise given.
-    event[EVENT_CONFIG_KEY][CONFIG_GLACIER_BUCKET_KEY] = get_default_glacier_bucket_name(
-        event[EVENT_CONFIG_KEY])  # todo: pass this in as parameter instead of adjusting config dictionary.
+    event[EVENT_CONFIG_KEY][
+        CONFIG_GLACIER_BUCKET_KEY
+    ] = get_default_glacier_bucket_name(
+        event[EVENT_CONFIG_KEY]
+    )  # todo: pass this in as parameter instead of adjusting config dictionary.
 
     # Get number of days to keep before it sinks back down into glacier from S3
     try:
@@ -179,12 +182,12 @@ def task(
 
 
 def inner_task(
-        event: Dict,
-        max_retries: int,
-        retry_sleep_secs: float,
-        retrieval_type: str,
-        restore_expire_days: int,
-        db_queue_url: str
+    event: Dict,
+    max_retries: int,
+    retry_sleep_secs: float,
+    retrieval_type: str,
+    restore_expire_days: int,
+    db_queue_url: str,
 ) -> Dict[str, Any]:  # pylint: disable-msg=unused-argument
     """
     Task called by the handler to perform the work.
@@ -237,11 +240,11 @@ def inner_task(
         )
 
     # Get the collection's multipart_chunksize from the event.
-    collection_multipart_chunksize_mb_str = \
-        event[EVENT_CONFIG_KEY].get(CONFIG_MULTIPART_CHUNKSIZE_MB_KEY, None)
+    collection_multipart_chunksize_mb_str = event[EVENT_CONFIG_KEY].get(
+        CONFIG_MULTIPART_CHUNKSIZE_MB_KEY, None
+    )
     if collection_multipart_chunksize_mb_str is None:
-        LOGGER.info(
-            f'{CONFIG_MULTIPART_CHUNKSIZE_MB_KEY} is not set for config.')
+        LOGGER.info(f"{CONFIG_MULTIPART_CHUNKSIZE_MB_KEY} is not set for config.")
         collection_multipart_chunksize_mb = None
     else:
         collection_multipart_chunksize_mb = int(collection_multipart_chunksize_mb_str)
@@ -311,7 +314,9 @@ def inner_task(
                 # todo: Workaround for CumulusLogger bug with dictionaries
                 #       this will need updating when a new CumulusLogger is
                 #       released with bug fix.
-                msg = f"Ran into error posting to SQS {retry + 1} time(s) with exception"
+                msg = (
+                    f"Ran into error posting to SQS {retry + 1} time(s) with exception"
+                )
                 msg = msg + " {ex}"
                 LOGGER.error(msg, ex=str(ex))
                 # todo: Use backoff code. ORCA-201
@@ -356,8 +361,7 @@ def get_default_glacier_bucket_name(config: Dict[str, Any]) -> str:
         if default_bucket is not None:
             return default_bucket
     except KeyError:
-        LOGGER.warn(
-            f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set.")
+        LOGGER.warn(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set.")
     return config.get(
         CONFIG_GLACIER_BUCKET_KEY,
         str(os.environ[OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]),
@@ -365,15 +369,15 @@ def get_default_glacier_bucket_name(config: Dict[str, Any]) -> str:
 
 
 def process_granule(
-        s3: BaseClient,
-        granule: Dict[str, Union[str, List[Dict]]],
-        glacier_bucket: str,
-        restore_expire_days: int,
-        max_retries: int,
-        retry_sleep_secs: float,
-        retrieval_type: str,
-        job_id: str,
-        db_queue_url: str,
+    s3: BaseClient,
+    granule: Dict[str, Union[str, List[Dict]]],
+    glacier_bucket: str,
+    restore_expire_days: int,
+    max_retries: int,
+    retry_sleep_secs: float,
+    retrieval_type: str,
+    job_id: str,
+    db_queue_url: str,
 ) -> None:  # pylint: disable-msg=unused-argument
     """Call restore_object for the files in the granule_list. Modifies granule for output.
     Args:
@@ -440,8 +444,8 @@ def process_granule(
         if attempt <= max_retries + 1:
             # Check for early completion.
             if all(
-                    a_file[FILE_SUCCESS_KEY]
-                    for a_file in granule[GRANULE_RECOVER_FILES_KEY]
+                a_file[FILE_SUCCESS_KEY]
+                for a_file in granule[GRANULE_RECOVER_FILES_KEY]
             ):
                 break
             # No early completion sleep and try again
@@ -527,7 +531,7 @@ def object_exists(s3_cli: BaseClient, glacier_bucket: str, file_key: str) -> boo
         code = err.response["Error"]["Code"]
         message = err.response["Error"]["Message"]
         if (
-                message == "NoSuchKey" or message == "Not Found" or code == "404"
+            message == "NoSuchKey" or message == "Not Found" or code == "404"
         ):  # Unit tests say 'Not Found', some online docs say 'NoSuchKey'
             return False
         raise
@@ -535,13 +539,13 @@ def object_exists(s3_cli: BaseClient, glacier_bucket: str, file_key: str) -> boo
 
 
 def restore_object(
-        s3_cli: BaseClient,
-        key: str,
-        days: int,
-        db_glacier_bucket_key: str,
-        attempt: int,
-        job_id: str,
-        retrieval_type: str = "Standard",
+    s3_cli: BaseClient,
+    key: str,
+    days: int,
+    db_glacier_bucket_key: str,
+    attempt: int,
+    job_id: str,
+    retrieval_type: str = "Standard",
 ) -> None:
     # noinspection SpellCheckingInspection
     """Restore an archived S3 Glacier object in an Amazon S3 bucket.

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -154,7 +154,7 @@ def task(
     try:
         orca_bucket = event[EVENT_CONFIG_KEY][CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY]
     except KeyError:
-        LOGGER.warn(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set.")
+        LOGGER.warn(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set. Using {OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY} environment value.")
         orca_bucket = None
     if orca_bucket is None:
         orca_bucket = event[EVENT_CONFIG_KEY].get(

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -35,7 +35,7 @@ OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY = "ORCA_DEFAULT_BUCKET"
 EVENT_CONFIG_KEY = "config"
 EVENT_INPUT_KEY = "input"
 
-CONFIG_ORCA_BUCKET_OVERRIDE_KEY = "orcaBucketOverride"
+CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY = "orcaDefaultBucketOverride"
 
 INPUT_GRANULES_KEY = "granules"
 
@@ -152,9 +152,9 @@ def task(
 
     # Use the default glacier bucket if none is specified for the collection or otherwise given.
     try:
-        orca_bucket = event[EVENT_CONFIG_KEY][CONFIG_ORCA_BUCKET_OVERRIDE_KEY]
+        orca_bucket = event[EVENT_CONFIG_KEY][CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY]
     except KeyError:
-        LOGGER.warn(f"{CONFIG_ORCA_BUCKET_OVERRIDE_KEY} is not set.")
+        LOGGER.warn(f"{CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY} is not set.")
         orca_bucket = None
     if orca_bucket is None:
         orca_bucket = event[EVENT_CONFIG_KEY].get(

--- a/tasks/request_files/schemas/config.json
+++ b/tasks/request_files/schemas/config.json
@@ -16,6 +16,10 @@
     "multipart_chunksize_mb": {
       "description": "Overrides default_multipart_chunksize from TF.",
       "type": ["number", "null"]
+    },
+    "orcaDefaultBucketOverride": {
+      "type": ["string", "null"],
+      "description": "Overrides the default bucket to copy to in os.environ['ORCA_DEFAULT_BUCKET']."
     }
   }
 }

--- a/tasks/request_files/schemas/config.json
+++ b/tasks/request_files/schemas/config.json
@@ -5,10 +5,6 @@
   "description": "The config for the request_files Lambda.",
   "type": "object",
   "properties": {
-    "glacier-bucket": {
-      "description": "The name of the glacier bucket from which the files will be restored. Defaults to OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY",
-      "type": "string"
-    },
     "asyncOperationId": {
       "description": "The unique identifier used for tracking requests. If not present, will be generated.",
       "type": "string"

--- a/tasks/request_files/test/testevents/request_files_fixture1.json
+++ b/tasks/request_files/test/testevents/request_files_fixture1.json
@@ -28,7 +28,7 @@
       "meta": {
         "response-endpoint": "arn:aws:sns:us-west-2:065089468788:providerResponseSNS",
         "granuleRecoveryWorkflow": "DrRecoveryWorkflow",
-        "glacier-bucket": "podaac-sndbx-cumulus-glacier"
+        "orcaDefaultBucketOverride": "podaac-sndbx-cumulus-glacier"
       }
     },
     "stack": "lab-cumulus",
@@ -82,7 +82,7 @@
       }
     },
     "request_files": {
-      "glacier-bucket": "{{$.meta.collection.meta.glacier-bucket}}"
+      "orcaDefaultBucketOverride": "{{$.meta.collection.meta.orcaDefaultBucketOverride}}"
     },
     "WorkflowFailed": {},
     "StopStatus": {

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -63,10 +63,11 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("request_files.get_default_glacier_bucket_name")
     @patch("request_files.inner_task")
-    def test_task_happy_path(self,
-                             mock_inner_task: MagicMock,
-                             mock_get_default_glacier_bucket_name: MagicMock
-                             ):
+    def test_task_happy_path(
+        self,
+        mock_inner_task: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         All variables present and valid.
         """
@@ -116,10 +117,11 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("request_files.get_default_glacier_bucket_name")
     @patch("request_files.inner_task")
-    def test_task_default_for_missing_max_retries(self,
-                                                  mock_inner_task: MagicMock,
-                                                  mock_get_default_glacier_bucket_name: MagicMock
-                                                  ):
+    def test_task_default_for_missing_max_retries(
+        self,
+        mock_inner_task: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         If max_retries missing, use default.
         """
@@ -165,10 +167,11 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("request_files.get_default_glacier_bucket_name")
     @patch("request_files.inner_task")
-    def test_task_default_for_missing_sleep_secs(self,
-                                                 mock_inner_task: MagicMock,
-                                                 mock_get_default_glacier_bucket_name: MagicMock
-                                                 ):
+    def test_task_default_for_missing_sleep_secs(
+        self,
+        mock_inner_task: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         If sleep_secs missing, use default.
         """
@@ -214,10 +217,11 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("request_files.get_default_glacier_bucket_name")
     @patch("request_files.inner_task")
-    def test_task_default_for_missing_retrieval_type(self,
-                                                     mock_inner_task: MagicMock,
-                                                     mock_get_default_glacier_bucket_name: MagicMock
-                                                     ):
+    def test_task_default_for_missing_retrieval_type(
+        self,
+        mock_inner_task: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         If retrieval_type is missing, use default.
         """
@@ -265,10 +269,11 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("request_files.get_default_glacier_bucket_name")
     @patch("request_files.inner_task")
-    def test_task_default_for_bad_retrieval_type(self,
-                                                 mock_inner_task: MagicMock,
-                                                 mock_get_default_glacier_bucket_name: MagicMock
-                                                 ):
+    def test_task_default_for_bad_retrieval_type(
+        self,
+        mock_inner_task: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         If retrieval_type is invalid, use default.
         """
@@ -318,10 +323,11 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("request_files.get_default_glacier_bucket_name")
     @patch("request_files.inner_task")
-    def test_task_default_for_missing_exp_days(self,
-                                               mock_inner_task: MagicMock,
-                                               mock_get_default_glacier_bucket_name: MagicMock
-                                               ):
+    def test_task_default_for_missing_exp_days(
+        self,
+        mock_inner_task: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         Uses default missing_exp_days if needed.
         """
@@ -367,10 +373,11 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("request_files.get_default_glacier_bucket_name")
     @patch("request_files.inner_task")
-    def test_task_job_id_missing_generates(self,
-                                           mock_inner_task: MagicMock,
-                                           mock_get_default_glacier_bucket_name: MagicMock
-                                           ):
+    def test_task_job_id_missing_generates(
+        self,
+        mock_inner_task: MagicMock,
+        mock_get_default_glacier_bucket_name: MagicMock,
+    ):
         """
         If job_id missing, generates a new one.
         """
@@ -440,12 +447,12 @@ class TestRequestFiles(unittest.TestCase):
     @patch("request_files.object_exists")
     @patch("boto3.client")
     def test_inner_task_missing_files_do_not_halt(
-            self,
-            mock_boto3_client: MagicMock,
-            mock_object_exists: MagicMock,
-            mock_process_granule: MagicMock,
-            mock_sleep: MagicMock,
-            mock_create_status_for_job: MagicMock,
+        self,
+        mock_boto3_client: MagicMock,
+        mock_object_exists: MagicMock,
+        mock_process_granule: MagicMock,
+        mock_sleep: MagicMock,
+        mock_create_status_for_job: MagicMock,
     ):
         """
         A return of 'false' from object_exists should ignore the file and continue.
@@ -505,10 +512,14 @@ class TestRequestFiles(unittest.TestCase):
             "request_time": mock.ANY,
             "last_update": mock.ANY,
             "error_message": f"{missing_file_key} does not exist in {glacier_bucket} bucket",
-            "completion_time": mock.ANY
+            "completion_time": mock.ANY,
         }
 
-        expected_input_granule_files = [expected_file0_output, expected_missing_file_output, expected_file1_output]
+        expected_input_granule_files = [
+            expected_file0_output,
+            expected_missing_file_output,
+            expected_file1_output,
+        ]
         granule = {
             request_files.GRANULE_GRANULE_ID_KEY: granule_id,
             request_files.GRANULE_KEYS_KEY: [
@@ -525,7 +536,7 @@ class TestRequestFiles(unittest.TestCase):
             request_files.EVENT_CONFIG_KEY: {
                 request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
                 request_files.CONFIG_JOB_ID_KEY: job_id,
-                request_files.CONFIG_MULTIPART_CHUNKSIZE_MB_KEY: collection_multipart_chunksize_mb
+                request_files.CONFIG_MULTIPART_CHUNKSIZE_MB_KEY: collection_multipart_chunksize_mb,
             },
             request_files.EVENT_INPUT_KEY: {
                 request_files.INPUT_GRANULES_KEY: [granule]
@@ -539,7 +550,7 @@ class TestRequestFiles(unittest.TestCase):
 
         # noinspection PyUnusedLocal
         def object_exists_return_func(
-                input_s3_cli, input_glacier_bucket, input_file_key
+            input_s3_cli, input_glacier_bucket, input_file_key
         ):
             return input_file_key in [file_key_0, file_key_1]
 
@@ -575,14 +586,14 @@ class TestRequestFiles(unittest.TestCase):
                 "request_time": mock.ANY,
                 "last_update": mock.ANY,
                 "error_message": f"{missing_file_key} does not exist in {glacier_bucket} bucket",
-                "completion_time": mock.ANY
+                "completion_time": mock.ANY,
             },
             {
                 "success": False,
                 "filename": file_key_1,
                 "key_path": file_key_1,
                 "restore_destination": file_dest_bucket_1,
-                'multipart_chunksize_mb': collection_multipart_chunksize_mb,
+                "multipart_chunksize_mb": collection_multipart_chunksize_mb,
                 "status_id": OrcaStatus.PENDING.value,
                 "request_time": mock.ANY,
                 "last_update": mock.ANY,
@@ -620,7 +631,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("time.sleep")
     @patch("request_files.restore_object")
     def test_process_granule_minimal_path(
-            self, mock_restore_object: MagicMock, mock_sleep: MagicMock
+        self, mock_restore_object: MagicMock, mock_sleep: MagicMock
     ):
         mock_s3 = Mock()
         max_retries = randint(10, 999)  # nosec
@@ -707,7 +718,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("time.sleep")
     @patch("request_files.restore_object")
     def test_process_granule_one_client_error_retries(
-            self, mock_restore_object: MagicMock, mock_sleep: MagicMock
+        self, mock_restore_object: MagicMock, mock_sleep: MagicMock
     ):
         mock_s3 = Mock()
         max_retries = 5
@@ -783,10 +794,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("request_files.restore_object")
     @patch("cumulus_logger.CumulusLogger.error")
     def test_process_granule_client_errors_retries_until_cap(
-            self,
-            mock_logger_error: MagicMock,
-            mock_restore_object: MagicMock,
-            mock_sleep: MagicMock,
+        self,
+        mock_logger_error: MagicMock,
+        mock_restore_object: MagicMock,
+        mock_sleep: MagicMock,
     ):
         mock_s3 = Mock()
         max_retries = randint(3, 20)  # nosec
@@ -971,7 +982,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_restore_object_client_error_last_attempt_logs_and_raises(
-            self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
+        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
     ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
@@ -1007,7 +1018,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_restore_object_log_to_db_fails_does_not_halt(
-            self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
+        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
     ):
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
@@ -1074,10 +1085,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_one_granule_4_files_success(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test four files for one granule - successful
@@ -1212,11 +1223,11 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_one_granule_1_file_db_error(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test one file for one granule - db error inserting status
@@ -1244,10 +1255,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_file_not_in_glacier(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test a file that is not in glacier.
@@ -1312,7 +1323,7 @@ class TestRequestFiles(unittest.TestCase):
     @patch("request_files.shared_recovery.post_entry_to_queue")
     @patch("boto3.client")
     def test_task_no_retries_env_var(
-            self, mock_boto3_client: MagicMock, mock_post_entry_to_queue: MagicMock
+        self, mock_boto3_client: MagicMock, mock_post_entry_to_queue: MagicMock
     ):
         """
         Test environment var RESTORE_REQUEST_RETRIES not set - use default.
@@ -1342,7 +1353,7 @@ class TestRequestFiles(unittest.TestCase):
                             "key_path": FILE1,
                             "restore_destination": PROTECTED_BUCKET,
                             "success": True,
-                            'multipart_chunksize_mb': None,
+                            "multipart_chunksize_mb": None,
                             "status_id": 1,
                         },
                     ],
@@ -1378,10 +1389,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_no_expire_days_env_var(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test environment var RESTORE_EXPIRE_DAYS not set - use default.
@@ -1411,7 +1422,7 @@ class TestRequestFiles(unittest.TestCase):
                             "key_path": FILE1,
                             "restore_destination": PROTECTED_BUCKET,
                             "success": True,
-                            'multipart_chunksize_mb': None,
+                            "multipart_chunksize_mb": None,
                             "status_id": 1,
                         },
                     ],
@@ -1446,11 +1457,11 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_client_error_one_file(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test retries for restore error for one file.
@@ -1517,11 +1528,11 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_client_error_3_times(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test three files, two successful, one errors on all retries and fails.
@@ -1586,7 +1597,7 @@ class TestRequestFiles(unittest.TestCase):
                 "dest_bucket": PUBLIC_BUCKET,
                 "success": False,
                 "err_msg": "An error occurred (NoSuchKey) when calling the restore_object "
-                           "operation: Unknown",
+                "operation: Unknown",
             },
             {
                 "key": FILE4,
@@ -1613,11 +1624,11 @@ class TestRequestFiles(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_client_error_2_times(
-            self,
-            mock_logger_info: MagicMock,
-            mock_logger_error: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_logger_error: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test two files, first successful, second has two errors, then success.
@@ -1655,7 +1666,7 @@ class TestRequestFiles(unittest.TestCase):
                         {
                             "filename": os.path.basename(FILE1),
                             "key_path": FILE1,
-                            'multipart_chunksize_mb': None,
+                            "multipart_chunksize_mb": None,
                             "restore_destination": PROTECTED_BUCKET,
                             "success": True,
                             "status_id": 1,
@@ -1664,7 +1675,7 @@ class TestRequestFiles(unittest.TestCase):
                             "error_message": "An error occurred (NoSuchBucket) when calling the restore_object operation: Unknown",
                             "filename": os.path.basename(FILE2),
                             "key_path": FILE2,
-                            'multipart_chunksize_mb': None,
+                            "multipart_chunksize_mb": None,
                             "restore_destination": PROTECTED_BUCKET,
                             "success": True,
                             "status_id": 1,
@@ -1698,10 +1709,10 @@ class TestRequestFiles(unittest.TestCase):
     @patch("boto3.client")
     @patch("cumulus_logger.CumulusLogger.info")
     def test_task_output_json_schema(
-            self,
-            mock_logger_info: MagicMock,
-            mock_boto3_client: MagicMock,
-            mock_post_entry_to_queue: MagicMock,
+        self,
+        mock_logger_info: MagicMock,
+        mock_boto3_client: MagicMock,
+        mock_post_entry_to_queue: MagicMock,
     ):
         """
         Test four files for one granule - successful. Check against output schema.
@@ -1794,10 +1805,12 @@ class TestRequestFiles(unittest.TestCase):
     )
     def test_get_default_glacier_bucket_name_returns_override_if_present(self):
         bucket = Mock()
-        result = request_files.get_default_glacier_bucket_name({
-            request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: bucket,
-            request_files.CONFIG_GLACIER_BUCKET_KEY: Mock()
-        })
+        result = request_files.get_default_glacier_bucket_name(
+            {
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: bucket,
+                request_files.CONFIG_GLACIER_BUCKET_KEY: Mock(),
+            }
+        )
         self.assertEqual(bucket, result)
 
     @patch.dict(
@@ -1807,11 +1820,13 @@ class TestRequestFiles(unittest.TestCase):
         },
         clear=True,
     )
-    def test_get_default_glacier_bucket_name_returns_default_bucket_if_no_override(self):
+    def test_get_default_glacier_bucket_name_returns_default_bucket_if_no_override(
+        self,
+    ):
         bucket = Mock()
-        result = request_files.get_default_glacier_bucket_name({
-            request_files.CONFIG_GLACIER_BUCKET_KEY: bucket
-        })
+        result = request_files.get_default_glacier_bucket_name(
+            {request_files.CONFIG_GLACIER_BUCKET_KEY: bucket}
+        )
         self.assertEqual(bucket, result)
 
     @patch.dict(
@@ -1821,12 +1836,16 @@ class TestRequestFiles(unittest.TestCase):
         },
         clear=True,
     )
-    def test_get_default_glacier_bucket_name_returns_default_bucket_if_none_override(self):
+    def test_get_default_glacier_bucket_name_returns_default_bucket_if_none_override(
+        self,
+    ):
         bucket = Mock()
-        result = request_files.get_default_glacier_bucket_name({
-            request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None,
-            request_files.CONFIG_GLACIER_BUCKET_KEY: bucket
-        })
+        result = request_files.get_default_glacier_bucket_name(
+            {
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None,
+                request_files.CONFIG_GLACIER_BUCKET_KEY: bucket,
+            }
+        )
         self.assertEqual(bucket, result)
 
     @patch.dict(
@@ -1838,10 +1857,17 @@ class TestRequestFiles(unittest.TestCase):
     )
     def test_get_default_glacier_bucket_name_returns_env_bucket_if_no_other(self):
         bucket = os.environ[request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]
-        result = request_files.get_default_glacier_bucket_name({
-            request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None
-        })
+        result = request_files.get_default_glacier_bucket_name(
+            {request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None}
+        )
         self.assertEqual(bucket, result)
+
+    def test_no_bucket_raises_error(self):
+        os.environ.pop(request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY)
+        with self.assertRaises(KeyError) as cm:
+            request_files.get_default_glacier_bucket_name(
+                {request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None}
+            )
 
 
 if __name__ == "__main__":

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -72,9 +72,7 @@ class TestRequestFiles(unittest.TestCase):
         All variables present and valid.
         """
         job_id = uuid.uuid4().__str__()
-        glacier_bucket = Mock()
         config = {
-            request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
             request_files.CONFIG_JOB_ID_KEY: job_id,
         }
         mock_event = {
@@ -104,7 +102,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_inner_task.assert_called_once_with(
             {
                 request_files.EVENT_CONFIG_KEY: {
-                    request_files.CONFIG_GLACIER_BUCKET_KEY: mock_get_default_glacier_bucket_name.return_value,
+                    request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: mock_get_default_glacier_bucket_name.return_value,
                     request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
@@ -128,7 +126,6 @@ class TestRequestFiles(unittest.TestCase):
         job_id = uuid.uuid4().__str__()
         glacier_bucket = Mock()
         config = {
-            request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
             request_files.CONFIG_JOB_ID_KEY: job_id,
         }
         mock_event = {
@@ -154,7 +151,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_inner_task.assert_called_once_with(
             {
                 request_files.EVENT_CONFIG_KEY: {
-                    request_files.CONFIG_GLACIER_BUCKET_KEY: mock_get_default_glacier_bucket_name.return_value,
+                    request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: mock_get_default_glacier_bucket_name.return_value,
                     request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
@@ -176,9 +173,7 @@ class TestRequestFiles(unittest.TestCase):
         If sleep_secs missing, use default.
         """
         job_id = uuid.uuid4().__str__()
-        glacier_bucket = Mock()
         config = {
-            request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
             request_files.CONFIG_JOB_ID_KEY: job_id,
         }
         mock_event = {
@@ -204,7 +199,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_inner_task.assert_called_once_with(
             {
                 request_files.EVENT_CONFIG_KEY: {
-                    request_files.CONFIG_GLACIER_BUCKET_KEY: mock_get_default_glacier_bucket_name.return_value,
+                    request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: mock_get_default_glacier_bucket_name.return_value,
                     request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
@@ -226,9 +221,7 @@ class TestRequestFiles(unittest.TestCase):
         If retrieval_type is missing, use default.
         """
         job_id = uuid.uuid4().__str__()
-        glacier_bucket = Mock()
         config = {
-            request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
             request_files.CONFIG_JOB_ID_KEY: job_id,
         }
         mock_event = {
@@ -256,7 +249,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_inner_task.assert_called_once_with(
             {
                 request_files.EVENT_CONFIG_KEY: {
-                    request_files.CONFIG_GLACIER_BUCKET_KEY: mock_get_default_glacier_bucket_name.return_value,
+                    request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: mock_get_default_glacier_bucket_name.return_value,
                     request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
@@ -278,9 +271,7 @@ class TestRequestFiles(unittest.TestCase):
         If retrieval_type is invalid, use default.
         """
         job_id = uuid.uuid4().__str__()
-        glacier_bucket = Mock()
         config = {
-            request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
             request_files.CONFIG_JOB_ID_KEY: job_id,
         }
         mock_event = {
@@ -310,7 +301,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_inner_task.assert_called_once_with(
             {
                 request_files.EVENT_CONFIG_KEY: {
-                    request_files.CONFIG_GLACIER_BUCKET_KEY: mock_get_default_glacier_bucket_name.return_value,
+                    request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: mock_get_default_glacier_bucket_name.return_value,
                     request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
@@ -332,9 +323,7 @@ class TestRequestFiles(unittest.TestCase):
         Uses default missing_exp_days if needed.
         """
         job_id = uuid.uuid4().__str__()
-        glacier_bucket = Mock()
         config = {
-            request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
             request_files.CONFIG_JOB_ID_KEY: job_id,
         }
         mock_event = {
@@ -360,7 +349,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_inner_task.assert_called_once_with(
             {
                 request_files.EVENT_CONFIG_KEY: {
-                    request_files.CONFIG_GLACIER_BUCKET_KEY: mock_get_default_glacier_bucket_name.return_value,
+                    request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: mock_get_default_glacier_bucket_name.return_value,
                     request_files.CONFIG_JOB_ID_KEY: job_id,
                 },
             },
@@ -381,9 +370,7 @@ class TestRequestFiles(unittest.TestCase):
         """
         If job_id missing, generates a new one.
         """
-        glacier_bucket = Mock()
         config = {
-            request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
             request_files.CONFIG_JOB_ID_KEY: None,
         }
         mock_event = {
@@ -415,7 +402,7 @@ class TestRequestFiles(unittest.TestCase):
         mock_inner_task.assert_called_once_with(
             {
                 request_files.EVENT_CONFIG_KEY: {
-                    request_files.CONFIG_GLACIER_BUCKET_KEY: mock_get_default_glacier_bucket_name.return_value,
+                    request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: mock_get_default_glacier_bucket_name.return_value,
                     request_files.CONFIG_JOB_ID_KEY: job_id.__str__(),
                 },
             },
@@ -534,7 +521,7 @@ class TestRequestFiles(unittest.TestCase):
         ] = expected_input_granule_files
         event = {
             request_files.EVENT_CONFIG_KEY: {
-                request_files.CONFIG_GLACIER_BUCKET_KEY: glacier_bucket,
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: glacier_bucket,
                 request_files.CONFIG_JOB_ID_KEY: job_id,
                 request_files.CONFIG_MULTIPART_CHUNKSIZE_MB_KEY: collection_multipart_chunksize_mb,
             },
@@ -1054,7 +1041,7 @@ class TestRequestFiles(unittest.TestCase):
         input_event = create_handler_event()
         expected_task_input = {
             "input": input_event["payload"],
-            "config": {"glacier-bucket": "podaac-sndbx-cumulus-glacier"},
+            "config": {request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "podaac-sndbx-cumulus-glacier"},
         }
         mock_task.return_value = {
             "granules": [
@@ -1098,7 +1085,7 @@ class TestRequestFiles(unittest.TestCase):
         input_event = {
             "input": {"granules": [{"granuleId": granule_id, "keys": files}]},
             "config": {
-                "glacier-bucket": "my-dr-fake-glacier-bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "my-dr-fake-glacier-bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             },
         }
@@ -1236,7 +1223,7 @@ class TestRequestFiles(unittest.TestCase):
         input_event = {
             "input": {"granules": [{"granuleId": granule_id, "keys": [KEY1]}]},
             "config": {
-                "glacier-bucket": "my-dr-fake-glacier-bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "my-dr-fake-glacier-bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             },
         }
@@ -1278,7 +1265,7 @@ class TestRequestFiles(unittest.TestCase):
                 ]
             },
             "config": {
-                "glacier-bucket": "my-bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "my-bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             },
         }
@@ -1334,7 +1321,7 @@ class TestRequestFiles(unittest.TestCase):
         event = {
             "input": {"granules": [{"granuleId": granule_id, "keys": [KEY1]}]},
             "config": {
-                "glacier-bucket": "some_bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "some_bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             },
         }
@@ -1402,7 +1389,7 @@ class TestRequestFiles(unittest.TestCase):
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         event = {
             "config": {
-                "glacier-bucket": "some_bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "some_bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             },
             "input": {"granules": [{"granuleId": granule_id, "keys": [KEY1]}]},
@@ -1468,7 +1455,7 @@ class TestRequestFiles(unittest.TestCase):
         """
         event = {
             "config": {
-                "glacier-bucket": "some_bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "some_bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             },
             "input": {
@@ -1507,7 +1494,7 @@ class TestRequestFiles(unittest.TestCase):
             ],
         }
         exp_err = "One or more files failed to be requested from {bucket}.".format(
-            bucket=event["config"]["glacier-bucket"]
+            bucket=event["config"][request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY]
         )
         try:
             request_files.task(event, self.context)
@@ -1541,7 +1528,7 @@ class TestRequestFiles(unittest.TestCase):
 
         event = {
             "config": {
-                "glacier-bucket": "some_bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY:  "some_bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             }
         }
@@ -1563,7 +1550,7 @@ class TestRequestFiles(unittest.TestCase):
             "recover_files": self.get_exp_files_3_errs(),
         }
         exp_err = "One or more files failed to be requested from {bucket}.".format(
-            bucket=event["config"]["glacier-bucket"]
+            bucket=event["config"][request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY]
         )
         try:
             request_files.task(event, self.context)
@@ -1635,7 +1622,7 @@ class TestRequestFiles(unittest.TestCase):
         """
         event = {
             "config": {
-                "glacier-bucket": "some_bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "some_bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             }
         }
@@ -1722,7 +1709,7 @@ class TestRequestFiles(unittest.TestCase):
         input_event = {
             "input": {"granules": [{"granuleId": granule_id, "keys": files}]},
             "config": {
-                "glacier-bucket": "my-dr-fake-glacier-bucket",
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: "my-dr-fake-glacier-bucket",
                 "asyncOperationId": uuid.uuid4().__str__(),
             },
         }
@@ -1807,8 +1794,7 @@ class TestRequestFiles(unittest.TestCase):
         bucket = Mock()
         result = request_files.get_default_glacier_bucket_name(
             {
-                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: bucket,
-                request_files.CONFIG_GLACIER_BUCKET_KEY: Mock(),
+                request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: bucket
             }
         )
         self.assertEqual(bucket, result)
@@ -1823,9 +1809,9 @@ class TestRequestFiles(unittest.TestCase):
     def test_get_default_glacier_bucket_name_returns_default_bucket_if_no_override(
         self,
     ):
-        bucket = Mock()
+        bucket = os.environ[request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]
         result = request_files.get_default_glacier_bucket_name(
-            {request_files.CONFIG_GLACIER_BUCKET_KEY: bucket}
+            {}
         )
         self.assertEqual(bucket, result)
 
@@ -1839,11 +1825,10 @@ class TestRequestFiles(unittest.TestCase):
     def test_get_default_glacier_bucket_name_returns_default_bucket_if_none_override(
         self,
     ):
-        bucket = Mock()
+        bucket = os.environ[request_files.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]
         result = request_files.get_default_glacier_bucket_name(
             {
                 request_files.CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY: None,
-                request_files.CONFIG_GLACIER_BUCKET_KEY: bucket,
             }
         )
         self.assertEqual(bucket, result)

--- a/tasks/request_status_for_granule/README.md
+++ b/tasks/request_status_for_granule/README.md
@@ -185,3 +185,42 @@ DATA
     OUTPUT_STATUS_KEY = 'status'
     Union = typing.Union
 ```
+
+## pydoc sqs_library.py
+
+```
+Help on sqs_library:
+NAME
+    sqs_library
+FUNCTIONS
+    post_to_metadata_queue(sqs_body: Dict[str, Any], metadata_queue_url: str,) -> None:
+        Posts metadata information to the metadata SQS queue.
+        Args:
+            sqs_body: A dictionary containing the metadata objects that will be sent to SQS.
+            metadata_queue_url: The metadata SQS queue URL defined by AWS.
+        Returns:
+            None
+    get_aws_region() -> str:
+        Gets AWS region variable from the runtime environment variable.
+        Args:
+            None
+        Returns:
+            The AWS region variable.
+        Raises:
+            Exception: Thrown if AWS region is empty or None.
+    
+    retry_error(max_retries: int, backoff_in_seconds: int, backoff_factor: int) -> Callable[[Callable[[], RT]], Callable[[], RT]]:
+        Decorator takes arguments to adjust number of retries and backoff strategy.
+        Args:
+            max_retries (int): number of times to retry in case of failure.
+            backoff_in_seconds (int): Number of seconds to sleep the first time through.
+            backoff_factor (int): Value of the factor used for backoff.
+DATA
+    Any = typing.Any
+    Callable = typing.Callable
+    Dict = typing.Dict
+    TypeVar = typing.TypeVar
+    MAX_RETRIES = 3
+    BACKOFF_FACTOR = 2
+    INITIAL_BACKOFF_IN_SECONDS = 1
+```

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -347,7 +347,7 @@ the ingest workflow.
          "task_config":{
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
             "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
-            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
+            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}"
             }
          }
       }
@@ -546,7 +546,7 @@ default setting set during ORCA installation. For more information, see the docu
     "granuleRecoveryWorkflow": "OrcaRecoveryWorkflow",
     "excludeFileTypes": [".cmr", ".xml", ".met"],
     "multipart_chunksize_mb": 400,
-    "orcaDefaultBucketOverride": "glacier"
+    "orcaDefaultBucketOverride": "prod_orca_worm"
   },
   ...
 }

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -346,7 +346,8 @@ the ingest workflow.
          "event.$":"$",
          "task_config":{
             "multipart_chunksize_mb": "{$.meta.collection.meta.multipart_chunksize_mb}",
-            "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}"
+            "excludeFileTypes": "{$.meta.collection.meta.excludeFileTypes}",
+            "orcaDefaultBucketOverride": "{$.meta.collection.meta.orca_default_bucket}"
             }
          }
       }
@@ -544,7 +545,8 @@ default setting set during ORCA installation. For more information, see the docu
   "meta": {
     "granuleRecoveryWorkflow": "OrcaRecoveryWorkflow",
     "excludeFileTypes": [".cmr", ".xml", ".met"],
-    "multipart_chunksize_mb": 400
+    "multipart_chunksize_mb": 400,
+    "orcaDefaultBucketOverride": "glacier"
   },
   ...
 }


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-151: As a developer, the orca bucket should be configurable at the collection level to better organize data.](https://bugs.earthdata.nasa.gov/browse/ORCA-151)

## Changes

* Added default_orca_bucket_override to copy_to_glacier and request_files

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tests pass locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Testing documentation
    - [x] Development documentation
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
