### PR TITLE
Feature/orca 478 Update s3 policies for deep glacier optional storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and includes an additional section for migration notes.
 
 ## [Unreleased]
 
+### Changed
+- *ORCA-478* Updated bucket policy documentation for deep glacier bucket in DR account so that the users now can only upload objects with storage type as either `GLACIER` or `DEEP_ARCHIVE`.
+
+### Migration Notes
+
+- Add the following rule to the existing glacier archive bucket policy under `Condition` key:
+
+```json
+"s3:x-amz-storage-class": ["GLACIER", "DEEP_ARCHIVE"]
+```
+See this policy [example](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-s3-bucket/#archive-bucket) for details.
+
 ## [5.0.0]
 
 ### Added
@@ -578,5 +590,3 @@ None - this is the baseline release.
   * Updated requirements-dev.txt files for each task and moved the testing framework from nosetest (no longer supported) to coverage and pytest. 
   * Support in GitHub for automated build/test/release via Bamboo
   * Use `coverage` and `pytest` for coverage/testing
-
-### Changed

--- a/website/docs/developer/deployment-guide/creating-orca-glacier-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-glacier-bucket.md
@@ -172,9 +172,10 @@ modifications, which will be detailed below.
       ],
       "Condition": {
         "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
+          "s3:x-amz-acl": "bucket-owner-full-control",
+          "s3:x-amz-storage-class": ["GLACIER", "DEEP_ARCHIVE"]
         }
-      }
+     }
     }
   ]
 }

--- a/website/docs/developer/deployment-guide/creating-orca-glacier-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-glacier-bucket.md
@@ -137,47 +137,50 @@ modifications, which will be detailed below.
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "Cross Account Access",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::012345678912:root"
+   "Version":"2012-10-17",
+   "Statement":[
+      {
+         "Sid":"Cross Account Access",
+         "Effect":"Allow",
+         "Principal":{
+            "AWS":"arn:aws:iam::012345678912:root"
+         },
+         "Action":[
+            "s3:GetObject*",
+            "s3:RestoreObject",
+            "s3:GetBucket*",
+            "s3:ListBucket",
+            "s3:PutBucketNotification",
+            "s3:GetInventoryConfiguration",
+            "s3:PutInventoryConfiguration",
+            "s3:ListBucketVersions"
+         ],
+         "Resource":[
+            "arn:aws:s3:::sandbox-orca-glacier-archive",
+            "arn:aws:s3:::sandbox-orca-glacier-archive/*"
+         ]
       },
-      "Action": [
-        "s3:GetObject*",
-        "s3:RestoreObject",
-        "s3:GetBucket*",
-        "s3:ListBucket",
-        "s3:PutBucketNotification",
-        "s3:GetInventoryConfiguration",
-        "s3:PutInventoryConfiguration",
-        "s3:ListBucketVersions"
-      ],
-      "Resource": [
-        "arn:aws:s3:::sandbox-orca-glacier-archive",
-        "arn:aws:s3:::sandbox-orca-glacier-archive/*"
-      ]
-    },
-    {
-      "Sid": "Cross Account Write Access",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::012345678912:root"
-      },
-      "Action": "s3:PutObject*",
-      "Resource": [
-        "arn:aws:s3:::sandbox-orca-glacier-archive/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control",
-          "s3:x-amz-storage-class": ["GLACIER", "DEEP_ARCHIVE"]
-        }
-     }
-    }
-  ]
+      {
+         "Sid":"Cross Account Write Access",
+         "Effect":"Allow",
+         "Principal":{
+            "AWS":"arn:aws:iam::012345678912:root"
+         },
+         "Action":"s3:PutObject*",
+         "Resource":[
+            "arn:aws:s3:::sandbox-orca-glacier-archive/*"
+         ],
+         "Condition":{
+            "StringEquals":{
+               "s3:x-amz-acl":"bucket-owner-full-control",
+               "s3:x-amz-storage-class":[
+                  "GLACIER",
+                  "DEEP_ARCHIVE"
+               ]
+            }
+         }
+      }
+   ]
 }
 ```
 

--- a/website/docs/developer/deployment-guide/creating-orca-glacier-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-glacier-bucket.md
@@ -112,7 +112,7 @@ an example of a justification.
 > The ORCA Cumulus application in the Cumulus Sandbox OU needs to read/write to
 > the ORCA DR account S3 buckets in order to create an operational archive copy of
 > ORCA data and recover data back to the primary Cumulus data holdings in case
-> of a failure. This cross account access will allow the Cumulus application to
+> of a failure. Note that only `GLACIER` and `DEEP_ARCHIVE` storage types are allowed for objects written to the bucket. This cross account access will allow the Cumulus application to
 > seamlessly perform these functions and provide operators with the capability to
 > test and verify disaster recovery scenarios.
 


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-478: Update s3 policies for deep glacier optional storage](https://bugs.earthdata.nasa.gov/browse/ORCA-478)

## Changes

* updated website/docs/developer/deployment-guide/creating-orca-glacier-bucket.md

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)
- [ x] This change requires a documentation update

## How Has This Been Tested?
deployed the bucket with the new policy in DR account.
Tried writing to the glacier bucket in DR account from the cumulus account.
Write operation succeeded when object storage type were ["GLACIER", "DEEP_ARCHIVE"]
Write operation gave access denied error for other storage types.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x ] Development documentation

## Possible fixes

Since glacier bucket is created in DR account, it cannot be deployed like other modules in ORCA that are deployed in cumulus account. The glacier bucket including its policy has to be deployed together in DR account.