### PR TITLE
ORCA-314 Remove common forbidden characters from db_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ and includes an additional section for migration notes.
   - db_name (Defaults to PREFIX_orca.
     - Any `-` in `prefix` are replaced with `_` to follow [SQL Naming Conventions](https://www.postgresql.org/docs/7.0/syntax525.htm#:~:text=Names%20in%20SQL%20must%20begin,but%20they%20will%20be%20truncated.)
     - If preserving a database from a previous version of Orca, set to disaster_recovery.
-    - If the generated `db_name` would violate [SQL Naming Conventions](https://www.postgresql.org/docs/7.0/syntax525.htm#:~:text=Names%20in%20SQL%20must%20begin,but%20they%20will%20be%20truncated.), set `db_name` to PREFIX_orca but modify your prefix to remove forbidden characters.)
   - rds_security_group_id (Requires a value. Set in terraform.tfvars to the Security Group ID of your RDS Database's Security Group. Output from Cumulus' RDS module as `security_group_id`)
   - vpc_endpoint_id
 - Add the following ORCA required variables definition to your `variables.tf` or `orca_variables.tf` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,10 @@ and includes an additional section for migration notes.
 - These are the new variables added:
   - db_admin_username (defaults to "postgres")
   - db_host_endpoint (Requires a value. Set in terraform.tfvars to your RDS Database's endpoint, similar to "PREFIX-cumulus-db.cluster-000000000000.us-west-2.rds.amazonaws.com")
-  - db_name (Defaults to PREFIX_orca. If preserving a database from a previous version of Orca, set to disaster_recovery.)
+  - db_name (Defaults to PREFIX_orca.
+    - Any `-` in `prefix` are replaced with `_` to follow [SQL Naming Conventions](https://www.postgresql.org/docs/7.0/syntax525.htm#:~:text=Names%20in%20SQL%20must%20begin,but%20they%20will%20be%20truncated.)
+    - If preserving a database from a previous version of Orca, set to disaster_recovery.
+    - If the generated `db_name` would violate [SQL Naming Conventions](https://www.postgresql.org/docs/7.0/syntax525.htm#:~:text=Names%20in%20SQL%20must%20begin,but%20they%20will%20be%20truncated.), set `db_name` to PREFIX_orca but modify your prefix to remove forbidden characters.)
   - rds_security_group_id (Requires a value. Set in terraform.tfvars to the Security Group ID of your RDS Database's Security Group. Output from Cumulus' RDS module as `security_group_id`)
   - vpc_endpoint_id
 - Add the following ORCA required variables definition to your `variables.tf` or `orca_variables.tf` file.

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 ## Local Variables
 locals {
-  db_name = var.db_name != null ? var.db_name : "${var.prefix}_orca"
+  db_name = var.db_name != null ? var.db_name : replace("${var.prefix}_orca", "-", "_")
   tags    = merge(var.tags, { Deployment = var.prefix }, { team = "ORCA", application = "ORCA" })
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -47,7 +47,7 @@ rds_security_group_id =
 ## Username for RDS database administrator authentication.
 # db_admin_username = "postgres"
 
-## The name of the Orca database within the RDS cluster. Default set to PREFIX_orca in main.tf.
+## The name of the Orca database within the RDS cluster. Default set to PREFIX_orca in main.tf. Any `-` in `prefix` will be replaced with `_`.
 # db_name = "PREFIX_db_orca"
 
 ## The default maximum size of chunks to use when copying. Can be overridden by collection config.

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -47,6 +47,9 @@ rds_security_group_id =
 ## Username for RDS database administrator authentication.
 # db_admin_username = "postgres"
 
+## The name of the Orca database within the RDS cluster. Default set to PREFIX_orca in main.tf.
+# db_name = "PREFIX_db_orca"
+
 ## The default maximum size of chunks to use when copying. Can be overridden by collection config.
 # default_multipart_chunksize_mb = 250
 

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "db_admin_username" {
 }
 
 variable "db_name" {
-  description = "The name of the Orca database within the RDS cluster. Default set to PREFIX_orca in main.tf."
+  description = "The name of the Orca database within the RDS cluster. Default set to PREFIX_orca in main.tf. Any `-` in `prefix` will be replaced with `_`."
   type        = string
   default     = null
 }

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -472,7 +472,7 @@ variables is shown in the table below.
 | `db_admin_username`                                   | string        | Username for RDS database administrator authentication.                                                 | "postgres" |
 | `default_multipart_chunksize_mb`                      | number        | The default maximum size of chunks to use when copying. Can be overridden by collection config.         | 250 |
 | `metadata_queue_message_retention_time_seconds`       | number        | Number of seconds the metadata-queue fifo SQS retains a message.                                        | 777600 |
-| `db_name`                                             | string        | The name of the Orca database within the RDS cluster.                                                   | PREFIX_orca |
+| `db_name`                                             | string        | The name of the Orca database within the RDS cluster. Any `-` in `prefix` will be replaced with `_`.    | PREFIX_orca |
 | `orca_ingest_lambda_memory_size`                      | number        | Amount of memory in MB the ORCA copy_to_glacier lambda can use at runtime.                              | 2240 |
 | `orca_ingest_lambda_timeout`                          | number        | Timeout in number of seconds for ORCA copy_to_glacier lambda.                                           | 600 |
 | `orca_recovery_buckets`                               | List (string) | List of bucket names that ORCA has permissions to restore data to. Default is all in the `buckets` map. | [] |


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-314: Remove common forbidden characters from db_name](https://bugs.earthdata.nasa.gov/browse/ORCA-314)

## Changes

* Dashes will be replaced by underscores when generating db_name

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Run through Terraform.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Testing documentation
    - [x] Development documentation
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets