### PR TITLE
fix: Removed dead comment from sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and includes an additional section for migration notes.
 
 ## [Unreleased]
 
+## [6.0.2]
+### Changed
+- *ORCA-570* Fixed an error that could prevent deployment of the database on fresh installations.
+
 ## [6.0.1]
 ### Changed
 - *ORCA-566* Shortened S3 inventory report name due to length limitation causing errors when a user's naming schema is long.

--- a/tasks/db_deploy/install/orca_sql.py
+++ b/tasks/db_deploy/install/orca_sql.py
@@ -1043,7 +1043,5 @@ def reconcile_phantom_report_table_sql() -> text:  # pragma: no cover
               IS 'Last update of the object as reported in the ORCA catalog.';
             COMMENT ON COLUMN reconcile_phantom_report.orca_size
               IS 'Size in bytes of the object as reported in the ORCA catalog.';
-            COMMENT ON COLUMN reconcile_phantom_report.s3_storage_class_id
-              IS 'Storage class of the file as reported in the ORCA catalog.';
         """
     )


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-570: Remove old comment from deployment sql](https://bugs.earthdata.nasa.gov/browse/ORCA-570)

## Changes

* Removed old comment from SQL.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Error seen in AWS. This fixes it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets