### PR TITLE
ORCA-519 feat: Added schema checks in request_status lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and includes an additional section for migration notes.
 - *ORCA-290* Adjusted workflows/step functions for `OrcaRecoveryWorkflow`.
   - `excludeFileTypes`, `orcaDefaultBucketOverride` and `orcaDefaultStorageClassOverride` arguments in `task_config` are now `excludedFileExtensions`, `defaultBucketOverride` and  `defaultStorageClassOverride` respectively.
   - `excludedFileExtensions`, `defaultBucketOverride` and `defaultStorageClassOverride` keys are now under `collection.meta.orca`. See the example below under `Migration Notes`.
+- *ORCA-519* Enforced schema checks in `request_status_for_granule` and `request_status_for_job`.
+  Both lambdas will return proper HTTP error codes for bad inputs of internal server errors.
 
 ### Migration Notes
 

--- a/tasks/request_status_for_granule/API.md
+++ b/tasks/request_status_for_granule/API.md
@@ -174,5 +174,5 @@ Entry point for the request_status_for_granule Lambda.
   
   Or, if an error occurs, see create_http_error_dict
   400 if granule_id is missing.
-  500 if an error occurs when querying the database, 404 if not found.
+  400 if input.json schema is not matched. 500 if an error occurs when querying the database. 404 if not found.
 

