### PR TITLE
Feat: Fixed admin_username not taken into account during DB creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and includes an additional section for migration notes.
 
 
 ## [Unreleased]
+## [4.0.2]
+
+### Fixed
+- Fixed bug where `db_admin_username` was not set as the owner of new databases.
+
 ## [4.0.1]
 
 ### Fixed

--- a/tasks/db_deploy/API.md
+++ b/tasks/db_deploy/API.md
@@ -403,7 +403,7 @@ SQL for a simple 'commit' to exit the current transaction.
 #### app\_database\_sql
 
 ```python
-app_database_sql(db_name: str) -> TextClause
+app_database_sql(db_name: str, admin_username: str) -> TextClause
 ```
 
 Full SQL for creating the ORCA application database.

--- a/tasks/db_deploy/db_deploy.py
+++ b/tasks/db_deploy/db_deploy.py
@@ -78,7 +78,7 @@ def task(config: Dict[str, str]) -> None:
             connection.execute(
                 orca_sql.commit_sql()
             )  # exit the default transaction to allow database creation.
-            connection.execute(orca_sql.app_database_sql(config["user_database"]))
+            connection.execute(orca_sql.app_database_sql(config["user_database"], config["admin_username"]))
             connection.execute(orca_sql.app_database_comment_sql(config["user_database"]))
             logger.info("Database created.")
             create_fresh_orca_install(config)

--- a/tasks/db_deploy/orca_sql.py
+++ b/tasks/db_deploy/orca_sql.py
@@ -21,7 +21,7 @@ def commit_sql() -> TextClause:
     return text("commit")
 
 
-def app_database_sql(db_name: str) -> TextClause:
+def app_database_sql(db_name: str, admin_username: str) -> TextClause:
     """
     Full SQL for creating the ORCA application database.
 
@@ -31,7 +31,7 @@ def app_database_sql(db_name: str) -> TextClause:
     return text(
         f"""
         CREATE DATABASE {db_name}
-            OWNER postgres
+            OWNER {admin_username}
             TEMPLATE template1
             ENCODING 'UTF8';
     """

--- a/tasks/db_deploy/test/unit_tests/test_db_deploy.py
+++ b/tasks/db_deploy/test/unit_tests/test_db_deploy.py
@@ -29,6 +29,7 @@ class TestDbDeployFunctions(unittest.TestCase):
         """
         self.mock_sm.start()
         self.test_sm = boto3.client("secretsmanager", region_name="us-west-2")
+        # todo: Switch to randomized values generated per-test.
         self.config = {
             "admin_database": "admin_db",
             "admin_password": "admin123",
@@ -94,12 +95,12 @@ class TestDbDeployFunctions(unittest.TestCase):
         db_deploy.task(self.config)
         mock_app_db_exists.assert_called_with(mock_connection().connect().__enter__(), self.config["user_database"])
         # Check the text calls occur and in the proper order
-        execute_calls = [
+        mock_app_database_sql.assert_called_once_with(self.config["user_database"], self.config["admin_username"])
+        mock_connection().connect().__enter__().execute.assert_has_calls([
             call(mock_commit_sql.return_value),
             call(mock_app_database_sql.return_value),
             call(mock_app_database_comment_sql.return_value)
-        ]
-        mock_connection().connect().__enter__().execute.assert_has_calls(execute_calls, any_order=False)
+        ], any_order=False)
         mock_create_fresh_orca_install.assert_called_once_with(self.config)
 
     @patch("db_deploy.get_admin_connection")

--- a/tasks/db_deploy/test/unit_tests/test_orca_sql.py
+++ b/tasks/db_deploy/test/unit_tests/test_orca_sql.py
@@ -73,10 +73,10 @@ class TestOrcaSqlLogic(unittest.TestCase):
         for name, function in getmembers(orca_sql, isfunction):
             if name not in ["text"]:
                 with self.subTest(function=function):
-                    if name in ["app_user_sql"]:
-                        self.assertEqual(type(function(uuid.uuid4().__str__(), uuid.uuid4().__str__())), TextClause)
+                    if name in ["app_database_sql", "app_user_sql"]:
                         # These functions take in two string parameters.
-                    elif name in ["app_database_sql", "app_database_comment_sql", "dbo_role_sql", "app_role_sql",
+                        self.assertEqual(type(function(uuid.uuid4().__str__(), uuid.uuid4().__str__())), TextClause)
+                    elif name in ["app_database_comment_sql", "dbo_role_sql", "app_role_sql",
                                   "drop_dr_role_sql", "drop_dbo_user_sql", "drop_drdbo_role_sql"]:
                         # These functions take in a string parameter.
                         self.assertEqual(type(function(uuid.uuid4().__str__())), TextClause)


### PR DESCRIPTION
## Summary of Changes

Fixed db_admin_username usage.

Addresses [ORCA-444: DbDeploy lambda does not respect db_admin_username variable value](https://bugs.earthdata.nasa.gov/browse/ORCA-444)

## Changes

* Added db_admin_username to database creation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets