### PR TITLE
Feature/orca 538 Remove "glacier" bucket name in TF

### DIFF
--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -253,7 +253,8 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
         # post to metadata SQS for each granule
         sqs_library.post_to_metadata_queue(sqs_body, metadata_queue_url)
 
-    return {"granules": granules_list, "copied_to_orca": copied_file_urls}  # Using "copied_to_orca" instead of "copied_to_archive" until we decouple from Cumulus.
+    # Using "copied_to_orca" instead of "copied_to_archive" until we decouple from Cumulus.
+    return {"granules": granules_list, "copied_to_orca": copied_file_urls}
 
 
 def get_destination_bucket_name(config: Dict[str, Any]) -> str:

--- a/tasks/internal_reconcile_report_orphan/README.md
+++ b/tasks/internal_reconcile_report_orphan/README.md
@@ -2,7 +2,7 @@
 
 **Lambda function internal_reconcile_report_orphan **
 
-Receives job id and page index from end user and returns reporting information of files that have records in the S3 glacier bucket but are missing in the ORCA catalog from the internal reconciliation job.
+Receives job id and page index from end user and returns reporting information of files that have records in the archive bucket but are missing in the ORCA catalog from the internal reconciliation job.
 
 Visit the [Developer Guide](https://nasa.github.io/cumulus-orca/docs/developer/development-guide/code/contrib-code-intro) for information on environment setup and testing.
 
@@ -38,7 +38,7 @@ Fully defined json schemas written in the schema of https://json-schema.org/ can
       "s3Etag": "d41d8cd98f00b204e9800998ecf8427",
       "s3FileLastUpdate": "2020-01-01T23:00:00Z",
       "s3SizeInBytes": 6543277389,
-      "storageClass": "glacier"
+      "storageClass": "GLACIER"
     }
   ]
 }

--- a/tasks/request_from_archive/API.md
+++ b/tasks/request_from_archive/API.md
@@ -67,13 +67,16 @@ def get_archive_recovery_type(config: Dict[str, Any]) -> str
 
 Returns the archive recovery type from either config or environment variable.
 Must be either 'Bulk', 'Expedited', or 'Standard'.
-Defaults to 'Standard' if none found.
 
 **Arguments**:
 
 - `config` - The config dictionary from lambda event.
   
-- `Raises` - ValueError if recovery type value is invalid.
+
+**Raises**:
+
+  KeyError if recovery type is not set.
+  ValueError if recovery type value is invalid.
 
 <a id="request_from_archive.inner_task"></a>
 

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -158,11 +158,12 @@ def get_archive_recovery_type(config: Dict[str, Any]) -> str:
     """
     Returns the archive recovery type from either config or environment variable.
     Must be either 'Bulk', 'Expedited', or 'Standard'.
-    Defaults to 'Standard' if none found.
     Args:
         config: The config dictionary from lambda event.
 
-    Raises: ValueError if recovery type value is invalid.
+    Raises:
+        KeyError if recovery type is not set.
+        ValueError if recovery type value is invalid.
     """
 
     # Look for config override
@@ -181,11 +182,7 @@ def get_archive_recovery_type(config: Dict[str, Any]) -> str:
                 f"found in the environment {OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY} key."
             )
         else:
-            recovery_type = "Standard"
-            LOGGER.info(
-                f"Using restore type of {recovery_type} "
-                f"due to lack of overrides."
-            )
+            raise KeyError("Recovery type not set.")
 
     if recovery_type not in VALID_RESTORE_TYPES:
         LOGGER.error(

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -167,48 +167,34 @@ def get_archive_recovery_type(config: Dict[str, Any]) -> str:
 
     # Look for config override
     recovery_type = config.get(CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY, None)
-    if recovery_type is not None:  # either return or raise error.
-        if recovery_type in VALID_RESTORE_TYPES:
+    if recovery_type is not None:
+        LOGGER.info(
+            f"Using restore type of {recovery_type} "
+            f"found in the configuration {CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY} key."
+        )
+    else:
+        # Look for default from TF
+        recovery_type = os.getenv(OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY, None)
+        if recovery_type is not None:
             LOGGER.info(
                 f"Using restore type of {recovery_type} "
-                f"found in the configuration {CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY} key."
+                f"found in the environment {OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY} key."
             )
-            return recovery_type
         else:
-            LOGGER.error(
-                f"Invalid restore type value of '{recovery_type}' "
-                f"found in the configuration {CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY} key."
-            )
-            raise ValueError(
-                f"Invalid restore type value in configuration "
-                f"{CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY} key."
+            recovery_type = "Standard"
+            LOGGER.info(
+                f"Using restore type of {recovery_type} "
+                f"due to lack of overrides."
             )
 
-    # Look for default from TF
-    recovery_type = os.getenv(OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY, None)
-    if recovery_type is None:
-        recovery_type = "Standard"
-        LOGGER.info(
-            f"Using restore type of {recovery_type} "
-            f"due to lack of overrides."
-        )
-        return recovery_type
-
-    if recovery_type in VALID_RESTORE_TYPES:
-        LOGGER.info(
-            f"Using restore type of {recovery_type} "
-            f"found in environment variable {OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY}."
-        )
-        return recovery_type
-    else:
+    if recovery_type not in VALID_RESTORE_TYPES:
         LOGGER.error(
-            f"Invalid restore type value of '{recovery_type}' "
-            f"found in environment variable {OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY}."
+            f"Invalid restore type value of '{recovery_type}'."
         )
         raise ValueError(
-            f"Invalid restore type value in environment variable "
-            f"{OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY}"
+            f"Invalid restore type value of '{recovery_type}'."
         )
+    return recovery_type
 
 
 def get_default_archive_bucket_name(config: Dict[str, Any]) -> str:

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -1249,19 +1249,17 @@ class TestRequestFromArchive(unittest.TestCase):
         """
         Raises ValueError if invalid config value.
         """
-        config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: "Nope"}
+        recovery_type = uuid.uuid4().__str__()  # nosec
+        config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: recovery_type}
         with self.assertRaises(ValueError) as ve:
             request_from_archive.get_archive_recovery_type(config)
         self.assertEqual(
-            f"Invalid restore type value in configuration "
-            f"{request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY} key.",
+            f"Invalid restore type value of '{recovery_type}'.",
             ve.exception.args[0],
         )
         mock_logger_error.assert_called_once_with(
             f"Invalid restore type value of "
-            f"'{config[request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY]}' found in "
-            f"the configuration {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY} "
-            f"key."
+            f"'{config[request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY]}'."
         )
 
     @patch.dict(
@@ -1295,15 +1293,13 @@ class TestRequestFromArchive(unittest.TestCase):
         with self.assertRaises(ValueError) as ve:
             request_from_archive.get_archive_recovery_type(config)
         self.assertEqual(
-            f"Invalid restore type value in environment variable "
-            f"{request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY}",
+            f"Invalid restore type value of "
+            f"'{os.environ[request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY]}'.",
             ve.exception.args[0],
         )
         mock_logger_error.assert_called_once_with(
             f"Invalid restore type value of "
-            f"'{os.environ[request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY]}' "
-            f"found in environment variable "
-            f"{request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY}."
+            f"'{os.environ[request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY]}'."
         )
 
     @patch("time.sleep")

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -1217,14 +1217,16 @@ class TestRequestFromArchive(unittest.TestCase):
         {},
         clear=True,
     )
-    def test_get_archive_recovery_no_value_defaults_to_standard(self):
+    def test_get_archive_recovery_no_value_raises_error(self):
         """
-        If no values are present, return "Standard"
+        If no values are present, raise KeyError
         """
         config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: None}
-        result = request_from_archive.get_archive_recovery_type(config)
+        with self.assertRaises(KeyError) as ve:
+            request_from_archive.get_archive_recovery_type(config)
         self.assertEqual(
-            "Standard", result
+            f"Recovery type not set.",
+            ve.exception.args[0],
         )
 
     @patch.dict(

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -42,18 +42,18 @@ class TestRequestFromArchive(unittest.TestCase):
         os.environ.pop(request_from_archive.OS_ENVIRON_STATUS_UPDATE_QUEUE_URL_KEY, None)
         os.environ.pop(request_from_archive.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY, None)
         os.environ.pop(request_from_archive.OS_ENVIRON_RESTORE_REQUEST_RETRIES_KEY, None)
-        os.environ.pop(request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY, None)
+        os.environ.pop(request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY, None)
         os.environ.pop(request_from_archive.OS_ENVIRON_RESTORE_RETRY_SLEEP_SECS_KEY, None)
         os.environ.pop(request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY, None)
 
-    @patch("request_from_archive.get_default_glacier_bucket_name")
+    @patch("request_from_archive.get_default_archive_bucket_name")
     @patch("request_from_archive.inner_task")
-    @patch("request_from_archive.get_glacier_recovery_type")
+    @patch("request_from_archive.get_archive_recovery_type")
     def test_task_happy_path(
         self,
-        mock_get_glacier_recovery_type: MagicMock,
+        mock_get_archive_recovery_type: MagicMock,
         mock_inner_task: MagicMock,
-        mock_get_default_glacier_bucket_name: MagicMock,
+        mock_get_default_archive_bucket_name: MagicMock,
     ):
         """
         All variables present and valid.
@@ -85,32 +85,32 @@ class TestRequestFromArchive(unittest.TestCase):
 
         request_from_archive.task(mock_event, None)
 
-        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
-        mock_get_glacier_recovery_type.assert_called_once_with(config)
+        mock_get_default_archive_bucket_name.assert_called_once_with(config)
+        mock_get_archive_recovery_type.assert_called_once_with(config)
         mock_inner_task.assert_called_once_with(
             {
                 request_from_archive.EVENT_CONFIG_KEY: {
                     request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY:
-                        mock_get_default_glacier_bucket_name.return_value,
+                        mock_get_default_archive_bucket_name.return_value,
                     request_from_archive.CONFIG_JOB_ID_KEY:
                         job_id,
                 },
             },
             max_retries,
             retry_sleep_secs,
-            mock_get_glacier_recovery_type(config),
+            mock_get_archive_recovery_type(config),
             exp_days,
             db_queue_url,
         )
 
-    @patch("request_from_archive.get_default_glacier_bucket_name")
+    @patch("request_from_archive.get_default_archive_bucket_name")
     @patch("request_from_archive.inner_task")
-    @patch("request_from_archive.get_glacier_recovery_type")
+    @patch("request_from_archive.get_archive_recovery_type")
     def test_task_default_for_missing_max_retries(
         self,
-        mock_get_glacier_recovery_type: MagicMock,
+        mock_get_archive_recovery_type: MagicMock,
         mock_inner_task: MagicMock,
-        mock_get_default_glacier_bucket_name: MagicMock,
+        mock_get_default_archive_bucket_name: MagicMock,
     ):
         """
         If max_retries missing, use default.
@@ -138,32 +138,32 @@ class TestRequestFromArchive(unittest.TestCase):
 
         request_from_archive.task(mock_event, None)
 
-        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
-        mock_get_glacier_recovery_type.assert_called_once_with(config)
+        mock_get_default_archive_bucket_name.assert_called_once_with(config)
+        mock_get_archive_recovery_type.assert_called_once_with(config)
         mock_inner_task.assert_called_once_with(
             {
                 request_from_archive.EVENT_CONFIG_KEY: {
                     request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY:
-                        mock_get_default_glacier_bucket_name.return_value,
+                        mock_get_default_archive_bucket_name.return_value,
                     request_from_archive.CONFIG_JOB_ID_KEY:
                         job_id,
                 },
             },
             request_from_archive.DEFAULT_MAX_REQUEST_RETRIES,
             retry_sleep_secs,
-            mock_get_glacier_recovery_type(config),
+            mock_get_archive_recovery_type(config),
             exp_days,
             db_queue_url,
         )
 
-    @patch("request_from_archive.get_default_glacier_bucket_name")
+    @patch("request_from_archive.get_default_archive_bucket_name")
     @patch("request_from_archive.inner_task")
-    @patch("request_from_archive.get_glacier_recovery_type")
+    @patch("request_from_archive.get_archive_recovery_type")
     def test_task_default_for_missing_sleep_secs(
         self,
-        mock_get_glacier_recovery_type: MagicMock,
+        mock_get_archive_recovery_type: MagicMock,
         mock_inner_task: MagicMock,
-        mock_get_default_glacier_bucket_name: MagicMock,
+        mock_get_default_archive_bucket_name: MagicMock,
     ):
         """
         If sleep_secs missing, use default.
@@ -191,32 +191,32 @@ class TestRequestFromArchive(unittest.TestCase):
 
         request_from_archive.task(mock_event, None)
 
-        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
-        mock_get_glacier_recovery_type.assert_called_once_with(config)
+        mock_get_default_archive_bucket_name.assert_called_once_with(config)
+        mock_get_archive_recovery_type.assert_called_once_with(config)
         mock_inner_task.assert_called_once_with(
             {
                 request_from_archive.EVENT_CONFIG_KEY: {
                     request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY:
-                        mock_get_default_glacier_bucket_name.return_value,
+                        mock_get_default_archive_bucket_name.return_value,
                     request_from_archive.CONFIG_JOB_ID_KEY:
                         job_id,
                 },
             },
             max_retries,
             request_from_archive.DEFAULT_RESTORE_RETRY_SLEEP_SECS,
-            mock_get_glacier_recovery_type(config),
+            mock_get_archive_recovery_type(config),
             exp_days,
             db_queue_url,
         )
 
-    @patch("request_from_archive.get_default_glacier_bucket_name")
+    @patch("request_from_archive.get_default_archive_bucket_name")
     @patch("request_from_archive.inner_task")
-    @patch("request_from_archive.get_glacier_recovery_type")
+    @patch("request_from_archive.get_archive_recovery_type")
     def test_task_default_for_missing_exp_days(
         self,
-        mock_get_glacier_recovery_type: MagicMock,
+        mock_get_archive_recovery_type: MagicMock,
         mock_inner_task: MagicMock,
-        mock_get_default_glacier_bucket_name: MagicMock,
+        mock_get_default_archive_bucket_name: MagicMock,
     ):
         """
         Uses default missing_exp_days if needed.
@@ -244,32 +244,32 @@ class TestRequestFromArchive(unittest.TestCase):
 
         request_from_archive.task(mock_event, None)
 
-        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
-        mock_get_glacier_recovery_type.assert_called_once_with(config)
+        mock_get_default_archive_bucket_name.assert_called_once_with(config)
+        mock_get_archive_recovery_type.assert_called_once_with(config)
         mock_inner_task.assert_called_once_with(
             {
                 request_from_archive.EVENT_CONFIG_KEY: {
                     request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY:
-                        mock_get_default_glacier_bucket_name.return_value,
+                        mock_get_default_archive_bucket_name.return_value,
                     request_from_archive.CONFIG_JOB_ID_KEY:
                         job_id,
                 },
             },
             max_retries,
             retry_sleep_secs,
-            mock_get_glacier_recovery_type(config),
+            mock_get_archive_recovery_type(config),
             request_from_archive.DEFAULT_RESTORE_EXPIRE_DAYS,
             db_queue_url,
         )
 
-    @patch("request_from_archive.get_default_glacier_bucket_name")
+    @patch("request_from_archive.get_default_archive_bucket_name")
     @patch("request_from_archive.inner_task")
-    @patch("request_from_archive.get_glacier_recovery_type")
+    @patch("request_from_archive.get_archive_recovery_type")
     def test_task_job_id_missing_generates(
         self,
-        mock_get_glacier_recovery_type: MagicMock,
+        mock_get_archive_recovery_type: MagicMock,
         mock_inner_task: MagicMock,
-        mock_get_default_glacier_bucket_name: MagicMock,
+        mock_get_default_archive_bucket_name: MagicMock,
     ):
         """
         If job_id missing, generates a new one.
@@ -302,20 +302,20 @@ class TestRequestFromArchive(unittest.TestCase):
         with patch.object(uuid, "uuid4", return_value=job_id):
             request_from_archive.task(mock_event, None)
 
-        mock_get_default_glacier_bucket_name.assert_called_once_with(config)
-        mock_get_glacier_recovery_type.assert_called_once_with(config)
+        mock_get_default_archive_bucket_name.assert_called_once_with(config)
+        mock_get_archive_recovery_type.assert_called_once_with(config)
         mock_inner_task.assert_called_once_with(
             {
                 request_from_archive.EVENT_CONFIG_KEY: {
                     request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY:
-                        mock_get_default_glacier_bucket_name.return_value,
+                        mock_get_default_archive_bucket_name.return_value,
                     request_from_archive.CONFIG_JOB_ID_KEY:
                         job_id.__str__(),
                 },
             },
             max_retries,
             retry_sleep_secs,
-            mock_get_glacier_recovery_type(config),
+            mock_get_archive_recovery_type(config),
             exp_days,
             db_queue_url,
         )
@@ -337,7 +337,7 @@ class TestRequestFromArchive(unittest.TestCase):
         """
         Basic path with multiple granules.
         """
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         collection_multipart_chunksize_mb = random.randint(1, 10000)  # nosec
         file_key_0 = uuid.uuid4().__str__()
         file_key_1 = uuid.uuid4().__str__()
@@ -408,7 +408,7 @@ class TestRequestFromArchive(unittest.TestCase):
 
         event = {
             request_from_archive.EVENT_CONFIG_KEY: {
-                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: glacier_bucket,
+                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: archive_bucket_name,
                 request_from_archive.CONFIG_JOB_ID_KEY: job_id,
                 request_from_archive.CONFIG_MULTIPART_CHUNKSIZE_MB_KEY:
                     collection_multipart_chunksize_mb,
@@ -440,7 +440,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     job_id,
                     granule_id0,
-                    glacier_bucket,
+                    archive_bucket_name,
                     [
                         {
                             request_from_archive.FILE_PROCESSED_KEY:
@@ -466,7 +466,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     job_id,
                     granule_id1,
-                    glacier_bucket,
+                    archive_bucket_name,
                     [
                         {
                             request_from_archive.FILE_PROCESSED_KEY:
@@ -497,7 +497,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     mock_s3_cli,
                     expected_input_granule0,
-                    glacier_bucket,
+                    archive_bucket_name,
                     restore_expire_days,
                     max_retries,
                     retry_sleep_secs,
@@ -508,7 +508,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     mock_s3_cli,
                     expected_input_granule1,
-                    glacier_bucket,
+                    archive_bucket_name,
                     restore_expire_days,
                     max_retries,
                     retry_sleep_secs,
@@ -545,7 +545,7 @@ class TestRequestFromArchive(unittest.TestCase):
         If the recovery type is 'Expedited', then files found with storage class
         'DEEP_ARCHIVE' cannot be recovered. Should mark file as processed, and move on.
         """
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         collection_multipart_chunksize_mb = random.randint(1, 10000)  # nosec
         file_key_0 = uuid.uuid4().__str__()
         file_key_1 = uuid.uuid4().__str__()
@@ -559,7 +559,7 @@ class TestRequestFromArchive(unittest.TestCase):
             request_from_archive.FILE_KEY_KEY: file_key_0,
             request_from_archive.FILE_DEST_BUCKET_KEY: file_dest_bucket_0,
         }
-        file_0_error_message = f"File '{file_key_0}' from bucket '{glacier_bucket}' " \
+        file_0_error_message = f"File '{file_key_0}' from bucket '{archive_bucket_name}' " \
                                f"is in storage class 'DEEP_ARCHIVE' " \
                                f"which is incompatible with recovery type 'Expedited'"
         expected_file0_output = {
@@ -621,7 +621,7 @@ class TestRequestFromArchive(unittest.TestCase):
 
         event = {
             request_from_archive.EVENT_CONFIG_KEY: {
-                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: glacier_bucket,
+                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: archive_bucket_name,
                 request_from_archive.CONFIG_JOB_ID_KEY: job_id,
                 request_from_archive.CONFIG_MULTIPART_CHUNKSIZE_MB_KEY:
                     collection_multipart_chunksize_mb,
@@ -656,7 +656,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     job_id,
                     granule_id0,
-                    glacier_bucket,
+                    archive_bucket_name,
                     [
                         {
                             request_from_archive.FILE_PROCESSED_KEY:
@@ -686,7 +686,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     job_id,
                     granule_id1,
-                    glacier_bucket,
+                    archive_bucket_name,
                     [
                         {
                             request_from_archive.FILE_PROCESSED_KEY:
@@ -717,7 +717,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     mock_s3_cli,
                     expected_input_granule0,
-                    glacier_bucket,
+                    archive_bucket_name,
                     restore_expire_days,
                     max_retries,
                     retry_sleep_secs,
@@ -728,7 +728,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     mock_s3_cli,
                     expected_input_granule1,
-                    glacier_bucket,
+                    archive_bucket_name,
                     restore_expire_days,
                     max_retries,
                     retry_sleep_secs,
@@ -764,7 +764,7 @@ class TestRequestFromArchive(unittest.TestCase):
         """
         If posting to status DB Queue fails, raise error.
         """
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         collection_multipart_chunksize_mb = random.randint(1, 10000)  # nosec
         file_key_0 = uuid.uuid4().__str__()
         file_key_1 = uuid.uuid4().__str__()
@@ -834,7 +834,7 @@ class TestRequestFromArchive(unittest.TestCase):
 
         event = {
             request_from_archive.EVENT_CONFIG_KEY: {
-                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: glacier_bucket,
+                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: archive_bucket_name,
                 request_from_archive.CONFIG_JOB_ID_KEY: job_id,
                 request_from_archive.CONFIG_MULTIPART_CHUNKSIZE_MB_KEY:
                     collection_multipart_chunksize_mb,
@@ -871,7 +871,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 call(
                     job_id,
                     granule_id0,
-                    glacier_bucket,
+                    archive_bucket_name,
                     [
                         {
                             request_from_archive.FILE_PROCESSED_KEY:
@@ -900,7 +900,7 @@ class TestRequestFromArchive(unittest.TestCase):
         self.assertEqual(max_retries + 1, mock_create_status_for_job.call_count)
         self.assertEqual(0, mock_process_granule.call_count)
 
-    def test_inner_task_missing_glacier_bucket_raises(self):
+    def test_inner_task_missing_archive_bucket_name_raises(self):
         try:
             request_from_archive.inner_task(
                 {request_from_archive.EVENT_CONFIG_KEY: dict()},
@@ -931,7 +931,7 @@ class TestRequestFromArchive(unittest.TestCase):
         """
         A return of None from get_s3_object_information should ignore the file and continue.
         """
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         collection_multipart_chunksize_mb = random.randint(1, 10000)  # nosec
         file_key_0 = uuid.uuid4().__str__()
         file_key_1 = uuid.uuid4().__str__()
@@ -997,7 +997,7 @@ class TestRequestFromArchive(unittest.TestCase):
             request_from_archive.FILE_LAST_UPDATE_KEY:
                 mock.ANY,
             request_from_archive.FILE_ERROR_MESSAGE_KEY:
-                f"'{missing_file_key}' does not exist in '{glacier_bucket}' bucket",
+                f"'{missing_file_key}' does not exist in '{archive_bucket_name}' bucket",
             request_from_archive.FILE_COMPLETION_TIME_KEY:
                 mock.ANY,
         }
@@ -1021,7 +1021,7 @@ class TestRequestFromArchive(unittest.TestCase):
         ] = expected_input_granule_files
         event = {
             request_from_archive.EVENT_CONFIG_KEY: {
-                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: glacier_bucket,
+                request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: archive_bucket_name,
                 request_from_archive.CONFIG_JOB_ID_KEY: job_id,
                 request_from_archive.CONFIG_MULTIPART_CHUNKSIZE_MB_KEY:
                     collection_multipart_chunksize_mb,
@@ -1038,7 +1038,7 @@ class TestRequestFromArchive(unittest.TestCase):
 
         # noinspection PyUnusedLocal
         def get_s3_object_information_return_func(
-            input_s3_cli, input_glacier_bucket, input_file_key
+            input_s3_cli, input_archive_bucket_name, input_file_key
         ):
             if input_file_key in [file_key_0, file_key_1]:
                 return {"StorageClass": "DEEP_ARCHIVE"}
@@ -1061,7 +1061,7 @@ class TestRequestFromArchive(unittest.TestCase):
         mock_create_status_for_job.assert_called_once_with(
             job_id,
             granule_id,
-            glacier_bucket,
+            archive_bucket_name,
             # Compare to orca_shared to verify schema.
             [
                 {
@@ -1100,7 +1100,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     shared_recovery.LAST_UPDATE_KEY:
                         mock.ANY,
                     shared_recovery.ERROR_MESSAGE_KEY:
-                        f"'{missing_file_key}' does not exist in '{glacier_bucket}' bucket",
+                        f"'{missing_file_key}' does not exist in '{archive_bucket_name}' bucket",
                     shared_recovery.COMPLETION_TIME_KEY:
                         mock.ANY,
                 },
@@ -1128,7 +1128,7 @@ class TestRequestFromArchive(unittest.TestCase):
         mock_process_granule.assert_called_once_with(
             mock_s3_cli,
             expected_input_granule,
-            glacier_bucket,
+            archive_bucket_name,
             restore_expire_days,
             max_retries,
             retry_sleep_secs,
@@ -1147,13 +1147,13 @@ class TestRequestFromArchive(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY: uuid.uuid4().__str__()
+            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY: uuid.uuid4().__str__()
         },
         clear=True,
     )
-    def test_get_default_glacier_bucket_name_returns_override_if_present(self):
+    def test_get_default_archive_bucket_name_returns_override_if_present(self):
         bucket = Mock()
-        result = request_from_archive.get_default_glacier_bucket_name(
+        result = request_from_archive.get_default_archive_bucket_name(
             {request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: bucket}
         )
         self.assertEqual(bucket, result)
@@ -1161,29 +1161,29 @@ class TestRequestFromArchive(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY: uuid.uuid4().__str__()
+            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY: uuid.uuid4().__str__()
         },
         clear=True,
     )
-    def test_get_default_glacier_bucket_name_returns_default_bucket_if_no_override(
+    def test_get_default_archive_bucket_name_returns_default_bucket_if_no_override(
         self,
     ):
-        bucket = os.environ[request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]
-        result = request_from_archive.get_default_glacier_bucket_name({})
+        bucket = os.environ[request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY]
+        result = request_from_archive.get_default_archive_bucket_name({})
         self.assertEqual(bucket, result)
 
     @patch.dict(
         os.environ,
         {
-            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY: uuid.uuid4().__str__()
+            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY: uuid.uuid4().__str__()
         },
         clear=True,
     )
-    def test_get_default_glacier_bucket_name_returns_default_bucket_if_none_override(
+    def test_get_default_archive_bucket_name_returns_default_bucket_if_none_override(
         self,
     ):
-        bucket = os.environ[request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]
-        result = request_from_archive.get_default_glacier_bucket_name(
+        bucket = os.environ[request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY]
+        result = request_from_archive.get_default_archive_bucket_name(
             {
                 request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: None,
             }
@@ -1193,42 +1193,57 @@ class TestRequestFromArchive(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY: uuid.uuid4().__str__()
+            request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY: uuid.uuid4().__str__()
         },
         clear=True,
     )
-    def test_get_default_glacier_bucket_name_returns_env_bucket_if_no_other(self):
-        bucket = os.environ[request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY]
-        result = request_from_archive.get_default_glacier_bucket_name(
+    def test_get_default_archive_bucket_name_returns_env_bucket_if_no_other(self):
+        bucket = os.environ[request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY]
+        result = request_from_archive.get_default_archive_bucket_name(
             {request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: None}
         )
         self.assertEqual(bucket, result)
 
-    def test_get_default_glacier_bucket_name_no_bucket_raises_error(self):
-        os.environ.pop(request_from_archive.OS_ENVIRON_ORCA_DEFAULT_GLACIER_BUCKET_KEY, None)
+    def test_get_default_archive_bucket_name_no_bucket_raises_error(self):
+        os.environ.pop(request_from_archive.OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY, None)
         with self.assertRaises(KeyError) as cm:
-            request_from_archive.get_default_glacier_bucket_name(
+            request_from_archive.get_default_archive_bucket_name(
                 {request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY: None}
             )
         self.assertEqual("'ORCA_DEFAULT_BUCKET'", str(cm.exception))
 
     @patch.dict(
         os.environ,
+        {},
+        clear=True,
+    )
+    def test_get_archive_recovery_no_value_defaults_to_standard(self):
+        """
+        If no values are present, return "Standard"
+        """
+        config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: None}
+        result = request_from_archive.get_archive_recovery_type(config)
+        self.assertEqual(
+            "Standard", result
+        )
+
+    @patch.dict(
+        os.environ,
         {request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY: "Bulk"},
         clear=True,
     )
-    def test_get_glacier_recovery_type_valid_config_overrides(self):
+    def test_get_archive_recovery_type_valid_config_overrides(self):
         """
         Returns the value in config if valid, overriding other values.
         """
-        config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: "Standard"}
-        result = request_from_archive.get_glacier_recovery_type(config)
+        config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: "Bulk"}
+        result = request_from_archive.get_archive_recovery_type(config)
         self.assertEqual(
             result, config[request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY]
         )
 
     @patch("cumulus_logger.CumulusLogger.error")
-    def test_get_glacier_recovery_type_invalid_config_raises_valueerror(
+    def test_get_archive_recovery_type_invalid_config_raises_valueerror(
         self, mock_logger_error: MagicMock
     ):
         """
@@ -1236,7 +1251,7 @@ class TestRequestFromArchive(unittest.TestCase):
         """
         config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: "Nope"}
         with self.assertRaises(ValueError) as ve:
-            request_from_archive.get_glacier_recovery_type(config)
+            request_from_archive.get_archive_recovery_type(config)
         self.assertEqual(
             f"Invalid restore type value in configuration "
             f"{request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY} key.",
@@ -1254,12 +1269,12 @@ class TestRequestFromArchive(unittest.TestCase):
         {request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY: "Bulk"},
         clear=True,
     )
-    def test_get_glacier_recovery_type_env_variable_valid(self):
+    def test_get_archive_recovery_type_env_variable_valid(self):
         """
         Returns the value in env variable if valid and config is None.
         """
         config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: None}
-        result = request_from_archive.get_glacier_recovery_type(config)
+        result = request_from_archive.get_archive_recovery_type(config)
         self.assertEqual(
             result, os.environ[request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY]
         )
@@ -1270,7 +1285,7 @@ class TestRequestFromArchive(unittest.TestCase):
         {request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY: "Nope"},
         clear=True,
     )
-    def test_get_glacier_recovery_type_env_variable_invalid_raises_valueerror(
+    def test_get_archive_recovery_type_env_variable_invalid_raises_valueerror(
         self, mock_logger_error: MagicMock
     ):
         """
@@ -1278,7 +1293,7 @@ class TestRequestFromArchive(unittest.TestCase):
         """
         config = {request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: None}
         with self.assertRaises(ValueError) as ve:
-            request_from_archive.get_glacier_recovery_type(config)
+            request_from_archive.get_archive_recovery_type(config)
         self.assertEqual(
             f"Invalid restore type value in environment variable "
             f"{request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY}",
@@ -1298,7 +1313,7 @@ class TestRequestFromArchive(unittest.TestCase):
     ):
         mock_s3 = Mock()
         max_retries = randint(10, 999)  # nosec
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         retry_sleep_secs = randint(0, 99)  # nosec
         recovery_type = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
@@ -1333,7 +1348,7 @@ class TestRequestFromArchive(unittest.TestCase):
         request_from_archive.process_granule(
             mock_s3,
             granule,
-            glacier_bucket,
+            archive_bucket_name,
             restore_expire_days,
             max_retries,
             retry_sleep_secs,
@@ -1359,7 +1374,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     1,
                     job_id,
                     recovery_type,
@@ -1368,7 +1383,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_1,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     1,
                     job_id,
                     recovery_type,
@@ -1385,7 +1400,7 @@ class TestRequestFromArchive(unittest.TestCase):
     ):
         mock_s3 = Mock()
         max_retries = 5
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         retry_sleep_secs = randint(0, 99)  # nosec
         recovery_type = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
@@ -1413,7 +1428,7 @@ class TestRequestFromArchive(unittest.TestCase):
         request_from_archive.process_granule(
             mock_s3,
             granule,
-            glacier_bucket,
+            archive_bucket_name,
             restore_expire_days,
             max_retries,
             retry_sleep_secs,
@@ -1433,7 +1448,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     1,
                     job_id,
                     recovery_type,
@@ -1442,7 +1457,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     2,
                     job_id,
                     recovery_type,
@@ -1466,7 +1481,7 @@ class TestRequestFromArchive(unittest.TestCase):
     ):
         mock_s3 = Mock()
         max_retries = randint(3, 20)  # nosec
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         retry_sleep_secs = randint(0, 99)  # nosec
         recovery_type = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
@@ -1496,7 +1511,7 @@ class TestRequestFromArchive(unittest.TestCase):
             request_from_archive.process_granule(
                 mock_s3,
                 granule,
-                glacier_bucket,
+                archive_bucket_name,
                 restore_expire_days,
                 max_retries,
                 retry_sleep_secs,
@@ -1508,7 +1523,7 @@ class TestRequestFromArchive(unittest.TestCase):
         # except request_from_archive.RestoreRequestError:
         except request_from_archive.RestoreRequestError as caught_error:
             self.assertEqual(
-                f"One or more files failed to be requested from '{glacier_bucket}'.",
+                f"One or more files failed to be requested from '{archive_bucket_name}'.",
                 str(caught_error),
             )
         self.assertFalse(
@@ -1523,7 +1538,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     1,
                     job_id,
                     recovery_type,
@@ -1532,7 +1547,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     2,
                     job_id,
                     recovery_type,
@@ -1541,7 +1556,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     3,
                     job_id,
                     recovery_type,
@@ -1562,11 +1577,11 @@ class TestRequestFromArchive(unittest.TestCase):
             [
                 call(
                     f"Failed to restore '{file_name_0}' from "
-                    f"'{glacier_bucket}'. Encountered error '{str(expected_error)}'."
+                    f"'{archive_bucket_name}'. Encountered error '{str(expected_error)}'."
                 ),
                 call(
                     f"One or more files failed to be requested from "
-                    f"'{glacier_bucket}'. GRANULE: {json.dumps(granule)}",
+                    f"'{archive_bucket_name}'. GRANULE: {json.dumps(granule)}",
                 ),
             ]
         )
@@ -1588,7 +1603,7 @@ class TestRequestFromArchive(unittest.TestCase):
         """
         mock_s3 = Mock()
         max_retries = randint(3, 20)  # nosec
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         retry_sleep_secs = randint(0, 99)  # nosec
         recovery_type = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
@@ -1621,7 +1636,7 @@ class TestRequestFromArchive(unittest.TestCase):
             request_from_archive.process_granule(
                 mock_s3,
                 granule,
-                glacier_bucket,
+                archive_bucket_name,
                 restore_expire_days,
                 max_retries,
                 retry_sleep_secs,
@@ -1648,7 +1663,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     1,
                     job_id,
                     recovery_type,
@@ -1657,7 +1672,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     2,
                     job_id,
                     recovery_type,
@@ -1666,7 +1681,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     mock_s3,
                     file_name_0,
                     restore_expire_days,
-                    glacier_bucket,
+                    archive_bucket_name,
                     3,
                     job_id,
                     recovery_type,
@@ -1694,7 +1709,7 @@ class TestRequestFromArchive(unittest.TestCase):
             [
                 call(
                     f"Failed to restore '{file_name_0}' from "
-                    f"'{glacier_bucket}'. Encountered error '{str(expected_error)}'."
+                    f"'{archive_bucket_name}'. Encountered error '{str(expected_error)}'."
                 ),
                 call(
                     f"Ran into error posting to SQS {max_retries + 1} time(s) "
@@ -1707,11 +1722,11 @@ class TestRequestFromArchive(unittest.TestCase):
     def test_get_s3_object_information_happy_path(self):
         mock_s3_cli = Mock()
         mock_s3_cli.head_object.side_effect = None
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         file_key = uuid.uuid4().__str__()
 
         result = request_from_archive.get_s3_object_information(
-            mock_s3_cli, glacier_bucket, file_key
+            mock_s3_cli, archive_bucket_name, file_key
         )
         self.assertEqual(mock_s3_cli.head_object.return_value, result)
 
@@ -1721,12 +1736,12 @@ class TestRequestFromArchive(unittest.TestCase):
         )
         mock_s3_cli = Mock()
         mock_s3_cli.head_object.side_effect = expected_error
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         file_key = uuid.uuid4().__str__()
 
         try:
             request_from_archive.get_s3_object_information(
-                mock_s3_cli, glacier_bucket, file_key
+                mock_s3_cli, archive_bucket_name, file_key
             )
             self.fail("Error not raised.")
         except ClientError as err:
@@ -1738,16 +1753,16 @@ class TestRequestFromArchive(unittest.TestCase):
         )
         mock_s3_cli = Mock()
         mock_s3_cli.head_object.side_effect = expected_error
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         file_key = uuid.uuid4().__str__()
 
         result = request_from_archive.get_s3_object_information(
-            mock_s3_cli, glacier_bucket, file_key
+            mock_s3_cli, archive_bucket_name, file_key
         )
         self.assertIsNone(result)
 
     def test_restore_object_happy_path(self):
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
         recovery_type = uuid.uuid4().__str__()
@@ -1760,14 +1775,14 @@ class TestRequestFromArchive(unittest.TestCase):
             mock_s3_cli,
             key,
             restore_expire_days,
-            glacier_bucket,
+            archive_bucket_name,
             randint(0, 99),  # nosec
             uuid.uuid4().__str__(),
             recovery_type,
         )
 
         mock_s3_cli.restore_object.assert_called_once_with(
-            Bucket=glacier_bucket,
+            Bucket=archive_bucket_name,
             Key=key,
             RestoreRequest={
                 "Days": restore_expire_days,
@@ -1779,7 +1794,7 @@ class TestRequestFromArchive(unittest.TestCase):
     @patch("cumulus_logger.CumulusLogger.info")
     def test_restore_object_client_error_raises(self, mock_logger_info: MagicMock):
         job_id = uuid.uuid4().__str__()
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
         recovery_type = uuid.uuid4().__str__()
@@ -1792,7 +1807,7 @@ class TestRequestFromArchive(unittest.TestCase):
                 mock_s3_cli,
                 key,
                 restore_expire_days,
-                glacier_bucket,
+                archive_bucket_name,
                 1,
                 job_id,
                 recovery_type,
@@ -1801,7 +1816,7 @@ class TestRequestFromArchive(unittest.TestCase):
         except ClientError as error:
             self.assertEqual(expected_error, error)
             mock_s3_cli.restore_object.assert_called_once_with(
-                Bucket=glacier_bucket,
+                Bucket=archive_bucket_name,
                 Key=key,
                 RestoreRequest={
                     "Days": restore_expire_days,
@@ -1816,7 +1831,7 @@ class TestRequestFromArchive(unittest.TestCase):
         A 200 indicates that the file is already restored,  and thus cannot
         presently be restored again. Should be raised.
         """
-        glacier_bucket = uuid.uuid4().__str__()
+        archive_bucket_name = uuid.uuid4().__str__()
         key = uuid.uuid4().__str__()
         restore_expire_days = randint(0, 99)  # nosec
         recovery_type = uuid.uuid4().__str__()
@@ -1830,14 +1845,14 @@ class TestRequestFromArchive(unittest.TestCase):
                 mock_s3_cli,
                 key,
                 restore_expire_days,
-                glacier_bucket,
+                archive_bucket_name,
                 2,
                 uuid.uuid4().__str__(),
                 recovery_type,
             )
         self.assertEqual(
             f"An error occurred (HTTPStatus: 200) when calling the restore_object operation: "
-            f"File '{key}' in bucket '{glacier_bucket}' has already been recovered.",
+            f"File '{key}' in bucket '{archive_bucket_name}' has already been recovered.",
             str(context.exception),
         )
 
@@ -1941,7 +1956,7 @@ class TestRequestFromArchive(unittest.TestCase):
             },
             "task_config": {
                 request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY:
-                    "my-dr-fake-glacier-bucket",
+                    "my-dr-fake-archive-bucket",
                 request_from_archive.CONFIG_JOB_ID_KEY: job_id,
                 request_from_archive.CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY: "Standard",
             },
@@ -1962,36 +1977,36 @@ class TestRequestFromArchive(unittest.TestCase):
 
         mock_boto3_client.assert_has_calls([call("s3")])
         mock_s3_cli.head_object.assert_any_call(
-            Bucket="my-dr-fake-glacier-bucket", Key=file0
+            Bucket="my-dr-fake-archive-bucket", Key=file0
         )
         mock_s3_cli.head_object.assert_any_call(
-            Bucket="my-dr-fake-glacier-bucket", Key=file1
+            Bucket="my-dr-fake-archive-bucket", Key=file1
         )
         mock_s3_cli.head_object.assert_any_call(
-            Bucket="my-dr-fake-glacier-bucket", Key=file2
+            Bucket="my-dr-fake-archive-bucket", Key=file2
         )
         mock_s3_cli.head_object.assert_any_call(
-            Bucket="my-dr-fake-glacier-bucket", Key=file3
+            Bucket="my-dr-fake-archive-bucket", Key=file3
         )
         restore_req_exp = {"Days": 5, "GlacierJobParameters": {"Tier": "Standard"}}
 
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket="my-dr-fake-glacier-bucket",
+            Bucket="my-dr-fake-archive-bucket",
             Key=file0,
             RestoreRequest=restore_req_exp,
         )
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket="my-dr-fake-glacier-bucket",
+            Bucket="my-dr-fake-archive-bucket",
             Key=file1,
             RestoreRequest=restore_req_exp,
         )
         mock_s3_cli.restore_object.assert_any_call(
-            Bucket="my-dr-fake-glacier-bucket",
+            Bucket="my-dr-fake-archive-bucket",
             Key=file2,
             RestoreRequest=restore_req_exp,
         )
         mock_s3_cli.restore_object.assert_called_with(
-            Bucket="my-dr-fake-glacier-bucket",
+            Bucket="my-dr-fake-archive-bucket",
             Key=file3,
             RestoreRequest=restore_req_exp,
         )


### PR DESCRIPTION
## Summary of Changes

Removed a few remaining references to "glaicer" bucket.

Addresses [ORCA-538: Remove "glacier" bucket name in TF](https://bugs.earthdata.nasa.gov/browse/ORCA-538)

## Changes

* Removed references to "glacier" bucket.
* Fixed bug where if request_files_from_archive was run on its own, default recovery type would not be applied.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tests pass locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] Development documentation
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets