### PR TITLE
Fix: Fixed bug where `db_admin_username` had to be lower-case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and includes an additional section for migration notes.
 
 
 ## [Unreleased]
+
+## [4.0.3]
+- Fixed bug where `db_admin_username` had to be lower-case.
+
 ## [4.0.2]
 
 ### Fixed

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 ## Local Variables
 locals {
-  db_name = var.db_name != null ? var.db_name : replace("${var.prefix}_orca", "-", "_")
+  db_name = lower(var.db_name != null ? var.db_name : replace("${var.prefix}_orca", "-", "_"))
   db_user_name = replace("${var.prefix}_orcauser", "-", "_")
   tags    = merge(var.tags, { Deployment = var.prefix }, { team = "ORCA", application = "ORCA" })
 }

--- a/tasks/db_deploy/orca_sql.py
+++ b/tasks/db_deploy/orca_sql.py
@@ -31,7 +31,7 @@ def app_database_sql(db_name: str, admin_username: str) -> TextClause:
     return text(
         f"""
         CREATE DATABASE {db_name}
-            OWNER {admin_username}
+            OWNER "{admin_username}"
             TEMPLATE template1
             ENCODING 'UTF8';
     """
@@ -82,7 +82,7 @@ def dbo_role_sql(db_name: str, admin_username: str) -> TextClause:
             -- Grants
             GRANT CONNECT ON DATABASE {db_name} TO orca_dbo;
             GRANT CREATE ON DATABASE {db_name} TO orca_dbo;
-            GRANT orca_dbo TO {admin_username};
+            GRANT orca_dbo TO "{admin_username}";
           END
         $$
     """
@@ -143,7 +143,7 @@ def orca_schema_sql() -> TextClause:
         -- GRANT the privelages needed
         GRANT USAGE ON SCHEMA orca TO orca_app;
 
-        -- Setup Default Privelages for application user as a catch all
+        -- Setup Default Privileges for application user as a catch all
         ALTER DEFAULT PRIVILEGES FOR USER orca_dbo IN SCHEMA orca GRANT SELECT ON TABLES TO orca_app;
         ALTER DEFAULT PRIVILEGES FOR USER orca_dbo IN SCHEMA orca GRANT INSERT ON TABLES TO orca_app;
         ALTER DEFAULT PRIVILEGES FOR USER orca_dbo IN SCHEMA orca GRANT UPDATE ON TABLES TO orca_app;
@@ -188,14 +188,14 @@ def app_user_sql(user_name: str, user_password: str) -> TextClause:
         BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_user WHERE usename = '{user_name}' ) THEN
                 -- Create {user_name}
-                CREATE ROLE {user_name}
+                CREATE ROLE "{user_name}"
                     LOGIN
                     INHERIT
                     ENCRYPTED PASSWORD '{user_password}'
                     IN ROLE orca_app;
 
                 -- Add comment
-                COMMENT ON ROLE {user_name}
+                COMMENT ON ROLE "{user_name}"
                     IS 'ORCA application user.';
 
                 RAISE NOTICE 'USER CREATED {user_name}.';
@@ -203,7 +203,7 @@ def app_user_sql(user_name: str, user_password: str) -> TextClause:
             END IF;
 
             -- Alter the roles search path so on login it has what it needs for a path
-            ALTER ROLE {user_name} SET search_path = orca, public;
+            ALTER ROLE "{user_name}" SET search_path = orca, public;
         END
         $$;
     """


### PR DESCRIPTION
## Summary of Changes

Fixes case where mixed-case prefix would lead to db breakage.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Deployed to AWS.

Run in ADS with mixed case name.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets