### PR TITLE
Updated create extension SQL in db_deploy to fix install failures

### DIFF
--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -28,6 +28,7 @@ module "orca_lambdas" {
   ## ORCA Variables
   ## --------------------------
   ## REQUIRED
+  db_connect_info_secret_arn                           = module.orca_secretsmanager.secretsmanager_arn
   orca_default_bucket                                  = var.orca_default_bucket
   orca_secretsmanager_s3_access_credentials_secret_arn = module.orca_secretsmanager.s3_access_credentials_secret_arn
   orca_sqs_internal_report_queue_id                    = module.orca_sqs.orca_sqs_internal_report_queue_id

--- a/tasks/db_deploy/README.md
+++ b/tasks/db_deploy/README.md
@@ -183,12 +183,14 @@ Using the AWS Lambda interface for db_deploy perform the following steps:
 
 1. Make sure the following environment variable is set for the Lambda.
    ```
-   PREFIX           - Your var.prefix value from variables.tfvars
+   DB_CONNECT_INFO_SECRET_ARN   - Your secretsmanager secret ARN needed for connecting to the DB.
    AWS_REGION       - automatically set by AWS as a defined runtime variable
    ```
-2. Create an empty JSON test event.
-   ```
-   {}
+2. Create a JSON test event as shown below. Replace `prefix` with the one you used.
+   ```json
+   {
+   "orcaBuckets": ["prefix-orca-primary"]
+   }  
    ```
 3. Perform validation of the migration similar to the tests and commands provided
    in the [manual test documentation](test/manual_tests/README.md) for validating

--- a/tasks/db_deploy/install/orca_sql.py
+++ b/tasks/db_deploy/install/orca_sql.py
@@ -234,10 +234,6 @@ def create_extension() -> TextClause:
         """
             -- Create extension
             CREATE EXTENSION IF NOT EXISTS aws_s3 CASCADE;
-
-            -- Comment
-            COMMENT ON EXTENSION aws_s3
-              IS 'Custom AWS extension that allows for data COPY from and to an S3 bucket object.';
         """
     )
 

--- a/tasks/db_deploy/migrations/migrate_versions_4_to_5/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_4_to_5/migrate_sql.py
@@ -54,10 +54,6 @@ def create_extension() -> TextClause:
         """
             -- Create extension
             CREATE EXTENSION IF NOT EXISTS aws_s3 CASCADE;
-
-            -- Comment
-            COMMENT ON EXTENSION aws_s3
-              IS 'Custom AWS extension that allows for data COPY from and to an S3 bucket object.';
         """
     )
 


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-416: Update create extension SQL in db_deploy to fix install failures](https://bugs.earthdata.nasa.gov/browse/ORCA-416)

## Changes

* fixed the terraform bug in modules/orca/main.tf
* removed extension comment in tasks/db_deploy/install/orca_sql.py
* removed extension comment in tasks/db_deploy/migrations/migrate_versions_4_to_5/migrate_sql.py

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cloudwatch logs link: 
https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frizh_db_deploy/log-events/2022$252F04$252F07$252F$255B$2524LATEST$255Db618732ce6e94a90bb3d506176f72f97

**Test case 1:** 

Dropped database prefix_orca, dropped users and roles while being connected to the postgres DB. This also removed all extensions in orca DB.

SQL query used:
```
DROP database rizh_orca;
DROP ROLE IF EXISTS rizh_orcauser;
REVOKE CREATE ON DATABASE rizh_orca FROM GROUP orca_dbo;
REVOKE CONNECT ON DATABASE rizh_orca FROM GROUP orca_dbo;
DROP GROUP IF EXISTS orca_dbo;
REVOKE CONNECT ON DATABASE rizh_orca FROM GROUP orca_app;
DROP GROUP IF EXISTS orca_app;
```
Once this is successful, I manually triggered the rizh_db_deploy using the following json test event:
```
{
"orcaBuckets": ["rizh-orca-primary"]
}
```
This showed a successful run. The next step was to check the db_deploy cloudwatch logs to make sure database, schemas and other roles, tables are created. The DB and schema creation was also verified by connecting to the ORCA DB and running queries like 
```select * from pg_extension;```

**Test case 2:** 

Dropped the orca schema from prefix_orca DB. The extensions and ORCA DB are not dropped. 
db-deploy was run using same test event as above which returned a successful run. 
Checked the lambda logs and verified that logs for creating the schema exist.
SQL query used to drop the schema from orca DB:
```
DROP schema orca cascade;
```
SQL for checking the extensions in orca DB:
```
select * from pg_extension;
```

**Test case 3:** 

No changes were made to the DB or extensions.
Only db-deploy lambda was run using same test event as above which returned a successful run. 
Checked the lambda logs and verified that there are no logs for migration or DB/schema creation.
```
{"message": "Current ORCA schema version detected. No migration needed!", "sender": "rizh_db_deploy", "version": "$LATEST", "timestamp": "2022-04-07T21:14:08.841678", "level": "info"}
```

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas