### PR TITLE
Fix Misspellings across /docs/ within ORCA-349

### DIFF
--- a/website/docs/about/introduction/contributing.md
+++ b/website/docs/about/introduction/contributing.md
@@ -3,7 +3,7 @@ id: intro-contributing
 title: Contributing to ORCA
 description: Provides high level information on contributing to the ORCA project.
 ---
-# Types of Contributers
+# Types of Contributors
 ## Engagement Levels
 ORCA has several ways to engage with the project and several different
 engagement levels. The various levels are explained below.

--- a/website/docs/about/introduction/glossary.md
+++ b/website/docs/about/introduction/glossary.md
@@ -42,7 +42,7 @@ resources you have in AWS.
 
 For more information, see the [AWS User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html).
 
-### Cloud Nofification Mechanism (CNM)
+### Cloud Notification Mechanism (CNM)
 An interface mechanism to support cloud-based ingest messaging. For more
 information, see [PO.DAAC's CNM Schema](https://github.com/podaac/cloud-notification-message-schema).
 

--- a/website/docs/developer/development-guide/documentation/documentation-deployment.md
+++ b/website/docs/developer/development-guide/documentation/documentation-deployment.md
@@ -26,7 +26,7 @@ deployment information can be found at the [Docusaurus deployment page](https://
 
 :::important Important
 
-* Users need **Node 12.15.0** installed to perform manaul updates to documentation.
+* Users need **Node 12.15.0** installed to perform manual updates to documentation.
 * The `Deployment_Branch` must = **gh-pages**.
 :::
 


### PR DESCRIPTION
## Summary of Changes
Fixes 3 misspellings across `website/docs/`

## Changes
`Contributers` -> `Contributors`
`Nofification` -> `Notification`
`manaul` -> `manual`