--- a/tasks/request_status_for_granule/API.md
+++ b/tasks/request_status_for_granule/API.md
@@ -31,7 +31,8 @@ def task(granule_id: str,
 - `job_id` - An optional additional filter to get a specific job's entry.
 - `Returns` - See output.json
   
-  Will also return a dict from create_http_error_dict with error NOT_FOUND if job/granule could not be found.
+  Will also return a dict from create_http_error_dict with error
+  NOT_FOUND if job/granule could not be found.
 
 <a id="request_status_for_granule.get_most_recent_job_id_for_granule"></a>
 
@@ -100,8 +101,10 @@ Gets the individual status entries for the files for the given job+granule.
 - `Returns` - A Dict with the following keys:
 - `'file_name'` _str_ - The name and extension of the file.
 - `'restore_destination'` _str_ - The name of the glacier bucket the file is being copied to.
-- `'status'` _str_ - The status of the restoration of the file. May be 'pending', 'staged', 'success', or 'failed'.
-- `'error_message'` _str_ - If the restoration of the file errored, the error will be stored here. Otherwise, None.
+- `'status'` _str_ - The status of the restoration of the file.
+  May be 'pending', 'staged', 'success', or 'failed'.
+- `'error_message'` _str_ - If the restoration of the file errored,
+  the error will be stored here. Otherwise, None.
 
 <a id="request_status_for_granule.create_http_error_dict"></a>
 
@@ -148,22 +151,28 @@ Entry point for the request_status_for_granule Lambda.
 - `context` - An object provided by AWS Lambda. Used for context tracking.
   
   Environment Vars:
-- `DB_CONNECT_INFO_SECRET_ARN` _string_ - Secret ARN of the AWS secretsmanager secret for connecting to the database.
+  DB_CONNECT_INFO_SECRET_ARN (string):
+  Secret ARN of the AWS secretsmanager secret for connecting to the database.
   See shared_db.py's get_configuration for further details.
   
 - `Returns` - A Dict with the following keys:
 - `'granule_id'` _str_ - The unique ID of the granule to retrieve status for.
 - `'asyncOperationId'` _str_ - The unique ID of the asyncOperation.
-- `'files'` _List_ - Description and status of the files within the given granule. List of Dicts with keys:
+- `'files'` _List_ - Description and status of the files within the given granule.
+  List of Dicts with keys:
 - `'file_name'` _str_ - The name and extension of the file.
-- `'restore_destination'` _str_ - The name of the glacier bucket the file is being copied to.
+- `'restore_destination'` _str_ - The name of the glacier bucket
+  the file is being copied to.
 - `'status'` _str_ - The status of the restoration of the file.
   May be 'pending', 'staged', 'success', or 'failed'.
-- `'error_message'` _str, Optional_ - If the restoration of the file errored, the error will be stored here.
-- `'request_time'` _DateTime_ - The time, in UTC isoformat, when the request to restore the granule was initiated.
-  'completion_time' (DateTime, Optional):
-  The time, in UTC isoformat, when all granule_files were no longer 'pending'/'staged'.
+- `'error_message'` _str, Optional_ - If the restoration of the file errored,
+  the error will be stored here.
+- `'request_time'` _DateTime_ - The time, in UTC isoformat,
+  when the request to restore the granule was initiated.
+- `'completion_time'` _DateTime, Optional_ - The time, in UTC isoformat,
+  when all granule_files were no longer 'pending'/'staged'.
   
   Or, if an error occurs, see create_http_error_dict
-  400 if granule_id is missing. 500 if an error occurs when querying the database, 404 if not found.
+  400 if granule_id is missing.
+  500 if an error occurs when querying the database, 404 if not found.
 

--- a/tasks/request_status_for_granule/request_status_for_granule.py
+++ b/tasks/request_status_for_granule/request_status_for_granule.py
@@ -332,7 +332,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
         Or, if an error occurs, see create_http_error_dict
             400 if granule_id is missing.
-            500 if an error occurs when querying the database, 404 if not found.
+            400 if input.json schema is not matched. 500 if an error occurs when querying the database. 404 if not found.
     """
 
     # get the secret ARN from the env variable

--- a/tasks/request_status_for_granule/request_status_for_granule.py
+++ b/tasks/request_status_for_granule/request_status_for_granule.py
@@ -1,8 +1,11 @@
+import json
 import os
 from http import HTTPStatus
 from typing import Any, Dict, List, Union
 
+import fastjsonschema
 from cumulus_logger import CumulusLogger
+from fastjsonschema import JsonSchemaException
 from orca_shared.database import shared_db
 from sqlalchemy import text
 from sqlalchemy.future import Engine
@@ -19,6 +22,12 @@ OUTPUT_STATUS_KEY = "status"
 OUTPUT_ERROR_MESSAGE_KEY = "errorMessage"
 OUTPUT_REQUEST_TIME_KEY = "requestTime"
 OUTPUT_COMPLETION_TIME_KEY = "completionTime"
+
+with open("schemas/input.json", "r") as raw_schema:
+    _VALIDATE_INPUT = fastjsonschema.compile(json.loads(raw_schema.read()))
+
+with open("schemas/output.json", "r") as raw_schema:
+    _VALIDATE_OUTPUT = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 LOGGER = CumulusLogger()
 
@@ -338,6 +347,16 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     try:
         LOGGER.setMetadata(event, context)
 
+        try:
+            _VALIDATE_INPUT(event)
+        except JsonSchemaException as json_schema_exception:
+            return create_http_error_dict(
+                "BadRequest",
+                HTTPStatus.BAD_REQUEST,
+                context.aws_request_id,
+                json_schema_exception.__str__(),
+            )
+
         granule_id = event.get(INPUT_GRANULE_ID_KEY, None)
         if granule_id is None or len(granule_id) == 0:
             return create_http_error_dict(
@@ -346,13 +365,16 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 context.aws_request_id,
                 f"{INPUT_GRANULE_ID_KEY} must be set to a non-empty value.",
             )
-
-        return task(
+        result = task(
             granule_id,
             db_connect_info,
             context.aws_request_id,
             event.get(INPUT_JOB_ID_KEY, None),
         )
+
+        _VALIDATE_OUTPUT(result)
+
+        return result
     except Exception as error:
         return create_http_error_dict(
             "InternalServerError",

--- a/tasks/request_status_for_granule/requirements.txt
+++ b/tasks/request_status_for_granule/requirements.txt
@@ -1,3 +1,4 @@
 cumulus-message-adapter-python==2.0.1
 SQLAlchemy==1.4.11
 ../../shared_libraries[all]
+fastjsonschema==2.15.0

--- a/tasks/request_status_for_job/API.md
+++ b/tasks/request_status_for_job/API.md
@@ -39,7 +39,8 @@ def task(job_id: str, db_connect_info: Dict,
   'granule_id' (str)
 - `'status'` _str_ - pending|staged|success|failed
   
-  Will also return a dict from create_http_error_dict with error NOT_FOUND if job could not be found.
+  Will also return a dict from create_http_error_dict with
+  error NOT_FOUND if job could not be found.
 
 <a id="request_status_for_job.get_granule_status_entries_for_job"></a>
 
@@ -127,19 +128,24 @@ Entry point for the request_status_for_job Lambda.
 - `context` - An object provided by AWS Lambda. Used for context tracking.
   
   Environment Vars:
-- `DB_CONNECT_INFO_SECRET_ARN` _string_ - Secret ARN of the AWS secretsmanager secret for connecting to the database.
+  DB_CONNECT_INFO_SECRET_ARN (string):
+  Secret ARN of the AWS secretsmanager secret for connecting to the database.
   See shared_db.py's get_configuration for further details.
   
 - `Returns` - A Dict with the following keys:
 - `asyncOperationId` _str_ - The unique ID of the asyncOperation.
-- `job_status_totals` _Dict[str, int]_ - Sums of how many granules are in each particular restoration status.
+- `job_status_totals` _Dict[str, int]_ - Sums of how many granules are in each
+  particular restoration status.
 - `pending` _int_ - The number of granules that still need to be copied.
 - `staged` _int_ - Currently unimplemented.
 - `success` _int_ - The number of granules that have been successfully copied.
-- `failed` _int_ - The number of granules that did not copy and will not copy due to an error.
-- `granules` _Array[Dict]_ - An array of Dicts representing each granule being copied as part of the job.
+- `failed` _int_ - The number of granules that did not copy
+  and will not copy due to an error.
+- `granules` _Array[Dict]_ - An array of Dicts representing each granule
+  being copied as part of the job.
 - `granule_id` _str_ - The unique ID of the granule.
-- `status` _str_ - The status of the restoration of the file. May be 'pending', 'staged', 'success', or 'failed'.
+- `status` _str_ - The status of the restoration of the file.
+  May be 'pending', 'staged', 'success', or 'failed'.
   
   Or, if an error occurs, see create_http_error_dict
   400 if asyncOperationId is missing. 500 if an error occurs when querying the database.

--- a/tasks/request_status_for_job/API.md
+++ b/tasks/request_status_for_job/API.md
@@ -148,5 +148,5 @@ Entry point for the request_status_for_job Lambda.
   May be 'pending', 'staged', 'success', or 'failed'.
   
   Or, if an error occurs, see create_http_error_dict
-  400 if asyncOperationId is missing. 500 if an error occurs when querying the database.
+  400 if input.json schema is not matched. 500 if an error occurs when querying the database.
 

--- a/tasks/request_status_for_job/request_status_for_job.py
+++ b/tasks/request_status_for_job/request_status_for_job.py
@@ -227,7 +227,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     May be 'pending', 'staged', 'success', or 'failed'.
 
         Or, if an error occurs, see create_http_error_dict
-            400 if asyncOperationId is missing. 500 if an error occurs when querying the database.
+            400 if input.json schema is not matched. 500 if an error occurs when querying the database.
     """
     # get the secret ARN from the env variable
     try:

--- a/tasks/request_status_for_job/requirements.txt
+++ b/tasks/request_status_for_job/requirements.txt
@@ -1,3 +1,4 @@
 cumulus-message-adapter-python==2.0.1
 SQLAlchemy==1.4.11
 ../../shared_libraries[database]
+fastjsonschema==2.15.0

--- a/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
+++ b/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
@@ -4,7 +4,6 @@ Name: test_request_status_for_job_unit.py
 Description:  Unit tests for request_status_for_job.py.
 """
 import copy
-import json
 import os
 import random
 import unittest
@@ -13,14 +12,9 @@ from http import HTTPStatus
 from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
-import fastjsonschema as fastjsonschema
-import sqlalchemy
+from sqlalchemy.exc import OperationalError
 
 import request_status_for_job
-
-# Generating schema validators can take time, so do it once and reuse.
-with open("schemas/output.json", "r") as raw_schema:
-    _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 
 class TestRequestStatusForJobUnit(
@@ -49,9 +43,26 @@ class TestRequestStatusForJobUnit(
         Basic path with all information present.
         """
         job_id = uuid.uuid4().__str__()
+        mock_task.return_value = {
+            request_status_for_job.OUTPUT_JOB_ID_KEY: job_id,
+            request_status_for_job.OUTPUT_GRANULES_KEY: [
+                {
+                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
+                    request_status_for_job.OUTPUT_STATUS_KEY: "staged"
+                }
+            ],
+            request_status_for_job.OUTPUT_JOB_STATUS_TOTALS_KEY:
+                {
+                    "pending": random.randint(0, 15),  # nosec
+                    "staged": random.randint(0, 15),  # nosec
+                    "success": random.randint(0, 15),  # nosec
+                    "failed": random.randint(0, 15)  # nosec
+                }
+        }
 
         event = {request_status_for_job.INPUT_JOB_ID_KEY: job_id}
         context = Mock()
+
         result = request_status_for_job.handler(event, context)
 
         mock_setMetadata.assert_called_once_with(event, context)
@@ -60,7 +71,8 @@ class TestRequestStatusForJobUnit(
         )
         self.assertEqual(mock_task.return_value, result)
 
-    # noinspection PyPep8Naming
+    # noinspection PyPep8Naming,PyUnusedLocal
+    @patch("request_status_for_job.create_http_error_dict")
     @patch("orca_shared.database.shared_db.get_configuration")
     @patch("cumulus_logger.CumulusLogger.setMetadata")
     @patch.dict(
@@ -69,17 +81,26 @@ class TestRequestStatusForJobUnit(
         clear=True,
     )
     def test_handler_missing_job_id_returns_error_code(
-        self, mock_setMetadata: MagicMock, mock_get_dbconnect_info: MagicMock
+        self, mock_setMetadata: MagicMock, mock_get_dbconnect_info: MagicMock,
+        mock_create_http_error_dict: MagicMock,
     ):
         """
         If job_id is not present, should return an error dictionary.
         """
         event = {}
         context = Mock()
-        result = request_status_for_job.handler(event, context)
-        self.assertEqual(HTTPStatus.BAD_REQUEST, result["httpStatus"])
 
-    # noinspection PyPep8Naming
+        result = request_status_for_job.handler(event, context)
+
+        mock_create_http_error_dict.assert_called_once_with(
+            "BadRequest",
+            HTTPStatus.BAD_REQUEST,
+            context.aws_request_id,
+            f"data must contain ['{request_status_for_job.OUTPUT_JOB_ID_KEY}'] properties")
+        self.assertEqual(mock_create_http_error_dict.return_value, result)
+
+    # noinspection PyPep8Naming,PyUnusedLocal
+    @patch("request_status_for_job.create_http_error_dict")
     @patch("cumulus_logger.CumulusLogger.error")
     @patch("request_status_for_job.task")
     @patch("orca_shared.database.shared_db.get_configuration")
@@ -95,6 +116,7 @@ class TestRequestStatusForJobUnit(
         mock_get_dbconnect_info: MagicMock,
         mock_task: MagicMock,
         mock_cumulus_logger_error: MagicMock,
+        mock_create_http_error_dict: MagicMock,
     ):
         """
         If database error is raised, it should be caught and returned in a dictionary.
@@ -103,9 +125,71 @@ class TestRequestStatusForJobUnit(
 
         event = {request_status_for_job.INPUT_JOB_ID_KEY: job_id}
         context = Mock()
-        mock_task.side_effect = sqlalchemy.exc.OperationalError
+        error = OperationalError(Mock(), Mock(), Mock())
+        mock_task.side_effect = error
+
         result = request_status_for_job.handler(event, context)
-        self.assertEqual(HTTPStatus.INTERNAL_SERVER_ERROR, result["httpStatus"])
+
+        mock_create_http_error_dict.assert_called_once_with(
+            "InternalServerError",
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            context.aws_request_id,
+            str(error))
+        self.assertEqual(mock_create_http_error_dict.return_value, result)
+
+    # noinspection PyPep8Naming
+    @patch("request_status_for_job.create_http_error_dict")
+    @patch("request_status_for_job.task")
+    @patch("orca_shared.database.shared_db.get_configuration")
+    @patch("cumulus_logger.CumulusLogger.setMetadata")
+    @patch.dict(
+        os.environ,
+        {"DB_CONNECT_INFO_SECRET_ARN": "test"},
+        clear=True,
+    )
+    def test_handler_invalid_output_raises_error(
+        self,
+        mock_setMetadata: MagicMock,
+        mock_get_dbconnect_info: MagicMock,
+        mock_task: MagicMock,
+        mock_create_http_error_dict: MagicMock,
+    ):
+        """
+        If output is in invalid format, raise error.
+        """
+        job_id = uuid.uuid4().__str__()
+        mock_task.return_value = {
+            request_status_for_job.OUTPUT_JOB_ID_KEY: job_id,
+            request_status_for_job.OUTPUT_GRANULES_KEY: [
+                {
+                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
+                    request_status_for_job.OUTPUT_STATUS_KEY: "staged"
+                }
+            ],
+            request_status_for_job.OUTPUT_JOB_STATUS_TOTALS_KEY:
+                {
+                    "pending": random.randint(0, 15),  # nosec
+                    "staged": random.randint(0, 15),  # nosec
+                    "success": random.randint(0, 15),  # nosec
+                }
+        }
+
+        event = {request_status_for_job.INPUT_JOB_ID_KEY: job_id}
+        context = Mock()
+
+        result = request_status_for_job.handler(event, context)
+
+        mock_setMetadata.assert_called_once_with(event, context)
+        mock_task.assert_called_once_with(
+            job_id, mock_get_dbconnect_info.return_value, context.aws_request_id
+        )
+        mock_create_http_error_dict.assert_called_once_with(
+            "InternalServerError",
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            context.aws_request_id,
+            f"data.{request_status_for_job.OUTPUT_JOB_STATUS_TOTALS_KEY} "
+            f"must contain ['pending', 'staged', 'success', 'failed'] properties")
+        self.assertEqual(mock_create_http_error_dict.return_value, result)
 
     @patch("orca_shared.database.shared_db.get_user_connection")
     @patch("request_status_for_job.get_granule_status_entries_for_job")
@@ -248,6 +332,7 @@ class TestRequestStatusForJobUnit(
         Raises error if async_operation_id is None.
         """
         try:
+            # noinspection PyTypeChecker
             request_status_for_job.task(None, Mock(), Mock())
         except ValueError:
             return
@@ -290,15 +375,17 @@ class TestRequestStatusForJobUnit(
         mock_engine = Mock()
         mock_engine.begin.return_value = Mock()
         mock_connection = Mock()
+        granule_id_0 = uuid.uuid4().__str__()
+        granule_id_1 = uuid.uuid4().__str__()
         mock_connection.execute.side_effect = [
             # granules
             [
                 {
-                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
+                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_0,
                     request_status_for_job.OUTPUT_STATUS_KEY: "success",
                 },
                 {
-                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
+                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_1,
                     request_status_for_job.OUTPUT_STATUS_KEY: "pending",
                 },
             ],
@@ -318,7 +405,21 @@ class TestRequestStatusForJobUnit(
         mock_get_user_connection.return_value = mock_engine
 
         result = request_status_for_job.task(job_id, db_connect_info, request_id)
+        self.assertEqual({
+            request_status_for_job.OUTPUT_JOB_ID_KEY: job_id,
+            request_status_for_job.OUTPUT_GRANULES_KEY: [
+                {
+                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_0,
+                    request_status_for_job.OUTPUT_STATUS_KEY: "success",
+                },
+                {
+                    request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_1,
+                    request_status_for_job.OUTPUT_STATUS_KEY: "pending",
+                }
+            ],
+            request_status_for_job.OUTPUT_JOB_STATUS_TOTALS_KEY: {
+                "failed": 1000, "pending": 5, "staged": 0, "success": 2
+            }
+        }, result)
 
         mock_get_user_connection.assert_called_once_with(db_connect_info)
-
-        _OUTPUT_VALIDATE(result)

--- a/website/docs/developer/api/api-gateway.md
+++ b/website/docs/developer/api/api-gateway.md
@@ -160,7 +160,7 @@ The following table lists the fields in the output:
 | requestTime        | `int`       | The time, in milliseconds since 1 January 1970 UTC, when the request to restore the granule was initiated.|
 | completionTime     | `int`       | The time, in milliseconds since 1 January 1970 UTC, when all granule_files were in an end state.    |
 
-The API returns status code 200 on success, 400 if `granuleId` is missing, 500 if an error occurs when querying the database and 404 if not found.
+The API returns status code 200 on success, 400 if input is in incorrect format, 500 if an error occurs when querying the database and 404 if not found.
 
 ## Recovery jobs API
 The `recovery/jobs` API call returns detailed status for a particular recovery job.
@@ -213,7 +213,7 @@ The following table lists the fields in the output:
 | granuleId           | `str`       | The unique ID of the granule retrieved.                                                             |
 | status              | `str`       | The status of the restoration of the file. May be 'pending', 'staged', 'success', or 'failed'.      |
 
-The API returns status code 200 on success, 400 if `asyncOperationId` is missing, 500 if an error occurs when querying the database and 404 if not found.
+The API returns status code 200 on success, 400 if input is in incorrect format, 500 if an error occurs when querying the database, and 404 if not found.
 
 ## Internal Reconcile report jobs API
 The `orca/datamanagement/reconciliation/internal/jobs` API call receives page index from end user and returns available internal reconciliation jobs from the Orca database.

--- a/website/docs/developer/development-guide/code/integration-tests.md
+++ b/website/docs/developer/development-guide/code/integration-tests.md
@@ -137,7 +137,7 @@ This is a list of tests that should be created for existing Orca architecture. T
   1. Post a mocked-up manifest to the report bucket.
   1. Retry calls to the [Internal Reconcile Report API](../../../developer/api/api-gateway.md/#internal-reconcile-report-jobs-api) until job is complete.
   1. Check that job is successful, and expected errors can be retrieved through the API.
-     ::: warning
+     :::warning
      If the catalog is not reset prior to this test, or other tests run in parallel, other errors may be present.
      Make sure none of these errors contain your randomized keys.
      :::


### PR DESCRIPTION
## Summary of Changes

Added input/output validation to request_status_for_granule and request_status_for_job

Addresses [ORCA-519: Check/validate output of request_status_for_job lambda](https://bugs.earthdata.nasa.gov/browse/ORCA-519)

## Changes

* Added input/output validation to request_status_for_job
* Added input/output validation to request_status_for_granule
* Updated unit tests

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added unit tests to both lambdas for each schema.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Development documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets