### PR TITLE
Feature/orca 335 Update status for duplicate granule requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and includes an additional section for migration notes.
 - *ORCA-177* Added AWS API Gateway in modules/api_gateway/main.tf for the request_status_for_granule and request_status_for_job lambdas.
 - *ORCA-257* orca_catalog_reporting lambda now returns data from actual catalog.
 - *ORCA-151* copy_to_glacier and request_files now accept "orcaDefaultBucketOverride" which can be used on a per-collection basis. If desired, add "orcaDefaultBucketOverride": "{$.meta.collection.meta.orcaDefaultBucketOverride}" to the workflow's task's task_config.
+- *ORCA-335* request_files now recognizes when a file is already recovered, and posts an error message to status tables.
 
 ### Changed
 - *ORCA-297* Default database name is now PREFIX_orca

--- a/tasks/request_files/README.md
+++ b/tasks/request_files/README.md
@@ -233,7 +233,7 @@ FUNCTIONS
             job_id: The unique id of the job. Used for logging.
             retrieval_type: Glacier Tier. Valid values are 'Standard'|'Bulk'|'Expedited'. Defaults to 'Standard'.
         Raises:
-            ClientError: Raises ClientErrors from restore_object.
+            ClientError: Raises ClientErrors from restore_object, or if the file is already restored.
     
     task(event: Dict, context: object) -> Dict[str, Any]
         Pulls information from os.environ, utilizing defaults if needed.

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -552,7 +552,7 @@ def restore_object(
         job_id: The unique id of the job. Used for logging.
         retrieval_type: Glacier Tier. Valid values are 'Standard'|'Bulk'|'Expedited'. Defaults to 'Standard'.
     Raises:
-        ClientError: Raises ClientErrors from restore_object.
+        ClientError: Raises ClientErrors from restore_object, or if the file is already restored.
     """
     request = {"Days": days, "GlacierJobParameters": {"Tier": retrieval_type}}
     # Submit the request

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -230,7 +230,9 @@ def inner_task(
     """
     # Get the glacier bucket from the event
     try:
-        glacier_bucket = event[EVENT_CONFIG_KEY][CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY]
+        glacier_bucket = event[EVENT_CONFIG_KEY][
+            CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY
+        ]
     except KeyError:
         raise RestoreRequestError(
             f"request: {event} does not contain a config value for {CONFIG_ORCA_DEFAULT_BUCKET_OVERRIDE_KEY}"
@@ -569,8 +571,15 @@ def restore_object(
         raise c_err
     if restore_result["ResponseMetadata"]["HTTPStatusCode"] == 200:
         # Will have a non-error path after https://bugs.earthdata.nasa.gov/browse/ORCA-336
-        raise ClientError({"key": key, "bucket": db_glacier_bucket_key},
-                          f"File '{key}' in bucket '{db_glacier_bucket_key}' has already been restored.")
+        raise ClientError(
+            {
+                "Error": {
+                    "Code": "HTTPStatus: 200",
+                    "Message": f"File '{key}' in bucket '{db_glacier_bucket_key}' has already been recovered.",
+                }
+            },
+            "restore_object",
+        )
 
     LOGGER.info(
         f"Restore {key} from {db_glacier_bucket_key} "

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -558,17 +558,9 @@ def restore_object(
     """
     request = {"Days": days, "GlacierJobParameters": {"Tier": retrieval_type}}
     # Submit the request
-    try:
-        restore_result = s3_cli.restore_object(
-            Bucket=db_glacier_bucket_key, Key=key, RestoreRequest=request
-        )
-    except ClientError as c_err:
-        # NoSuchBucket, NoSuchKey, or InvalidObjectState error == the object's
-        # storage class was not GLACIER
-        LOGGER.error(
-            f"{c_err}. bucket: {db_glacier_bucket_key} file: {key} Job ID: {job_id}"
-        )
-        raise c_err
+    restore_result = s3_cli.restore_object(
+        Bucket=db_glacier_bucket_key, Key=key, RestoreRequest=request
+    )  # Allow ClientErrors to bubble up.
     if restore_result["ResponseMetadata"]["HTTPStatusCode"] == 200:
         # Will have a non-error path after https://bugs.earthdata.nasa.gov/browse/ORCA-336
         raise ClientError(

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -704,7 +704,7 @@ class TestRequestFiles(unittest.TestCase):
 
     @patch("time.sleep")
     @patch("request_files.restore_object")
-    def test_process_granule_one_client_error_retries(
+    def test_process_granule_one_client_or_key_error_retries(
         self, mock_restore_object: MagicMock, mock_sleep: MagicMock
     ):
         mock_s3 = Mock()
@@ -732,7 +732,7 @@ class TestRequestFiles(unittest.TestCase):
             ],
         }
 
-        mock_restore_object.side_effect = [ClientError({}, ""), None]
+        mock_restore_object.side_effect = [ClientError({}, ""), KeyError(), None]
 
         request_files.process_granule(
             mock_s3,
@@ -771,10 +771,20 @@ class TestRequestFiles(unittest.TestCase):
                     job_id,
                     retrieval_type,
                 ),
+                call(
+                    mock_s3,
+                    file_name_0,
+                    restore_expire_days,
+                    glacier_bucket,
+                    3,
+                    job_id,
+                    retrieval_type,
+                )
             ]
         )
-        self.assertEqual(2, mock_restore_object.call_count)
-        mock_sleep.assert_called_once_with(retry_sleep_secs)
+        self.assertEqual(3, mock_restore_object.call_count)
+        mock_sleep.assert_has_calls([call(retry_sleep_secs), call(retry_sleep_secs)])
+        self.assertEqual(2, mock_sleep.call_count)
 
     # noinspection PyUnusedLocal
     @patch("time.sleep")
@@ -911,6 +921,7 @@ class TestRequestFiles(unittest.TestCase):
         restore_expire_days = randint(0, 99)  # nosec
         retrieval_type = uuid.uuid4().__str__()
         mock_s3_cli = Mock()
+        mock_s3_cli.restore_object.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         request_files.restore_object(
             mock_s3_cli,
@@ -966,20 +977,22 @@ class TestRequestFiles(unittest.TestCase):
             )
 
     # noinspection PyUnusedLocal
-    @patch("cumulus_logger.CumulusLogger.error")
     @patch("cumulus_logger.CumulusLogger.info")
-    def test_restore_object_client_error_last_attempt_logs_and_raises(
-        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
+    def test_restore_object_202_returned_raises(
+        self, mock_logger_info: MagicMock
     ):
+        """
+        A 202 indicates that the file is already restored, and thus cannot presently be restored again.
+        Should be raised.
+        """
         glacier_bucket = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
         retrieval_type = uuid.uuid4().__str__()
-        expected_error = ClientError({}, "")
         mock_s3_cli = Mock()
-        mock_s3_cli.restore_object.side_effect = expected_error
+        mock_s3_cli.restore_object.return_value = {"ResponseMetadata": {"HTTPStatusCode": 202}}
 
-        try:
+        with self.assertRaises(KeyError) as context:
             request_files.restore_object(
                 mock_s3_cli,
                 key,
@@ -988,17 +1001,6 @@ class TestRequestFiles(unittest.TestCase):
                 2,
                 uuid.uuid4().__str__(),
                 retrieval_type,
-            )
-            self.fail("Error not Raised.")
-        except ClientError as error:
-            self.assertEqual(expected_error, error)
-            mock_s3_cli.restore_object.assert_called_once_with(
-                Bucket=glacier_bucket,
-                Key=key,
-                RestoreRequest={
-                    "Days": restore_expire_days,
-                    "GlacierJobParameters": {"Tier": retrieval_type},
-                },
             )
 
     # noinspection PyUnusedLocal
@@ -1012,6 +1014,7 @@ class TestRequestFiles(unittest.TestCase):
         restore_expire_days = randint(0, 99)  # nosec
         retrieval_type = uuid.uuid4().__str__()
         mock_s3_cli = Mock()
+        mock_s3_cli.restore_object.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
         request_files.restore_object(
             mock_s3_cli,
@@ -1091,7 +1094,10 @@ class TestRequestFiles(unittest.TestCase):
         }
 
         mock_s3_cli = mock_boto3_client("s3")
-        mock_s3_cli.restore_object.side_effect = [None, None, None, None]
+        mock_s3_cli.restore_object.side_effect = [{"ResponseMetadata": {"HTTPStatusCode": 200}},
+                                                  {"ResponseMetadata": {"HTTPStatusCode": 200}},
+                                                  {"ResponseMetadata": {"HTTPStatusCode": 200}},
+                                                  {"ResponseMetadata": {"HTTPStatusCode": 200}}]
 
         result = request_files.task(input_event, self.context)
 
@@ -1327,7 +1333,7 @@ class TestRequestFiles(unittest.TestCase):
         }
 
         mock_s3_cli = mock_boto3_client("s3")
-        mock_s3_cli.restore_object.side_effect = [None]
+        mock_s3_cli.restore_object.side_effect = [{"ResponseMetadata": {"HTTPStatusCode": 200}}]
 
         exp_granules = {
             "granules": [
@@ -1397,7 +1403,7 @@ class TestRequestFiles(unittest.TestCase):
 
         mock_s3_cli = mock_boto3_client("s3")
         # mock_s3_cli.head_object = Mock()  # todo: Look into why this line was in so many tests without asserts.
-        mock_s3_cli.restore_object.side_effect = [None]
+        mock_s3_cli.restore_object.side_effect = [{"ResponseMetadata": {"HTTPStatusCode": 200}}]
         exp_granules = {
             "granules": [
                 {
@@ -1536,10 +1542,11 @@ class TestRequestFiles(unittest.TestCase):
 
         event["input"] = {"granules": [gran]}
         mock_s3_cli = mock_boto3_client("s3")
+
         mock_s3_cli.restore_object.side_effect = [
-            None,
+            {"ResponseMetadata": {"HTTPStatusCode": 200}},
             ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
-            None,
+            {"ResponseMetadata": {"HTTPStatusCode": 200}},
             ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
             ClientError({"Error": {"Code": "NoSuchKey"}}, "restore_object"),
         ]
@@ -1635,10 +1642,10 @@ class TestRequestFiles(unittest.TestCase):
         mock_s3_cli = mock_boto3_client("sqs")
 
         mock_s3_cli.restore_object.side_effect = [
-            None,
+            {"ResponseMetadata": {"HTTPStatusCode": 200}},
             ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
             ClientError({"Error": {"Code": "NoSuchBucket"}}, "restore_object"),
-            None,
+            {"ResponseMetadata": {"HTTPStatusCode": 200}},
         ]
 
         exp_granules = {
@@ -1715,7 +1722,10 @@ class TestRequestFiles(unittest.TestCase):
         }
 
         mock_s3_cli = mock_boto3_client("s3")
-        mock_s3_cli.restore_object.side_effect = [None, None, None, None]
+        mock_s3_cli.restore_object.side_effect = [{"ResponseMetadata": {"HTTPStatusCode": 200}},
+                                                  {"ResponseMetadata": {"HTTPStatusCode": 200}},
+                                                  {"ResponseMetadata": {"HTTPStatusCode": 200}},
+                                                  {"ResponseMetadata": {"HTTPStatusCode": 200}}]
 
         result = request_files.task(input_event, self.context)
 

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -997,38 +997,6 @@ class TestRequestFiles(unittest.TestCase):
                          f"File '{key}' in bucket '{glacier_bucket}' has already been recovered.",
                          str(context.exception))
 
-    # noinspection PyUnusedLocal
-    @patch("cumulus_logger.CumulusLogger.error")
-    @patch("cumulus_logger.CumulusLogger.info")
-    def test_restore_object_log_to_db_fails_does_not_halt(
-        self, mock_logger_info: MagicMock, mock_logger_error: MagicMock
-    ):
-        glacier_bucket = uuid.uuid4().__str__()
-        key = uuid.uuid4().__str__()
-        restore_expire_days = randint(0, 99)  # nosec
-        retrieval_type = uuid.uuid4().__str__()
-        mock_s3_cli = Mock()
-        mock_s3_cli.restore_object.return_value = {"ResponseMetadata": {"HTTPStatusCode": 202}}
-
-        request_files.restore_object(
-            mock_s3_cli,
-            key,
-            restore_expire_days,
-            glacier_bucket,
-            randint(0, 99),  # nosec
-            uuid.uuid4().__str__(),
-            retrieval_type,
-        )
-
-        mock_s3_cli.restore_object.assert_called_once_with(
-            Bucket=glacier_bucket,
-            Key=key,
-            RestoreRequest={
-                "Days": restore_expire_days,
-                "GlacierJobParameters": {"Tier": retrieval_type},
-            },
-        )
-
     # The below are legacy tests that don't strictly check request_files.py on its own. Remove/adjust as needed.
     @patch("request_files.task")
     def test_handler_happy_path(self, mock_task: MagicMock):

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -993,6 +993,9 @@ class TestRequestFiles(unittest.TestCase):
                 uuid.uuid4().__str__(),
                 retrieval_type,
             )
+        self.assertEqual(f"An error occurred (HTTPStatus: 200) when calling the restore_object operation: "
+                         f"File '{key}' in bucket '{glacier_bucket}' has already been recovered.",
+                         str(context.exception))
 
     # noinspection PyUnusedLocal
     @patch("cumulus_logger.CumulusLogger.error")


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-335: Update status for duplicate granule requests](https://bugs.earthdata.nasa.gov/browse/ORCA-335)

## Changes

* 202 from restore_object is now an error state similar to client errors.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests (unit, integration, ad-hoc, or otherwise) that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [ ] CHANGELOG.md
    - [ ] Testing documentation
    - [ ] Development documentation
    - [ ] User documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets