### PR TITLE
Feature/orca 426 Update lambdas to move schema validation code out of handler for better lambda performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and includes an additional section for migration notes.
     "orcaDefaultRecoveryTypeOverride": "Standard"
   }
   ```
+- *ORCA-426* Performance improvements around json schema validators.
 
 ### Migration Notes
 

--- a/tasks/copy_to_glacier/sqs_library.py
+++ b/tasks/copy_to_glacier/sqs_library.py
@@ -24,6 +24,13 @@ BACKOFF_FACTOR = 2  # Value of the factor used to backoff
 INITIAL_BACKOFF_IN_SECONDS = 1  # Number of seconds to sleep the first time through.
 RT = TypeVar("RT")  # return type
 
+try:
+    with open("schemas/body.json", "r") as raw_schema:
+        _BODY_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
+except Exception as ex:
+    LOGGER.error(f"Could not build schema validator: {ex}")
+    raise
+
 
 # Retry decorator for function
 # todo: Lacks unit tests. Will likely eventually be part of shared lib ORCA-148.
@@ -121,12 +128,8 @@ def post_to_metadata_queue(
     Raises:
         None
     """
-    # validate body.json schema
-    with open("schemas/body.json", "r") as raw_schema:
-        schema = json.loads(raw_schema.read())
-    validate = fastjsonschema.compile(schema)
     LOGGER.debug("Validating the SQS message body with the schema.")
-    validate(sqs_body)
+    _BODY_VALIDATE(sqs_body)
     body = json.dumps(sqs_body)
     LOGGER.debug(
         "Creating SQS resource for {metadata_queue_url}",

--- a/tasks/copy_to_glacier/test/unit_tests/test_copy_to_glacier.py
+++ b/tasks/copy_to_glacier/test/unit_tests/test_copy_to_glacier.py
@@ -14,6 +14,9 @@ from copy_to_glacier import *
 from test.helpers import LambdaContextMock
 from test.unit_tests.ConfigCheck import ConfigCheck
 
+# Generating schema validators can take time, so do it once and reuse.
+with open("schemas/output.json", "r") as raw_schema:
+    _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 class TestCopyToGlacierHandler(TestCase):
     """
@@ -241,11 +244,7 @@ class TestCopyToGlacierHandler(TestCase):
 
         mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result)
+        _OUTPUT_VALIDATE(result)
 
         expected_granules = copy.deepcopy(event["input"]["granules"])
         self.assertEqual(expected_granules, result["granules"])
@@ -508,11 +507,7 @@ class TestCopyToGlacierHandler(TestCase):
 
         mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result)
+        _OUTPUT_VALIDATE(result)
 
         expected_granules = copy.deepcopy(event["input"]["granules"])
         self.assertEqual(expected_granules, result["granules"])
@@ -612,11 +607,7 @@ class TestCopyToGlacierHandler(TestCase):
 
         mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result)
+        _OUTPUT_VALIDATE(result)
 
         expected_granules = copy.deepcopy(event["input"]["granules"])
         self.assertEqual(expected_granules, result["granules"])
@@ -690,11 +681,7 @@ class TestCopyToGlacierHandler(TestCase):
 
         mock_get_default_glacier_bucket_name.assert_called_once_with(config)
 
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result)
+        _OUTPUT_VALIDATE(result)
 
         self.assertEqual([], result["granules"])
         granules = result["granules"]

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
@@ -13,6 +13,11 @@ import extract_filepaths_for_granule
 import fastjsonschema as fastjsonschema
 from unittest.mock import patch, MagicMock, Mock
 
+# Generating schema validators can take time, so do it once and reuse.
+with open("schemas/input.json", "r") as raw_schema:
+    _INPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
+with open("schemas/output.json", "r") as raw_schema:
+    _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 class TestExtractFilePaths(unittest.TestCase):
     """
@@ -383,11 +388,7 @@ class TestExtractFilePaths(unittest.TestCase):
         self.assertEqual(exp_result, result)
 
         # Validate the output is correct by matching with the output schema
-        with open("schemas/output.json", "r") as output_schema:
-            output_schema = json.loads(output_schema.read())
-
-        validate_output = fastjsonschema.compile(output_schema)
-        validate_output(exp_result)
+        _OUTPUT_VALIDATE(exp_result)
 
     def test_exclude_file_types(self):
         """
@@ -420,11 +421,8 @@ class TestExtractFilePaths(unittest.TestCase):
             ]
         }
         # Validate the input is correct by matching with the input schema
-        with open("schemas/input.json", "r") as input_schema:
-            input_schema = json.loads(input_schema.read())
         try:
-            validate_input = fastjsonschema.compile(input_schema)
-            validate_input(input_event)
+            _INPUT_VALIDATE(input_event)
         except Exception as ex:
             self.assertEqual(
                 ex.message,

--- a/tasks/internal_reconcile_report_job/internal_reconcile_report_job.py
+++ b/tasks/internal_reconcile_report_job/internal_reconcile_report_job.py
@@ -157,8 +157,6 @@ def create_http_error_dict(
             'requestId' (str)
             'message' (str)
     """
-    # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-    message = message.replace("{", "{{").replace("}", "}}")
     LOGGER.error(message)
     return {
         "errorType": error_type,

--- a/tasks/internal_reconcile_report_job/test/unit_tests/test_internal_reconcile_report_job.py
+++ b/tasks/internal_reconcile_report_job/test/unit_tests/test_internal_reconcile_report_job.py
@@ -337,6 +337,28 @@ class TestInternalReconcileReportJob(
             result,
         )
 
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_create_http_error_dict_happy_path(
+            self,
+            mock_error: MagicMock
+    ):
+        error_type = uuid.uuid4().__str__()
+        http_status_code = random.randint(0, 9999)  # nosec
+        request_id = uuid.uuid4().__str__()
+        message = """Some error dictionary: {"fruit": "apple"}"""
+        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+
+        result = internal_reconcile_report_job.create_http_error_dict(error_type, http_status_code, request_id, message)
+
+        self.assertEqual({
+            "errorType": error_type,
+            "httpStatus": http_status_code,
+            "requestId": request_id,
+            "message": modified_message,
+        }, result)
+
+        mock_error.assert_called_once_with(modified_message)
+
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(
         os.environ,

--- a/tasks/internal_reconcile_report_job/test/unit_tests/test_internal_reconcile_report_job.py
+++ b/tasks/internal_reconcile_report_job/test/unit_tests/test_internal_reconcile_report_job.py
@@ -345,8 +345,7 @@ class TestInternalReconcileReportJob(
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
-        message = """Some error dictionary: {"fruit": "apple"}"""
-        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+        message = uuid.uuid4().__str__()
 
         result = internal_reconcile_report_job.create_http_error_dict(error_type, http_status_code, request_id, message)
 
@@ -354,10 +353,10 @@ class TestInternalReconcileReportJob(
             "errorType": error_type,
             "httpStatus": http_status_code,
             "requestId": request_id,
-            "message": modified_message,
+            "message": message,
         }, result)
 
-        mock_error.assert_called_once_with(modified_message)
+        mock_error.assert_called_once_with(message)
 
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(

--- a/tasks/internal_reconcile_report_mismatch/internal_reconcile_report_mismatch.py
+++ b/tasks/internal_reconcile_report_mismatch/internal_reconcile_report_mismatch.py
@@ -181,8 +181,6 @@ def create_http_error_dict(
             'requestId' (str)
             'message' (str)
     """
-    # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-    message = message.replace("{", "{{").replace("}", "}}")
     LOGGER.error(message)
     return {
         "errorType": error_type,

--- a/tasks/internal_reconcile_report_mismatch/test/unit_tests/test_internal_reconcile_report_mismatch.py
+++ b/tasks/internal_reconcile_report_mismatch/test/unit_tests/test_internal_reconcile_report_mismatch.py
@@ -396,8 +396,7 @@ class TestInternalReconcileReportMismatch(
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
-        message = """Some error dictionary: {"fruit": "apple"}"""
-        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+        message = uuid.uuid4().__str__()
 
         result = internal_reconcile_report_mismatch.create_http_error_dict(error_type, http_status_code, request_id, message)
 
@@ -405,10 +404,10 @@ class TestInternalReconcileReportMismatch(
             "errorType": error_type,
             "httpStatus": http_status_code,
             "requestId": request_id,
-            "message": modified_message,
+            "message": message,
         }, result)
 
-        mock_error.assert_called_once_with(modified_message)
+        mock_error.assert_called_once_with(message)
 
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(

--- a/tasks/internal_reconcile_report_mismatch/test/unit_tests/test_internal_reconcile_report_mismatch.py
+++ b/tasks/internal_reconcile_report_mismatch/test/unit_tests/test_internal_reconcile_report_mismatch.py
@@ -388,6 +388,28 @@ class TestInternalReconcileReportMismatch(
             result,
         )
 
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_create_http_error_dict_happy_path(
+            self,
+            mock_error: MagicMock
+    ):
+        error_type = uuid.uuid4().__str__()
+        http_status_code = random.randint(0, 9999)  # nosec
+        request_id = uuid.uuid4().__str__()
+        message = """Some error dictionary: {"fruit": "apple"}"""
+        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+
+        result = internal_reconcile_report_mismatch.create_http_error_dict(error_type, http_status_code, request_id, message)
+
+        self.assertEqual({
+            "errorType": error_type,
+            "httpStatus": http_status_code,
+            "requestId": request_id,
+            "message": modified_message,
+        }, result)
+
+        mock_error.assert_called_once_with(modified_message)
+
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(
         os.environ,

--- a/tasks/internal_reconcile_report_orphan/internal_reconcile_report_orphan.py
+++ b/tasks/internal_reconcile_report_orphan/internal_reconcile_report_orphan.py
@@ -146,8 +146,6 @@ def create_http_error_dict(
             'requestId' (str)
             'message' (str)
     """
-    # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-    message = message.replace("{", "{{").replace("}", "}}")
     LOGGER.error(message)
     return {
         "errorType": error_type,

--- a/tasks/internal_reconcile_report_orphan/test/unit_tests/test_internal_reconcile_report_orphan.py
+++ b/tasks/internal_reconcile_report_orphan/test/unit_tests/test_internal_reconcile_report_orphan.py
@@ -345,8 +345,7 @@ class TestInternalReconcileReportOrphan(
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
-        message = """Some error dictionary: {"fruit": "apple"}"""
-        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+        message = uuid.uuid4().__str__()
 
         result = internal_reconcile_report_orphan.create_http_error_dict(error_type, http_status_code, request_id, message)
 
@@ -354,10 +353,10 @@ class TestInternalReconcileReportOrphan(
             "errorType": error_type,
             "httpStatus": http_status_code,
             "requestId": request_id,
-            "message": modified_message,
+            "message": message,
         }, result)
 
-        mock_error.assert_called_once_with(modified_message)
+        mock_error.assert_called_once_with(message)
 
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(

--- a/tasks/internal_reconcile_report_orphan/test/unit_tests/test_internal_reconcile_report_orphan.py
+++ b/tasks/internal_reconcile_report_orphan/test/unit_tests/test_internal_reconcile_report_orphan.py
@@ -337,6 +337,28 @@ class TestInternalReconcileReportOrphan(
             result,
         )
 
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_create_http_error_dict_happy_path(
+            self,
+            mock_error: MagicMock
+    ):
+        error_type = uuid.uuid4().__str__()
+        http_status_code = random.randint(0, 9999)  # nosec
+        request_id = uuid.uuid4().__str__()
+        message = """Some error dictionary: {"fruit": "apple"}"""
+        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+
+        result = internal_reconcile_report_orphan.create_http_error_dict(error_type, http_status_code, request_id, message)
+
+        self.assertEqual({
+            "errorType": error_type,
+            "httpStatus": http_status_code,
+            "requestId": request_id,
+            "message": modified_message,
+        }, result)
+
+        mock_error.assert_called_once_with(modified_message)
+
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(
         os.environ,

--- a/tasks/internal_reconcile_report_phantom/internal_reconcile_report_phantom.py
+++ b/tasks/internal_reconcile_report_phantom/internal_reconcile_report_phantom.py
@@ -154,8 +154,6 @@ def create_http_error_dict(
             'requestId' (str)
             'message' (str)
     """
-    # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-    message = message.replace("{", "{{").replace("}", "}}")
     LOGGER.error(message)
     return {
         "errorType": error_type,

--- a/tasks/internal_reconcile_report_phantom/test/unit_tests/test_internal_reconcile_report_phantom.py
+++ b/tasks/internal_reconcile_report_phantom/test/unit_tests/test_internal_reconcile_report_phantom.py
@@ -347,6 +347,28 @@ class TestInternalReconcileReportPhantom(
             result,
         )
 
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_create_http_error_dict_happy_path(
+            self,
+            mock_error: MagicMock
+    ):
+        error_type = uuid.uuid4().__str__()
+        http_status_code = random.randint(0, 9999)  # nosec
+        request_id = uuid.uuid4().__str__()
+        message = """Some error dictionary: {"fruit": "apple"}"""
+        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+
+        result = internal_reconcile_report_phantom.create_http_error_dict(error_type, http_status_code, request_id, message)
+
+        self.assertEqual({
+            "errorType": error_type,
+            "httpStatus": http_status_code,
+            "requestId": request_id,
+            "message": modified_message,
+        }, result)
+
+        mock_error.assert_called_once_with(modified_message)
+
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(
         os.environ,

--- a/tasks/internal_reconcile_report_phantom/test/unit_tests/test_internal_reconcile_report_phantom.py
+++ b/tasks/internal_reconcile_report_phantom/test/unit_tests/test_internal_reconcile_report_phantom.py
@@ -355,8 +355,7 @@ class TestInternalReconcileReportPhantom(
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
-        message = """Some error dictionary: {"fruit": "apple"}"""
-        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+        message = uuid.uuid4().__str__()
 
         result = internal_reconcile_report_phantom.create_http_error_dict(error_type, http_status_code, request_id, message)
 
@@ -364,10 +363,10 @@ class TestInternalReconcileReportPhantom(
             "errorType": error_type,
             "httpStatus": http_status_code,
             "requestId": request_id,
-            "message": modified_message,
+            "message": message,
         }, result)
 
-        mock_error.assert_called_once_with(modified_message)
+        mock_error.assert_called_once_with(message)
 
     # tests for check_env_variable copied from https://github.com/nasa/cumulus-orca/pull/260/
     @patch.dict(

--- a/tasks/orca_catalog_reporting/orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/orca_catalog_reporting.py
@@ -191,8 +191,6 @@ def create_http_error_dict(
             'requestId' (str)
             'message' (str)
     """
-    # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-    message = message.replace("{", "{{").replace("}", "}}")
     LOGGER.error(message)
     return {
         "errorType": error_type,

--- a/tasks/orca_catalog_reporting/orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/orca_catalog_reporting.py
@@ -13,6 +13,20 @@ from sqlalchemy.future import Engine
 LOGGER = CumulusLogger()
 
 PAGE_SIZE = 100
+# Generating schema validators can take time, so do it once and reuse.
+try:
+    with open("schemas/input.json", "r") as raw_schema:
+        _INPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
+except Exception as ex:
+    LOGGER.error(f"Could not build schema validator: {ex}")
+    raise
+
+try:
+    with open("schemas/output.json", "r") as raw_schema:
+        _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
+except Exception as ex:
+    LOGGER.error(f"Could not build schema validator: {ex}")
+    raise
 
 
 def task(
@@ -211,11 +225,7 @@ def handler(
         LOGGER.setMetadata(event, context)
 
         try:
-            with open("schemas/input.json", "r") as raw_schema:
-                schema = json.loads(raw_schema.read())
-
-            validate = fastjsonschema.compile(schema)
-            validate(event)
+            _INPUT_VALIDATE(event)
         except JsonSchemaException as json_schema_exception:
             return create_http_error_dict(
                 "BadRequest",
@@ -243,11 +253,7 @@ def handler(
             event["pageIndex"],
             db_connect_info,
         )
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result)
+        _OUTPUT_VALIDATE(result)
 
         return result
     except Exception as error:

--- a/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
@@ -451,23 +451,25 @@ class TestOrcaCatalogReportingUnit(
         )
 
     @patch("cumulus_logger.CumulusLogger.error")
-    def test_create_http_error_dict_happy_path(
-            self,
-            mock_error: MagicMock
-    ):
+    def test_create_http_error_dict_happy_path(self, mock_error: MagicMock):
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
         message = """Some error dictionary: {"fruit": "apple"}"""
         modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
 
-        result = orca_catalog_reporting.create_http_error_dict(error_type, http_status_code, request_id, message)
+        result = orca_catalog_reporting.create_http_error_dict(
+            error_type, http_status_code, request_id, message
+        )
 
-        self.assertEqual({
-            "errorType": error_type,
-            "httpStatus": http_status_code,
-            "requestId": request_id,
-            "message": modified_message,
-        }, result)
+        self.assertEqual(
+            {
+                "errorType": error_type,
+                "httpStatus": http_status_code,
+                "requestId": request_id,
+                "message": modified_message,
+            },
+            result,
+        )
 
         mock_error.assert_called_once_with(modified_message)

--- a/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
@@ -455,8 +455,7 @@ class TestOrcaCatalogReportingUnit(
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
-        message = """Some error dictionary: {"fruit": "apple"}"""
-        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+        message = uuid.uuid4().__str__()
 
         result = orca_catalog_reporting.create_http_error_dict(
             error_type, http_status_code, request_id, message
@@ -467,9 +466,9 @@ class TestOrcaCatalogReportingUnit(
                 "errorType": error_type,
                 "httpStatus": http_status_code,
                 "requestId": request_id,
-                "message": modified_message,
+                "message": message,
             },
             result,
         )
 
-        mock_error.assert_called_once_with(modified_message)
+        mock_error.assert_called_once_with(message)

--- a/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
@@ -1,5 +1,5 @@
 """
-Name: test_orca_catalog_reporting_unit.py
+Name: test_orca_catalog_reporting.py
 
 Description:  Unit tests for orca_catalog_reporting.py.
 """
@@ -21,11 +21,9 @@ class TestOrcaCatalogReportingUnit(
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     @patch.dict(
         os.environ,
-        {
-            "DB_CONNECT_INFO_SECRET_ARN": "test"
-        },
+        {"DB_CONNECT_INFO_SECRET_ARN": "test"},
         clear=True,
-     )
+    )
     def test_handler_happy_path(
         self,
         mock_setMetadata: MagicMock,
@@ -98,11 +96,9 @@ class TestOrcaCatalogReportingUnit(
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     @patch.dict(
         os.environ,
-        {
-            "DB_CONNECT_INFO_SECRET_ARN": "test"
-        },
+        {"DB_CONNECT_INFO_SECRET_ARN": "test"},
         clear=True,
-     )
+    )
     def test_handler_missing_properties_uses_default(
         self,
         mock_setMetadata: MagicMock,
@@ -138,11 +134,9 @@ class TestOrcaCatalogReportingUnit(
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     @patch.dict(
         os.environ,
-        {
-            "DB_CONNECT_INFO_SECRET_ARN": "test"
-        },
+        {"DB_CONNECT_INFO_SECRET_ARN": "test"},
         clear=True,
-     )
+    )
     def test_handler_missing_page_index_returns_error(
         self,
         mock_setMetadata: MagicMock,
@@ -221,11 +215,9 @@ class TestOrcaCatalogReportingUnit(
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     @patch.dict(
         os.environ,
-        {
-            "DB_CONNECT_INFO_SECRET_ARN": "test"
-        },
+        {"DB_CONNECT_INFO_SECRET_ARN": "test"},
         clear=True,
-     )
+    )
     def test_handler_bad_output_raises_error(
         self,
         mock_setMetadata: MagicMock,
@@ -457,3 +449,25 @@ class TestOrcaCatalogReportingUnit(
             ],
             result,
         )
+
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_create_http_error_dict_happy_path(
+            self,
+            mock_error: MagicMock
+    ):
+        error_type = uuid.uuid4().__str__()
+        http_status_code = random.randint(0, 9999)  # nosec
+        request_id = uuid.uuid4().__str__()
+        message = """Some error dictionary: {"fruit": "apple"}"""
+        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+
+        result = orca_catalog_reporting.create_http_error_dict(error_type, http_status_code, request_id, message)
+
+        self.assertEqual({
+            "errorType": error_type,
+            "httpStatus": http_status_code,
+            "requestId": request_id,
+            "message": modified_message,
+        }, result)
+
+        mock_error.assert_called_once_with(modified_message)

--- a/tasks/request_files/test/unit_tests/test_request_files.py
+++ b/tasks/request_files/test/unit_tests/test_request_files.py
@@ -23,6 +23,9 @@ from botocore.exceptions import ClientError
 
 import request_files
 
+# Generating schema validators can take time, so do it once and reuse.
+with open("schemas/output.json", "r") as raw_schema:
+    _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 class TestRequestFiles(unittest.TestCase):
     """
@@ -1659,11 +1662,7 @@ class TestRequestFiles(unittest.TestCase):
         }
 
         # Validate the output is correct
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result_value)
+        _OUTPUT_VALIDATE(result_value)
 
         # Check the values of the result less the times since those will never match
         for granule in result_value["granules"]:

--- a/tasks/request_status_for_granule/request_status_for_granule.py
+++ b/tasks/request_status_for_granule/request_status_for_granule.py
@@ -274,8 +274,6 @@ def create_http_error_dict(
             'requestId' (str)
             'message' (str)
     """
-    # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-    message = message.replace("{", "{{").replace("}", "}}")
     LOGGER.error(message)
     return {
         "errorType": error_type,

--- a/tasks/request_status_for_granule/request_status_for_granule.py
+++ b/tasks/request_status_for_granule/request_status_for_granule.py
@@ -281,8 +281,7 @@ def create_http_error_dict(
         "errorType": error_type,
         "httpStatus": http_status_code,
         "requestId": request_id,
-        # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-        "message": message.replace("{", "{{").replace("}", "}}"),
+        "message": message,
     }
 
 

--- a/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule.py
+++ b/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule.py
@@ -462,8 +462,7 @@ class TestRequestStatusForGranuleUnit(
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
-        message = """Some error dictionary: {"fruit": "apple"}"""
-        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+        message = uuid.uuid4().__str__()
 
         result = request_status_for_granule.create_http_error_dict(error_type, http_status_code, request_id, message)
 
@@ -471,10 +470,10 @@ class TestRequestStatusForGranuleUnit(
             "errorType": error_type,
             "httpStatus": http_status_code,
             "requestId": request_id,
-            "message": modified_message,
+            "message": message,
         }, result)
 
-        mock_error.assert_called_once_with(modified_message)
+        mock_error.assert_called_once_with(message)
 
     # Multi-Function Tests:
     @patch("orca_shared.database.shared_db.get_user_connection")

--- a/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule.py
+++ b/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule.py
@@ -451,6 +451,28 @@ class TestRequestStatusForGranuleUnit(
 
         self.assertEqual(expected_result, result)
 
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_create_http_error_dict_happy_path(
+            self,
+            mock_error: MagicMock
+    ):
+        error_type = uuid.uuid4().__str__()
+        http_status_code = random.randint(0, 9999)  # nosec
+        request_id = uuid.uuid4().__str__()
+        message = """Some error dictionary: {"fruit": "apple"}"""
+        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+
+        result = request_status_for_granule.create_http_error_dict(error_type, http_status_code, request_id, message)
+
+        self.assertEqual({
+            "errorType": error_type,
+            "httpStatus": http_status_code,
+            "requestId": request_id,
+            "message": modified_message,
+        }, result)
+
+        mock_error.assert_called_once_with(modified_message)
+
     # Multi-Function Tests:
     @patch("orca_shared.database.shared_db.get_user_connection")
     def test_task_output_json_schema(self, mock_get_user_connection: MagicMock):

--- a/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule.py
+++ b/tasks/request_status_for_granule/test/unit_tests/test_request_status_for_granule.py
@@ -17,6 +17,9 @@ import sqlalchemy.exc
 
 import request_status_for_granule
 
+# Generating schema validators can take time, so do it once and reuse.
+with open("schemas/output.json", "r") as raw_schema:
+    _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 class TestRequestStatusForGranuleUnit(
     unittest.TestCase
@@ -528,8 +531,4 @@ class TestRequestStatusForGranuleUnit(
         )
 
         mock_get_user_connection.assert_called_once_with(db_connect_info)
-        with open("schemas/output.json", "r") as raw_schema:
-            schema = json.loads(raw_schema.read())
-
-        validate = fastjsonschema.compile(schema)
-        validate(result)
+        _OUTPUT_VALIDATE(result)

--- a/tasks/request_status_for_job/request_status_for_job.py
+++ b/tasks/request_status_for_job/request_status_for_job.py
@@ -187,7 +187,7 @@ def create_http_error_dict(
         "httpStatus": http_status_code,
         "requestId": request_id,
         # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-        "message": message.replace("{", "{{").replace("}", "}}"),
+        "message": message,
     }
 
 

--- a/tasks/request_status_for_job/request_status_for_job.py
+++ b/tasks/request_status_for_job/request_status_for_job.py
@@ -179,14 +179,11 @@ def create_http_error_dict(
             'requestId' (str)
             'message' (str)
     """
-    # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
-    message = message.replace("{", "{{").replace("}", "}}")
     LOGGER.error(message)
     return {
         "errorType": error_type,
         "httpStatus": http_status_code,
         "requestId": request_id,
-        # CumulusLogger will error if a string containing '{' or '}' is passed in without escaping.
         "message": message,
     }
 

--- a/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
+++ b/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
@@ -17,6 +17,9 @@ import sqlalchemy
 
 import request_status_for_job
 
+# Generating schema validators can take time, so do it once and reuse.
+with open("schemas/output.json", "r") as raw_schema:
+    _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 class TestRequestStatusForJobUnit(
     unittest.TestCase
@@ -314,5 +317,4 @@ class TestRequestStatusForJobUnit(
         with open("schemas/output.json", "r") as raw_schema:
             schema = json.loads(raw_schema.read())
 
-        validate = fastjsonschema.compile(schema)
-        validate(result)
+        _OUTPUT_VALIDATE(result)

--- a/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
+++ b/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
@@ -6,6 +6,7 @@ Description:  Unit tests for request_status_for_job.py.
 import copy
 import json
 import os
+import random
 import unittest
 import uuid
 from http import HTTPStatus
@@ -243,6 +244,28 @@ class TestRequestStatusForJobUnit(
         except ValueError:
             return
         self.fail("Error not raised.")
+
+    @patch("cumulus_logger.CumulusLogger.error")
+    def test_create_http_error_dict_happy_path(
+            self,
+            mock_error: MagicMock
+    ):
+        error_type = uuid.uuid4().__str__()
+        http_status_code = random.randint(0, 9999)  # nosec
+        request_id = uuid.uuid4().__str__()
+        message = """Some error dictionary: {"fruit": "apple"}"""
+        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+
+        result = request_status_for_job.create_http_error_dict(error_type, http_status_code, request_id, message)
+
+        self.assertEqual({
+            "errorType": error_type,
+            "httpStatus": http_status_code,
+            "requestId": request_id,
+            "message": modified_message,
+        }, result)
+
+        mock_error.assert_called_once_with(modified_message)
 
     # Multi-Function Tests:
     @patch("orca_shared.database.shared_db.get_user_connection")

--- a/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
+++ b/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
@@ -256,8 +256,7 @@ class TestRequestStatusForJobUnit(
         error_type = uuid.uuid4().__str__()
         http_status_code = random.randint(0, 9999)  # nosec
         request_id = uuid.uuid4().__str__()
-        message = """Some error dictionary: {"fruit": "apple"}"""
-        modified_message = """Some error dictionary: {{"fruit": "apple"}}"""
+        message = uuid.uuid4().__str__()
 
         result = request_status_for_job.create_http_error_dict(error_type, http_status_code, request_id, message)
 
@@ -265,10 +264,10 @@ class TestRequestStatusForJobUnit(
             "errorType": error_type,
             "httpStatus": http_status_code,
             "requestId": request_id,
-            "message": modified_message,
+            "message": message,
         }, result)
 
-        mock_error.assert_called_once_with(modified_message)
+        mock_error.assert_called_once_with(message)
 
     # Multi-Function Tests:
     @patch("orca_shared.database.shared_db.get_user_connection")


### PR DESCRIPTION
## Summary of Changes

Update lambdas to move schema validation code out of handler for better lambda performance

Addresses [ORCA-426: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/ORCA-426)

## Changes

* Moved schema validation creation to main functions
* Added test for create_http_error_dict to various lambdas
* Minor code/file cleanup

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests functional.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets