### PR TITLE
Feature/orca 304 Research using ECS instances instead of lambdas for get_current_archive_list and perform_orca_reconcile.

### DIFF
--- a/website/docs/developer/research/research-lambda-container.md
+++ b/website/docs/developer/research/research-lambda-container.md
@@ -182,7 +182,7 @@ The Orca Internal Reconciliation workflow lambdas require an alternative approac
 
   CMD ["python", "main.py"]
   ```
-- Follow prior instructions up to the Terraform deployment. Use the following Terraform instead of the pervious example.
+- Follow prior instructions up to the Terraform deployment. Use the following Terraform instead of the previous example.
 ```terraform
 data "aws_iam_policy_document" "sqs_task_policy_document" {
   statement {
@@ -247,6 +247,7 @@ resource "aws_ecs_cluster" "test-cluster" {
   }
 }
 
+# Defines how the image will be run. container_definitions can be replaced by data element.
 resource "aws_ecs_task_definition" "task" {
   family                   = "${var.prefix}_orca_sqs_task"
   network_mode             = "awsvpc"
@@ -284,6 +285,7 @@ DEFINITION
 }
 :::note
 The above example was developed for deploying a simple task that posts to an sqs queue. Names and values should be changed to match new use cases.
+Values such as `cpu` and `memory` should similarly be reevaluated.
 :::
 :::warning
 Applying admin permissions to orca_ecs_task_execution_role is likely overly permissive.
@@ -291,6 +293,8 @@ Applying admin permissions to orca_ecs_task_execution_role is likely overly perm
 - The task can now be run in the cluster.
 This can be done through [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task) or the GUI,
 though the former is presently untested.
+- [Pricing](https://aws.amazon.com/ecs/pricing/?trk=2f064982-4fad-4e1f-ab75-e1df26258a60&sc_channel=ps&sc_campaign=acquisition&sc_medium=GC-PMM|PS-GO|Brand|All|PA|Database|ECS|Product|US|EN|Text|xx|SEM|PMO22-13405&s_kwcid=AL!4422!3!547620651289!e!!g!!amazon%20ecs%20pricing&ef_id=EAIaIQobChMIsO-ehu2l9wIVCfrICh0gOQ5OEAAYASABEgIZmfD_BwE:G:s&s_kwcid=AL!4422!3!547620651289!e!!g!!amazon%20ecs%20pricing) only applies to what is used in the moment, and can auto-scale down.
+  - Minimum compute time is one minute, so this architecture should not be used for small, frequent tasks.
 
 
 

--- a/website/docs/developer/research/research-lambda-container.md
+++ b/website/docs/developer/research/research-lambda-container.md
@@ -290,7 +290,7 @@ Values such as `cpu` and `memory` should similarly be reevaluated.
 :::warning
 Applying admin permissions to orca_ecs_task_execution_role is likely overly permissive.
 :::
-- The task can now be run in the cluster.
+- The Fargate task can now be run in the ECS cluster.
 This can be done through [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task) or the GUI,
 though the former is presently untested.
 - [Pricing](https://aws.amazon.com/ecs/pricing/?trk=2f064982-4fad-4e1f-ab75-e1df26258a60&sc_channel=ps&sc_campaign=acquisition&sc_medium=GC-PMM|PS-GO|Brand|All|PA|Database|ECS|Product|US|EN|Text|xx|SEM|PMO22-13405&s_kwcid=AL!4422!3!547620651289!e!!g!!amazon%20ecs%20pricing&ef_id=EAIaIQobChMIsO-ehu2l9wIVCfrICh0gOQ5OEAAYASABEgIZmfD_BwE:G:s&s_kwcid=AL!4422!3!547620651289!e!!g!!amazon%20ecs%20pricing) only applies to what is used in the moment, and can auto-scale down.

--- a/website/docs/developer/research/research-lambda-container.md
+++ b/website/docs/developer/research/research-lambda-container.md
@@ -322,7 +322,13 @@ though the former is presently untested.
 - [Pricing](https://aws.amazon.com/ecs/pricing/?trk=2f064982-4fad-4e1f-ab75-e1df26258a60&sc_channel=ps&sc_campaign=acquisition&sc_medium=GC-PMM|PS-GO|Brand|All|PA|Database|ECS|Product|US|EN|Text|xx|SEM|PMO22-13405&s_kwcid=AL!4422!3!547620651289!e!!g!!amazon%20ecs%20pricing&ef_id=EAIaIQobChMIsO-ehu2l9wIVCfrICh0gOQ5OEAAYASABEgIZmfD_BwE:G:s&s_kwcid=AL!4422!3!547620651289!e!!g!!amazon%20ecs%20pricing) only applies to what is used in the moment, and can auto-scale down.
   - Minimum compute time is one minute, so this architecture should not be used for small, frequent tasks.
 
-
+#### Recommendation
+Recommend use of the above architecture to resolve concerns with timeouts when handling large inventories.
+get_current_archive_list and perform_orca_reconcile can be merged into one codebase, with an overarching loop. https://bugs.earthdata.nasa.gov/browse/ORCA-428
+This script can be built into a Docker container and deployed to the result of [ECR reserach](https://bugs.earthdata.nasa.gov/browse/ORCA-375). https://bugs.earthdata.nasa.gov/browse/ORCA-429
+This new script can then be deployed as a task definition in AWS. https://bugs.earthdata.nasa.gov/browse/ORCA-432
+The task definition can be run periodically to empty the queue of any internal reconciliation jobs. https://bugs.earthdata.nasa.gov/browse/ORCA-430
+We can either remove triggering from post_to_queue_and_trigger_step_function or update it to trigger the Fargate task when called. https://bugs.earthdata.nasa.gov/browse/ORCA-431
 
 ##### References
 - https://aws.amazon.com/blogs/aws/new-for-aws-lambda-container-image-support/

--- a/website/docs/developer/research/research-lambda-container.md
+++ b/website/docs/developer/research/research-lambda-container.md
@@ -161,10 +161,8 @@ The Orca Internal Reconciliation workflow lambdas require an alternative approac
     - Alternatively, a side-program could manually stop the task if it exceeds its' time limit.
     - Remember that in addition to processing time, Aurora Serverless can take up to 5 minutes to spin up.
   - Raise the internal-report queue's `visibility_timeout_seconds` to the expected timeout.
+  - Environment variables can be passed in at task definition, or when the task is run. The former should be sufficient.
   
-
-
-
 - Follow prior instructions up to the Terraform deployment.
 - Create an IAM role with the permissions needed. Use case should be `EC2`. Note that developers do not have this capability.
 - Create a task definition for the image.
@@ -178,7 +176,8 @@ The Orca Internal Reconciliation workflow lambdas require an alternative approac
     - `PREFIX-orca-internal-reconciliation-container` name
     - Link to the uploaded image for Image
 - Create an ECS cluster
-  - TODO
+
+TODO: Demo this with a simple service that posts to a queue.
 
 
 


### PR DESCRIPTION
## Summary of Changes

Research using ECS instances instead of lambdas for get_current_archive_list and perform_orca_reconcile. Added recommendations and sample implementation to docs.

Addresses [ORCA-304: Research using ECS instances instead of lambdas for get_current_archive_list and perform_orca_reconcile.](https://bugs.earthdata.nasa.gov/browse/ORCA-304)

## Changes

* Added researched implementation for running Python via Fargate to docs.
* Added suggestions on code changes for merging get_current_archive_list and perform_orca_reconcile to docs.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Deployed sample code to AWS with the instructions given.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] Development documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets