### PR TITLE
Feature/orca 534 Remove loop logic for dest_bucket in extract_filepaths_for_granule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and includes an additional section for migration notes.
 - *ORCA-539*
   - Renamed lambda `request_files` to `request_from_archive`.
   - Output of Terraform updated to match. Unlikely to affect any integrations.
+- *ORCA-534* `extract_filepaths_for_granule` now raises a descriptive error when no destination bucket (`destBucket`) is found in `fileBucketMaps` for a given file.
+  Previously was a general `JsonSchemaException`.
+  Now is a `ExtractFilePathsError` with a description of which file could not be placed.
 
 ### Migration Notes
 - If utilizing the `copied_to_glacier` [output property](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/tasks/copy_to_glacier/schemas/output.json#L47) of `copy_to_glacier`, 

--- a/tasks/extract_filepaths_for_granule/API.md
+++ b/tasks/extract_filepaths_for_granule/API.md
@@ -57,7 +57,7 @@ This task will parse the input, removing the granuleId and file keys for a granu
 #### get\_regex\_buckets
 
 ```python
-def get_regex_buckets(event)
+def get_regex_buckets(event) -> Dict[str, str]
 ```
 
 Gets a dict of regular expressions and the corresponding archive bucket for files


### PR DESCRIPTION
## Summary of Changes

Remove loop logic for dest_bucket in extract_filepaths_for_granule

Addresses [ORCA-534: Remove loop logic for dest_bucket in extract_filepaths_for_granule](https://bugs.earthdata.nasa.gov/browse/ORCA-534)

## Changes

* Switched to `first` call instead of loop for destination bucket.
* Added descriptive error for if no destination bucket is found.

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Tests pass locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Development documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets