### PR TITLE
Added granule.provider_id to orca_catalog_reporting

### DIFF
--- a/tasks/orca_catalog_reporting/README.md
+++ b/tasks/orca_catalog_reporting/README.md
@@ -29,7 +29,7 @@ Fully defined json schemas written in the schema of https://json-schema.org/ can
   "anotherPage": false,
   "granules": [
     {
-      "providerId": ["lpdaac"],
+      "providerId": "lpdaac",
       "collectionId": "MOD14A1___061",
       "id": "MOD14A1.061.A23V45.2020235",
       "createdAt": "628021850000",

--- a/tasks/orca_catalog_reporting/orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/orca_catalog_reporting.py
@@ -61,13 +61,13 @@ def query_db(
     """
 
     Args:
+        engine: The sqlalchemy engine to use for contacting the database.
         provider_id: The unique ID of the provider(s) making the request.
         collection_id: The unique ID of collection(s) to compare.
         granule_id: The unique ID of granule(s) to compare.
         start_timestamp: Cumulus createdAt start time for date range to compare data.
         end_timestamp: Cumulus createdAt end-time for date range to compare data.
         page_index: The 0-based index of the results page to return.
-        engine: The sqlalchemy engine to use for contacting the database.
     """
     with engine.begin() as connection:
         sql_results = connection.execute(
@@ -89,7 +89,7 @@ def query_db(
         for sql_result in sql_results:
             granules.append(
                 {
-                    "providerId": sql_result["provider_ids"],
+                    "providerId": sql_result["provider_id"],
                     "collectionId": sql_result["collection_id"],
                     "id": sql_result["cumulus_granule_id"],
                     "createdAt": sql_result["cumulus_create_time"],
@@ -128,8 +128,9 @@ SELECT
                 granules.cumulus_granule_id
             FROM granules
             WHERE 
-                (:granule_id is null or cumulus_granule_id=ANY(:granule_id)) and 
+                (:provider_id is null or provider_id=ANY(:provider_id)) and 
                 (:collection_id is null or collection_id=ANY(:collection_id)) and 
+                (:granule_id is null or cumulus_granule_id=ANY(:granule_id)) and 
                 (:start_timestamp is null or (EXTRACT(EPOCH FROM date_trunc('milliseconds', cumulus_create_time) AT TIME ZONE 'UTC') * 1000)::bigint>=:start_timestamp) and 
                 (:end_timestamp is null or (EXTRACT(EPOCH FROM date_trunc('milliseconds', cumulus_create_time) AT TIME ZONE 'UTC') * 1000)::bigint<:end_timestamp)
             ORDER BY cumulus_granule_id

--- a/tasks/orca_catalog_reporting/schemas/output.json
+++ b/tasks/orca_catalog_reporting/schemas/output.json
@@ -29,11 +29,8 @@
         ],
         "properties": {
           "providerId": {
-            "description": "The unique ID of the provider. Provided by Cumulus. May be multiple.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "description": "The unique ID of the provider. Provided by Cumulus.",
+            "type": "string"
           },
           "collectionId": {
             "description": "The unique ID of the collection. Provided by Cumulus.",

--- a/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting_unit.py
+++ b/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting_unit.py
@@ -48,7 +48,7 @@ class TestOrcaCatalogReportingUnit(
             "anotherPage": False,
             "granules": [
                 {
-                    "providerId": [uuid.uuid4().__str__()],
+                    "providerId": uuid.uuid4().__str__(),
                     "collectionId": uuid.uuid4().__str__(),
                     "id": uuid.uuid4().__str__(),
                     "createdAt": random.randint(0, 628021800000),
@@ -220,7 +220,7 @@ class TestOrcaCatalogReportingUnit(
             "anotherPage": False,
             "granules": [
                 {
-                    "providerId": [uuid.uuid4().__str__()],
+                    "providerId": uuid.uuid4().__str__(),
                     "collectionId": uuid.uuid4().__str__(),
                     "id": uuid.uuid4().__str__(),
                     "createdAt": 628021800000,
@@ -367,7 +367,7 @@ class TestOrcaCatalogReportingUnit(
         returned_files = Mock()
 
         returned_row0 = {
-            "provider_ids": returned_provider_id,
+            "provider_id": returned_provider_id,
             "collection_id": returned_collection_id,
             "cumulus_granule_id": returned_granule_id,
             "cumulus_create_time": returned_created_at,


### PR DESCRIPTION
## Summary of Changes

Added support for provider_id on granule.

Addresses [ORCA-319: Update orca_catalog_reporting with new catalog schema](https://bugs.earthdata.nasa.gov/browse/ORCA-319)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests (unit, integration, ad-hoc, or otherwise) that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [ ] CHANGELOG.md
    - [x] Testing documentation
    - [x] Development documentation
    - [x] User documentation
    - [x] README
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets