### PR TITLE
feature/ORCA-364 Fix ordering in orca_catalog_reporting

### DIFF
--- a/tasks/orca_catalog_reporting/orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/orca_catalog_reporting.py
@@ -133,11 +133,11 @@ SELECT
                 (:granule_id is null or cumulus_granule_id=ANY(:granule_id)) and 
                 (:start_timestamp is null or (EXTRACT(EPOCH FROM date_trunc('milliseconds', cumulus_create_time) AT TIME ZONE 'UTC') * 1000)::bigint>=:start_timestamp) and 
                 (:end_timestamp is null or (EXTRACT(EPOCH FROM date_trunc('milliseconds', cumulus_create_time) AT TIME ZONE 'UTC') * 1000)::bigint<:end_timestamp)
-            ORDER BY cumulus_granule_id
             ) as granule_ids
             JOIN
                 granules ON granule_ids.cumulus_granule_id = granules.cumulus_granule_id
         ) as granules
+    ORDER BY cumulus_granule_id, provider_id
     OFFSET :page_index*:page_size
     LIMIT :page_size+1
 ) as granules


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-364: Fix ordering in orca_catalog_reporting](https://bugs.earthdata.nasa.gov/browse/ORCA-364)

## Changes

* Ordering by granule id now functional.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run against real DB.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets