### PR TITLE
Update security policy for KMS to allow admin and readonly access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and includes an additional section for migration notes.
 ### Changed
 - *ORCA-297* Default database name is now PREFIX_orca
 - *ORCA-287* Updated copy_to_glacier and extract_filepaths_for_granule to [new Cumulus file format](https://github.com/nasa/cumulus/blob/master/packages/schemas/files.schema.json). 
+- *ORCA-245* Update resource policies related to KMS keys to provide better security.
 
 ### Migration Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and includes an additional section for migration notes.
 ### Changed
 - *ORCA-297* Default database name is now PREFIX_orca
 - *ORCA-287* Updated copy_to_glacier and extract_filepaths_for_granule to [new Cumulus file format](https://github.com/nasa/cumulus/blob/master/packages/schemas/files.schema.json). 
-- *ORCA-245* Update resource policies related to KMS keys to provide better security.
+- *ORCA-245* Updated resource policies related to KMS keys to provide better security.
 
 ### Migration Notes
 

--- a/modules/secretsmanager/main.tf
+++ b/modules/secretsmanager/main.tf
@@ -1,14 +1,3 @@
-## Local Variables
-locals {
-  tags = merge(var.tags, { Deployment = var.prefix })
-  iam_users    = data.aws_iam_users.orca_users.arns
-  account_id   = data.aws_caller_identity.current_account.account_id
-  region       = data.aws_region.current_region.name
-  kms_arn    = "arn:aws:kms:${local.region}:${local.account_id}:key/*"
-  lambda_rolename = "${var.prefix}_restore_object_role"
-}
-
-
 ## Data Lookups
 
 ## =============================================================================
@@ -24,6 +13,17 @@ data "aws_region" "current_region" {}
 # This data lookup pulls back a single iam role arn for use with the secretmanager policy
 data "aws_iam_role" "roles" {
   name = local.lambda_rolename
+}
+
+
+## Local Variables
+locals {
+  tags = merge(var.tags, { Deployment = var.prefix })
+  iam_users    = data.aws_iam_users.orca_users.arns
+  account_id   = data.aws_caller_identity.current_account.account_id
+  region       = data.aws_region.current_region.name
+  kms_arn    = "arn:aws:kms:${local.region}:${local.account_id}:key/*"
+  lambda_rolename = "${var.prefix}_restore_object_role"
 }
 
 

--- a/modules/secretsmanager/main.tf
+++ b/modules/secretsmanager/main.tf
@@ -1,7 +1,31 @@
 ## Local Variables
 locals {
   tags = merge(var.tags, { Deployment = var.prefix })
+  iam_users    = data.aws_iam_users.orca_users.arns
+  account_id   = data.aws_caller_identity.current_account.account_id
+  region       = data.aws_region.current_region.name
+  kms_arn    = "arn:aws:kms:${local.region}:${local.account_id}:key/*"
+  lambda_rolename = "${var.prefix}_restore_object_role"
 }
+
+
+## Data Lookups
+
+## =============================================================================
+## SECRET MANAGER DATA LOOKUPS
+## =============================================================================
+
+data "aws_iam_users" "orca_users" {}
+
+data "aws_caller_identity" "current_account" {}
+
+data "aws_region" "current_region" {}
+
+# This data lookup pulls back a single iam role arn for use with the secretmanager policy
+data "aws_iam_role" "roles" {
+  name = local.lambda_rolename
+}
+
 
 ## Resources
 
@@ -32,38 +56,44 @@ resource "aws_secretsmanager_secret_version" "db_login" {
     port           = "5432"
   })
 }
+
+
 ## KMS key policy
 ## ====================================================================================================
 data "aws_iam_policy_document" "orca_kms_key_policy" {
   statement {
-    sid = "orca_kms_policy"
+    sid = "orca_kms_policy_admin"
     # work with NGAP to restrict actions
     actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt",
-      "kms:CreateGrant",
-      "kms:PutKeyPolicy",
-      "kms:GenerateDataKey*",
-      "kms:CreateKey",
-      "kms:PutKeyPolicy",
-      "kms:UpdateKeyDescription",
-      "kms:DisableKey",
-      "kms:DisableKeyRotation",
-      "kms:ScheduleKeyDeletion",
-      "kms:CancelKeyDeletion",
-      "kms:DescribeKey",
-      "kms:Get*",
-      "kms:List*"
+      "kms:*"
     ]
+
     resources = ["*"]
     effect    = "Allow"
+
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = local.iam_users
+    }
+  }
+  statement {
+    sid = "orca_kms_policy_readonly"
+    # work with NGAP to restrict actions
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    resources = [local.kms_arn]
+    effect    = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_role.roles.arn]
     }
   }
 }
+
+
 ## KMS key resource
 ## ====================================================================================================
 resource "aws_kms_key" "orca_kms_key" {


### PR DESCRIPTION
## Summary of Changes

Increase security footprint by reducing the access to the KMS service.

Addresses [ORCA-245: Restrict ORCA KMS key policy to allow only specific users to able to update the key.](https://bugs.earthdata.nasa.gov/browse/ORCA-245)

## Changes

* Modified modules/secretsmanager/main.tf
  * Added local variables
  * Added data lookups
  * Modified orca_kms_key_policy to restrict security access

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests (unit, integration, ad-hoc, or otherwise) that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Applied changes and was able to run a sample lambda utilizing the correct role and KMS key, retrieving sample secret contents
- Made sure my user was able to view and destroy the KMS key that was created during testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests (outlined above)
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
    - [x] Manual testing/integration testing passes (if forked)
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets

## What is the current behavior?

All resources and users have full admin access to KMS keys.

## What is the expected correct/added behavior?

KMS keys are read-only to lambda resources and only account users have administrative access to KMS keys.

## Possible fixes

KMS key policy needs to be updated to better narrow security focus to KMS keys.
