### PR TITLE
Feature/orca 363 Switch from orcauser to prefix-able username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and includes an additional section for migration notes.
   - db_name (Defaults to PREFIX_orca.)
     - Any `-` in `prefix` are replaced with `_` to follow [SQL Naming Conventions](https://www.postgresql.org/docs/7.0/syntax525.htm#:~:text=Names%20in%20SQL%20must%20begin,but%20they%20will%20be%20truncated.)
     - If preserving a database from a previous version of Orca, set to disaster_recovery.
+  - db_user_name (Defaults to PREFIX_orcauser.)
+    - Any `-` in `prefix` are replaced with `_` to follow [SQL Naming Conventions](https://www.postgresql.org/docs/7.0/syntax525.htm#:~:text=Names%20in%20SQL%20must%20begin,but%20they%20will%20be%20truncated.)
+    - If preserving a database from a previous version of Orca, set to orcauser.
   - rds_security_group_id (Requires a value. Set in terraform.tfvars to the Security Group ID of your RDS Database's Security Group. Output from Cumulus' RDS module as `security_group_id`)
   - vpc_endpoint_id
 - Adjust workflows/step functions for `extract_filepaths`.

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 ## Local Variables
 locals {
   db_name = var.db_name != null ? var.db_name : replace("${var.prefix}_orca", "-", "_")
+  db_user_name = replace("${var.prefix}_orcauser", "-", "_")
   tags    = merge(var.tags, { Deployment = var.prefix }, { team = "ORCA", application = "ORCA" })
 }
 
@@ -37,6 +38,7 @@ module "orca" {
   ## OPTIONAL
   db_admin_username                                    = var.db_admin_username
   db_name                                              = local.db_name
+  db_user_name                                         = local.db_user_name
   default_multipart_chunksize_mb                       = var.default_multipart_chunksize_mb
   metadata_queue_message_retention_time_seconds        = var.metadata_queue_message_retention_time_seconds
   orca_ingest_lambda_memory_size                       = var.orca_ingest_lambda_memory_size

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -124,6 +124,7 @@ module "orca_secretsmanager" {
   ## OPTIONAL
   db_admin_username = var.db_admin_username
   db_name           = var.db_name
+  db_user_name      = var.db_user_name
 }
 ## orca_sqs - SQS module
 ## =============================================================================

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -103,6 +103,12 @@ variable "db_name" {
 }
 
 
+variable "db_user_name" {
+  description = "Username for RDS database user authentication"
+  type        = string
+}
+
+
 variable "orca_ingest_lambda_memory_size" {
   type        = number
   description = "Amount of memory in MB the ORCA copy_to_glacier lambda can use at runtime."

--- a/modules/secretsmanager/main.tf
+++ b/modules/secretsmanager/main.tf
@@ -43,7 +43,7 @@ resource "aws_secretsmanager_secret_version" "db_login" {
     admin_username = var.db_admin_username
     admin_password = var.db_admin_password
     admin_database = "postgres"
-    user_username  = "orcauser"
+    user_username  = var.db_user_name
     user_password  = var.db_user_password
     user_database  = var.db_name
     host           = var.db_host_endpoint

--- a/modules/secretsmanager/variables.tf
+++ b/modules/secretsmanager/variables.tf
@@ -18,6 +18,11 @@ variable "db_admin_password" {
   type        = string
 }
 
+variable "db_user_name" {
+  description = "Username for RDS database user authentication"
+  type        = string
+}
+
 variable "db_user_password" {
   description = "Password for RDS database user authentication"
   type        = string

--- a/tasks/db_deploy/create_db.py
+++ b/tasks/db_deploy/create_db.py
@@ -31,7 +31,7 @@ def create_fresh_orca_install(config: Dict[str, str]) -> None:
 
     with admin_app_connection.connect() as conn:
         # Create the roles, schema and user
-        create_app_schema_role_users(conn, config["user_password"], config["user_database"])
+        create_app_schema_role_users(conn, config["user_username"], config["user_password"], config["user_database"])
 
         # Change to DBO role and set search path
         set_search_path_and_role(conn)
@@ -45,13 +45,14 @@ def create_fresh_orca_install(config: Dict[str, str]) -> None:
         conn.commit()
 
 
-def create_app_schema_role_users(connection: Connection, app_password: str, db_name: str) -> None:
+def create_app_schema_role_users(connection: Connection, app_username: str, app_password: str, db_name: str) -> None:
     """
     Creates the ORCA application database schema, users and roles.
 
     Args:
         connection (sqlalchemy.future.Connection): Database connection.
-        app_password
+        app_username: The name for the created scoped user.
+        app_password: The password for the created scoped user.
         db_name: The name of the Orca database within the RDS cluster.
 
     Returns:
@@ -73,7 +74,7 @@ def create_app_schema_role_users(connection: Connection, app_password: str, db_n
 
     # Create the users last
     logger.debug("Creating the ORCA application user ...")
-    connection.execute(app_user_sql(app_password))
+    connection.execute(app_user_sql(app_username, app_password))
     logger.info("ORCA application user created.")
 
 

--- a/tasks/db_deploy/orca_sql.py
+++ b/tasks/db_deploy/orca_sql.py
@@ -171,7 +171,7 @@ def app_user_sql(user_name: str, user_password: str) -> TextClause:
         (sqlalchemy.sql.element.TextClause): SQL for creating PREFIX_orcauser user.
     """
     if user_name is None or len(user_name) == 0:
-        logger.critical("Username must be non-empty.")
+        logger.critical("Username not long enough.")
         raise Exception("Username not long enough.")
     if len(user_name) > 63:
         logger.critical("Username must be less than 64 characters.")
@@ -198,7 +198,7 @@ def app_user_sql(user_name: str, user_password: str) -> TextClause:
                 COMMENT ON ROLE {user_name}
                     IS 'ORCA application user.';
 
-                RAISE NOTICE 'USER CREATED {user_name}. PLEASE UPDATE THE USERS PASSWORD!';
+                RAISE NOTICE 'USER CREATED {user_name}.';
 
             END IF;
 

--- a/tasks/db_deploy/orca_sql.py
+++ b/tasks/db_deploy/orca_sql.py
@@ -159,7 +159,7 @@ def orca_schema_sql() -> TextClause:
     )
 
 
-def app_user_sql(user_password: str) -> TextClause:
+def app_user_sql(user_name: str, user_password: str) -> TextClause:
     """
     Full SQL for creating the ORCA application database user. Must be created
     after the app_role_sql and orca_schema_sql.
@@ -168,8 +168,15 @@ def app_user_sql(user_password: str) -> TextClause:
         user_password (str): Password for the application user
 
     Returns:
-        (sqlalchemy.sql.element.TextClause): SQL for creating orcauser user.
+        (sqlalchemy.sql.element.TextClause): SQL for creating PREFIX_orcauser user.
     """
+    if user_name is None or len(user_name) == 0:
+        logger.critical("Username must be non-empty.")
+        raise Exception("Username not long enough.")
+    if len(user_name) > 63:
+        logger.critical("Username must be less than 64 characters.")
+        raise Exception("Username too long.")
+
     if user_password is None or len(user_password) < 12:
         logger.critical("User password must be at least 12 characters long.")
         raise Exception("Password not long enough.")
@@ -179,24 +186,24 @@ def app_user_sql(user_password: str) -> TextClause:
         DO
         $$
         BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_user WHERE usename = 'orcauser' ) THEN
-                -- Create orcauser
-                CREATE ROLE orcauser
+            IF NOT EXISTS (SELECT 1 FROM pg_user WHERE usename = '{user_name}' ) THEN
+                -- Create {user_name}
+                CREATE ROLE {user_name}
                     LOGIN
                     INHERIT
                     ENCRYPTED PASSWORD '{user_password}'
                     IN ROLE orca_app;
 
                 -- Add comment
-                COMMENT ON ROLE orcauser
+                COMMENT ON ROLE {user_name}
                     IS 'ORCA application user.';
 
-                RAISE NOTICE 'USER CREATED orcauser. PLEASE UPDATE THE USERS PASSWORD!';
+                RAISE NOTICE 'USER CREATED {user_name}. PLEASE UPDATE THE USERS PASSWORD!';
 
             END IF;
 
             -- Alter the roles search path so on login it has what it needs for a path
-            ALTER ROLE orcauser SET search_path = orca, public;
+            ALTER ROLE {user_name} SET search_path = orca, public;
         END
         $$;
     """

--- a/tasks/db_deploy/orca_sql.py
+++ b/tasks/db_deploy/orca_sql.py
@@ -171,15 +171,15 @@ def app_user_sql(user_name: str, user_password: str) -> TextClause:
         (sqlalchemy.sql.element.TextClause): SQL for creating PREFIX_orcauser user.
     """
     if user_name is None or len(user_name) == 0:
-        logger.critical("Username not long enough.")
-        raise Exception("Username not long enough.")
+        logger.critical("Username must be non-empty.")
+        raise Exception("Username must be non-empty.")
     if len(user_name) > 63:
         logger.critical("Username must be less than 64 characters.")
-        raise Exception("Username too long.")
+        raise Exception("Username must be less than 64 characters.")
 
     if user_password is None or len(user_password) < 12:
         logger.critical("User password must be at least 12 characters long.")
-        raise Exception("Password not long enough.")
+        raise Exception("User password must be at least 12 characters long.")
 
     return text(
         f"""

--- a/tasks/db_deploy/test/manual_tests/env_template
+++ b/tasks/db_deploy/test/manual_tests/env_template
@@ -13,7 +13,7 @@ export TASK_DIR=""
 # root password for postgres user. Must be at least 12 characters long.
 export ADMIN_PASSWORD=""
 
-# application password for orcauser user. Must be at least 12 characters long.
+# application password for PREFIX_orcauser user. Must be at least 12 characters long.
 export APPLICATION_PASSWORD=""
 
 

--- a/tasks/db_deploy/test/manual_tests/manual_test.py
+++ b/tasks/db_deploy/test/manual_tests/manual_test.py
@@ -19,7 +19,7 @@ def set_search_path():
 def get_configuration():
     """
     Sets a static configuration so testing is easy. Only HOST and PASSWORDS
-    are variable per user.
+    are variable per user. Username is variable for the non-admin user.
     """
     my_host = os.getenv("DATABASE_HOST")
     my_admin_pass = os.getenv("ADMIN_PASSWORD")

--- a/tasks/db_deploy/test/unit_tests/test_create_db.py
+++ b/tasks/db_deploy/test/unit_tests/test_create_db.py
@@ -61,7 +61,7 @@ class TestCreateDatabaseLibraries(unittest.TestCase):
         mock_conn_enter = mock_connection().connect().__enter__()
 
         mock_create_app_schema_roles.assert_called_once_with(
-            mock_conn_enter, self.config["user_password"], self.config["user_database"]
+            mock_conn_enter, self.config["user_username"], self.config["user_password"], self.config["user_database"]
         )
         mock_set_search_path_role.assert_called_once_with(mock_conn_enter)
         mock_create_inventory_objects.assert_called_once_with(mock_conn_enter)
@@ -90,14 +90,14 @@ class TestCreateDatabaseLibraries(unittest.TestCase):
         Tests happy path of create_app_schema_role_users function.
         """
         create_db.create_app_schema_role_users(
-            self.mock_connection, self.config["user_password"], self.config["user_database"]
+            self.mock_connection, self.config["user_username"], self.config["user_password"], self.config["user_database"]
         )
 
         # Check that SQL called properly
         mock_dbo_role_sql.assert_called_once()
         mock_app_role_sql.assert_called_once()
         mock_schema_sql.assert_called_once()
-        mock_user_sql.assert_called_once_with(self.config["user_password"])
+        mock_user_sql.assert_called_once_with(self.config["user_username"], self.config["user_password"])
 
         # Check SQL called in proper order
         execution_order = [

--- a/tasks/db_deploy/test/unit_tests/test_orca_sql.py
+++ b/tasks/db_deploy/test/unit_tests/test_orca_sql.py
@@ -27,16 +27,19 @@ class TestOrcaSqlLogic(unittest.TestCase):
         user password is a part of the SQL.
         """
         user_pass = "MySup3rL0ngPassForAUser"
-        user_sql = orca_sql.app_user_sql(user_pass)
+        user_name = uuid.uuid4().__str__()
+        user_sql = orca_sql.app_user_sql(user_pass, user_name)
 
-        # Check that the password is in the SQL and the typw is text
+        # Check that the username and password are in the SQL and the type is text
         self.assertIn(user_pass, user_sql.text)
+        self.assertIn(user_name, user_sql.text)
         self.assertEqual(type(user_sql), TextClause)
 
     def test_app_user_sql_exceptions(self) -> None:
         """
         Tests that an exception is thrown if the password is not set or is not
-        a minimum of 12 characters.
+        a minimum of 12 characters,
+        or if user_name is not set or is over 64 characters.
         """
         bad_passwords = [None, "", "abc123", "1234567890", "AbCdEfG1234"]
         message = "Password not long enough."
@@ -44,8 +47,23 @@ class TestOrcaSqlLogic(unittest.TestCase):
         for bad_password in bad_passwords:
             with self.subTest(bad_password=bad_password):
                 with self.assertRaises(Exception) as cm:
-                    orca_sql.app_user_sql(bad_password)
+                    orca_sql.app_user_sql("orcauser", bad_password)
                 self.assertEqual(str(cm.exception), message)
+
+        bad_user_names = [None, ""]
+        message = "Username not long enough."
+        for bad_user_name in bad_user_names:
+            with self.subTest(bad_user_name=bad_user_name):
+                with self.assertRaises(Exception) as cm:
+                    orca_sql.app_user_sql(bad_user_name, "AbCdEfG12345")
+                self.assertEqual(str(cm.exception), message)
+
+        message = "Username too long."
+        bad_user_name = "".join("a" * 64)
+        with self.subTest(bad_user_name=bad_user_name) as cm:
+            with self.assertRaises(Exception) as cm:
+                orca_sql.app_user_sql(bad_user_name, "AbCdEfG12345")
+            self.assertEqual(str(cm.exception), message)
 
     def test_all_functions_return_text(self) -> None:
         """
@@ -55,8 +73,11 @@ class TestOrcaSqlLogic(unittest.TestCase):
         for name, function in getmembers(orca_sql, isfunction):
             if name not in ["text"]:
                 with self.subTest(function=function):
-                    if name in ["app_database_sql", "app_database_comment_sql", "dbo_role_sql", "app_role_sql",
-                                "app_user_sql", "drop_dr_role_sql", "drop_dbo_user_sql", "drop_drdbo_role_sql"]:
+                    if name in ["app_user_sql"]:
+                        self.assertEqual(type(function(uuid.uuid4().__str__(), uuid.uuid4().__str__())), TextClause)
+                        # These functions take in two string parameters.
+                    elif name in ["app_database_sql", "app_database_comment_sql", "dbo_role_sql", "app_role_sql",
+                                  "drop_dr_role_sql", "drop_dbo_user_sql", "drop_drdbo_role_sql"]:
                         # These functions take in a string parameter.
                         self.assertEqual(type(function(uuid.uuid4().__str__())), TextClause)
                     else:

--- a/tasks/db_deploy/test/unit_tests/test_orca_sql.py
+++ b/tasks/db_deploy/test/unit_tests/test_orca_sql.py
@@ -42,7 +42,7 @@ class TestOrcaSqlLogic(unittest.TestCase):
         or if user_name is not set or is over 64 characters.
         """
         bad_passwords = [None, "", "abc123", "1234567890", "AbCdEfG1234"]
-        message = "Password not long enough."
+        message = "User password must be at least 12 characters long."
 
         for bad_password in bad_passwords:
             with self.subTest(bad_password=bad_password):
@@ -51,14 +51,14 @@ class TestOrcaSqlLogic(unittest.TestCase):
                 self.assertEqual(str(cm.exception), message)
 
         bad_user_names = [None, ""]
-        message = "Username not long enough."
+        message = "Username must be non-empty."
         for bad_user_name in bad_user_names:
             with self.subTest(bad_user_name=bad_user_name):
                 with self.assertRaises(Exception) as cm:
                     orca_sql.app_user_sql(bad_user_name, "AbCdEfG12345")
                 self.assertEqual(str(cm.exception), message)
 
-        message = "Username too long."
+        message = "Username must be less than 64 characters."
         bad_user_name = "".join("a" * 64)
         with self.subTest(bad_user_name=bad_user_name) as cm:
             with self.assertRaises(Exception) as cm:

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,14 @@ variable "db_name" {
   default     = null
 }
 
+
+variable "db_user_name" {
+  description = "The name of the application user for the Orca database. Default set to PREFIX_orca in main.tf. Any `-` in `prefix` will be replaced with `_`."
+  type        = string
+  default     = null
+}
+
+
 variable "default_multipart_chunksize_mb" {
   type        = number
   description = "The default maximum size of chunks to use when copying. Can be overridden by collection config."

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -487,6 +487,7 @@ variables is shown in the table below.
 | `default_multipart_chunksize_mb`                      | number        | The default maximum size of chunks to use when copying. Can be overridden by collection config.         | 250 |
 | `metadata_queue_message_retention_time_seconds`       | number        | Number of seconds the metadata-queue fifo SQS retains a message.                                        | 777600 |
 | `db_name`                                             | string        | The name of the Orca database within the RDS cluster. Any `-` in `prefix` will be replaced with `_`.    | PREFIX_orca |
+| `db_user_name`                                        | string        | The name of the application user for the Orca database. Any `-` in `prefix` will be replaced with `_`.    | PREFIX_orcauser |
 | `orca_ingest_lambda_memory_size`                      | number        | Amount of memory in MB the ORCA copy_to_glacier lambda can use at runtime.                              | 2240 |
 | `orca_ingest_lambda_timeout`                          | number        | Timeout in number of seconds for ORCA copy_to_glacier lambda.                                           | 600 |
 | `orca_recovery_buckets`                               | List (string) | List of bucket names that ORCA has permissions to restore data to. Default is all in the `buckets` map. | [] |


### PR DESCRIPTION
## Summary of Changes

Database username now parameterized to allow multiple orcausers within the same cluster.

Addresses [ORCA-363: Switch from orcauser to prefix-able username](https://bugs.earthdata.nasa.gov/browse/ORCA-363)

## Changes

* Added to tf as db_user_name

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Deployed to AWS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Testing documentation
    - [x] Development documentation
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets