### PR TITLE
Feature/orca 334

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and includes an additional section for migration notes.
 - *ORCA-299* `db_deploy` task has been updated to deploy ORCA internal reconciliation tables and objects.
 - *ORCA-161* Changed staged recovery SQS queue type from FIFO to standard queue.
 - SQS Queue names adjusted to include Orca. For example: `"${var.prefix}-orca-status-update-queue.fifo"`. Queues will be automatically recreated by Terraform.
+- *ORCA-334* Created IAM role for the extract_filepaths_for_granule lambda function, attached the role to the function
 
 ### Migration Notes
 


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-334](https://bugs.earthdata.nasa.gov/browse/ORCA-334)

## Changes

* Created new aws_iam_policy_document, aws_iam_role, and aws_iam_role_policy objects used for lambda execution
* Created an aws_iam_role_policy_attachment used for lambda deployment and attached it to the created aws_iam_role
* Set the role to be used by the extract_filepaths_for_granule lambda

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Test the lambda using the lambda execution UI
- Test the lambda using the OrcaRecoveryWorkflow stepfunction

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets