### PR TITLE
Feature/orca 575 Remove run_cumulus_task from request_from_archive lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and includes an additional section for migration notes.
 ### Changed
 - *ORCA-522*
   - Removed `run_cumulus_task` function from extract_filepath_for_granule lambda to decouple ORCA from Cumulus.
+- *ORCA-575*
+  - Removed `run_cumulus_task` function from request_from_archive lambda to decouple ORCA from Cumulus.
 - *ORCA-521*
   - Replaced CumulusLogger with AWS powertools logger in all of the lambdas currently present in ORCA.
 - *ORCA-537*

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -1,7 +1,6 @@
 {
   "Comment": "Recover files belonging to a granule",
-  "StartAt": "ExtractFilepaths",
-  "TimeoutSeconds": 18000,
+  "StartAt": "ExtractFilepaths",  "TimeoutSeconds": 18000,
   "States": {
     "ExtractFilepaths": {
       "Parameters": {
@@ -14,6 +13,7 @@
       },
       "Type": "Task",
       "Resource": "${orca_lambda_extract_filepaths_for_granule_arn}",
+      "ResultPath": "$.output_extract_filepath_from_granules",
       "Retry": [
         {
           "ErrorEquals": [
@@ -39,8 +39,14 @@
     },
     "RequestFromArchive": {
       "Parameters": {
-        "input.$": "$",
-        "config.$": "$"
+        "event.$": "$",
+        "input.$": "$.output_extract_filepath_from_granules",
+        "config": {
+          "asyncOperationId": ".cumulus_meta.asyncOperationId",
+          "defaultBucketOverride": ".meta.collection.meta.orca.defaultBucketOverride",
+          "defaultRecoveryTypeOverride": ".meta.collection.meta.orca.defaultRecoveryTypeOverride",
+          "s3MultipartChunksizeMb": ".meta.collection.meta.s3MultipartChunksizeMb"
+          }
       },
       "Type": "Task",
       "Resource": "${orca_lambda_request_from_archive_arn}",

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -39,17 +39,12 @@
     },
     "RequestFromArchive": {
       "Parameters": {
-        "cma": {
-          "event.$": "$",
-          "ReplaceConfig": {
-            "FullMessage": true
-          },
-          "task_config": {
-            "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
-            "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-            "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}",
-            "defaultRecoveryTypeOverride": "{$.meta.collection.meta.orca.defaultRecoveryTypeOverride}"
-          }
+        "input.$": "$",
+        "config": {
+          "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
+          "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
+          "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}",
+          "defaultRecoveryTypeOverride": "{$.meta.collection.meta.orca.defaultRecoveryTypeOverride}"
         }
       },
       "Type": "Task",

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -40,12 +40,7 @@
     "RequestFromArchive": {
       "Parameters": {
         "input.$": "$",
-        "config": {
-          "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
-          "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-          "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}",
-          "defaultRecoveryTypeOverride": "{$.meta.collection.meta.orca.defaultRecoveryTypeOverride}"
-        }
+        "config.$": "$"
       },
       "Type": "Task",
       "Resource": "${orca_lambda_request_from_archive_arn}",

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -43,10 +43,12 @@
         "event.$": "$",
         "input.$": "$.previous_step_output",
         "optionalValues": {
-          "config.defaultRecoveryTypeOverride": "event.meta.collection.meta.orca.defaultRecoveryTypeOverride",
-          "config.defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",
-          "config.s3MultipartChunksizeMb": "event.meta.collection.meta.s3MultipartChunksizeMb",
-          "config.asyncOperationId": "event.cumulus_meta.asyncOperationId"
+          "config": {
+            "defaultRecoveryTypeOverride": "event.meta.collection.meta.orca.defaultRecoveryTypeOverride",
+            "defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",
+            "s3MultipartChunksizeMb": "event.meta.collection.meta.s3MultipartChunksizeMb",
+            "asyncOperationId": "event.cumulus_meta.asyncOperationId"
+          }
         }
       },
       "Type": "Task",

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -1,6 +1,7 @@
 {
   "Comment": "Recover files belonging to a granule",
-  "StartAt": "ExtractFilepaths",  "TimeoutSeconds": 18000,
+  "StartAt": "ExtractFilepaths",
+  "TimeoutSeconds": 18000,
   "States": {
     "ExtractFilepaths": {
       "Parameters": {
@@ -13,7 +14,7 @@
       },
       "Type": "Task",
       "Resource": "${orca_lambda_extract_filepaths_for_granule_arn}",
-      "ResultPath": "$.output_extract_filepath_from_granules",
+      "ResultPath": "$.previous_step_output",
       "Retry": [
         {
           "ErrorEquals": [
@@ -40,7 +41,7 @@
     "RequestFromArchive": {
       "Parameters": {
         "event.$": "$",
-        "input.$": "$.output_extract_filepath_from_granules",
+        "input.$": "$.previous_step_output",
         "optionalValues": {
           "config.defaultRecoveryTypeOverride": "event.meta.collection.meta.orca.defaultRecoveryTypeOverride",
           "config.defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",

--- a/tasks/request_from_archive/API.md
+++ b/tasks/request_from_archive/API.md
@@ -221,9 +221,9 @@ Restore an archived S3 object in an Amazon S3 bucket.
 #### set\_optional\_event\_property
 
 ```python
-def set_optional_event_property(event: Dict[str, Any], source_path: str,
-                                target_path: str,
-                                logger: logging.Logger) -> None
+def set_optional_event_property(event: Dict[str,
+                                            Any], target_path_cursor: Dict,
+                                target_path_segments: List) -> None
 ```
 
 Sets the optional variable value from event if present, otherwise sets to None.
@@ -231,8 +231,8 @@ Sets the optional variable value from event if present, otherwise sets to None.
 **Arguments**:
 
 - `event` - See schemas/input.json.
-- `source_path` - The source path containing the optional variable.
-- `target_path` - The target path to get the desired key.
+- `target_path_cursor` - Cursor of the current section to check.
+- `target_path_segments` - The path to the current cursor.
 
 **Returns**:
 
@@ -264,8 +264,6 @@ RESTORE_RETRY_SLEEP_SECS (int, optional, default = 0): The number of seconds
 to sleep between retry attempts.
 RESTORE_RECOVERY_TYPE (str, optional, default = 'Standard'): the Tier
 for the restore request. Valid values are 'Standard'|'Bulk'|'Expedited'.
-CUMULUS_MESSAGE_ADAPTER_DISABLED (str): If set to 'true',
-CumulusMessageAdapter does not modify input.
 STATUS_UPDATE_QUEUE_URL
 The URL of the SQS queue to post status to.
 ORCA_DEFAULT_BUCKET

--- a/tasks/request_from_archive/API.md
+++ b/tasks/request_from_archive/API.md
@@ -8,6 +8,7 @@
   * [process\_granule](#request_from_archive.process_granule)
   * [get\_s3\_object\_information](#request_from_archive.get_s3_object_information)
   * [restore\_object](#request_from_archive.restore_object)
+  * [set\_optional\_event\_property](#request_from_archive.set_optional_event_property)
   * [handler](#request_from_archive.handler)
 
 <a id="request_from_archive"></a>
@@ -32,7 +33,7 @@ Exception to be raised if the restore request fails submission for any of the fi
 #### task
 
 ```python
-def task(event: Dict, context: object) -> Dict[str, Any]
+def task(event: Dict) -> Dict[str, Any]
 ```
 
 Pulls information from os.environ, utilizing defaults if needed,
@@ -45,7 +46,6 @@ then calls inner_task.
 - `event` - A dict with the following keys:
 - `'config'` _dict_ - See schemas/config.json for details.
 - `'input'` _dict_ - See schemas/input.json for details.
-- `context` - Passed through from AWS and CMA. Unused.
   Environment Vars:
   See docs in handler for details.
 
@@ -216,6 +216,28 @@ Restore an archived S3 object in an Amazon S3 bucket.
 
 - `ClientError` - Raises ClientErrors from restore_object, or if the file is already restored.
 
+<a id="request_from_archive.set_optional_event_property"></a>
+
+#### set\_optional\_event\_property
+
+```python
+def set_optional_event_property(event: Dict[str, Any], source_path: str,
+                                target_path: str,
+                                logger: logging.Logger) -> None
+```
+
+Sets the optional variable value from event if present, otherwise sets to None.
+
+**Arguments**:
+
+- `event` - See schemas/input.json.
+- `source_path` - The source path containing the optional variable.
+- `target_path` - The target path to get the desired key.
+
+**Returns**:
+
+  None
+
 <a id="request_from_archive.handler"></a>
 
 #### handler
@@ -251,14 +273,13 @@ The bucket to use if destBucket is not set.
 
 **Arguments**:
 
-- `event` - See schemas/input.json and combine with knowledge of CumulusMessageAdapter.
+- `event` - See schemas/input.json.
 - `context` - This object provides information about the lambda invocation, function,
   and execution env.
 
 **Returns**:
 
-  A dict with the value at 'payload' matching schemas/output.json
-  Combine with knowledge of CumulusMessageAdapter for other properties.
+  A dict matching schemas/output.json
 
 **Raises**:
 

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -609,8 +609,8 @@ def restore_object(
     )
 
 
-def set_optional_event_property(event: Dict[str, Any], target_path_cursor, target_path_segments
-                                ) -> None:
+def set_optional_event_property(event: Dict[str, Any], target_path_cursor: Dict,
+                                target_path_segments: List) -> None:
     """Sets the optional variable value from event if present, otherwise sets to None.
     Args:
         event: See schemas/input.json.
@@ -674,8 +674,6 @@ def handler(event: Dict[str, Any], context: LambdaContext):  # pylint: disable-m
                 to sleep between retry attempts.
             RESTORE_RECOVERY_TYPE (str, optional, default = 'Standard'): the Tier
                 for the restore request. Valid values are 'Standard'|'Bulk'|'Expedited'.
-            CUMULUS_MESSAGE_ADAPTER_DISABLED (str): If set to 'true',
-                CumulusMessageAdapter does not modify input.
             STATUS_UPDATE_QUEUE_URL
                 The URL of the SQS queue to post status to.
             ORCA_DEFAULT_BUCKET

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -612,6 +612,15 @@ def restore_object(
 
 def set_optional_event_property(event: Dict[str, Any], source_path: str, target_path: str,
                                 logger: logging.Logger) -> None:
+
+    """Sets the optional variable value from event if present, otherwise sets to None.
+    Args:
+        event: See schemas/input.json.
+        source_path: The source path containing the optional variable.
+        target_path: The target path to get the desired key.
+    Returns:
+        None
+    """
     source_path_segments = source_path.split(".")
     target_path_segments = target_path.split(".")
 
@@ -660,7 +669,7 @@ def handler(event: Dict[str, Any], context: LambdaContext):  # pylint: disable-m
             ORCA_DEFAULT_BUCKET
                 The bucket to use if destBucket is not set.
         Args:
-            event: See schemas/input.json and combine with knowledge of CumulusMessageAdapter.
+            event: See schemas/input.json.
             context: This object provides information about the lambda invocation, function,
                 and execution env.
         Returns:

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -612,12 +612,12 @@ def restore_object(
 
 def set_optional_event_property(event: Dict[str, Any], source_path: str, target_path: str,
                                 logger: logging.Logger) -> None:
-
     """Sets the optional variable value from event if present, otherwise sets to None.
     Args:
         event: See schemas/input.json.
         source_path: The source path containing the optional variable.
         target_path: The target path to get the desired key.
+        logger: The logger to use.
     Returns:
         None
     """

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -3,7 +3,6 @@ Name: request_from_archive.py
 Description:  Lambda function that makes a restore request from archive bucket for each input file.
 """
 import json
-import logging
 import os
 import time
 import uuid
@@ -610,14 +609,13 @@ def restore_object(
     )
 
 
-def set_optional_event_property(event: Dict[str, Any], source_path: str, target_path: str,
-                                logger: logging.Logger) -> None:
+def set_optional_event_property(event: Dict[str, Any], source_path: str, target_path: str
+                                ) -> None:
     """Sets the optional variable value from event if present, otherwise sets to None.
     Args:
         event: See schemas/input.json.
         source_path: The source path containing the optional variable.
         target_path: The target path to get the desired key.
-        logger: The logger to use.
     Returns:
         None
     """
@@ -636,7 +634,7 @@ def set_optional_event_property(event: Dict[str, Any], source_path: str, target_
     for source_path_segment in source_path_segments:
         source_path_cursor = source_path_cursor.get(source_path_segment, None)
         if source_path_cursor is None:
-            logger.info(f"When retrieving '{target_path}', "
+            LOGGER.info(f"When retrieving '{target_path}', "
                         f"no value found in '{source_path}' at key {source_path_segment}. "
                         f"Defaulting to null.")
             return

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -614,8 +614,8 @@ def set_optional_event_property(event: Dict[str, Any], target_path_cursor: Dict,
     """Sets the optional variable value from event if present, otherwise sets to None.
     Args:
         event: See schemas/input.json.
-        source_path: The source path containing the optional variable.
-        target_path: The target path to get the desired key.
+        target_path_cursor: Cursor of the current section to check.
+        target_path_segments: The path to the current cursor.
     Returns:
         None
     """

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -37,6 +37,7 @@ OS_ENVIRON_STATUS_UPDATE_QUEUE_URL_KEY = "STATUS_UPDATE_QUEUE_URL"
 OS_ENVIRON_ORCA_DEFAULT_ARCHIVE_BUCKET_KEY = "ORCA_DEFAULT_BUCKET"
 
 EVENT_CONFIG_KEY = "config"
+EVENT_INPUT_KEY = "input"
 
 CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY = "defaultBucketOverride"
 CONFIG_DEFAULT_RECOVERY_TYPE_OVERRIDE_KEY = "defaultRecoveryTypeOverride"
@@ -283,7 +284,7 @@ def inner_task(
         collection_multipart_chunksize_mb = int(collection_multipart_chunksize_mb_str)
 
     # Get the granule array from the event
-    granules = event[INPUT_GRANULES_KEY]
+    granules = event[EVENT_INPUT_KEY][INPUT_GRANULES_KEY]
 
     # Create the S3 client
     s3 = boto3.client("s3")  # pylint: disable-msg=invalid-name
@@ -645,7 +646,7 @@ def handler(event: Dict[str, Any], context: LambdaContext):  # pylint: disable-m
             the files for which the restore request failed to submit.
     """
     try:
-        _VALIDATE_INPUT(event)
+        _VALIDATE_INPUT(event["input"])
     except JsonSchemaException as json_schema_exception:
         LOGGER.error(json_schema_exception)
         raise

--- a/tasks/request_from_archive/requirements-dev.txt
+++ b/tasks/request_from_archive/requirements-dev.txt
@@ -14,7 +14,7 @@ aws_lambda_powertools==1.31.0
 ## Additional validation libraries
 ## ---------------------------------------------------------------------------
 bandit==1.7.0
-safety==1.10.3
+safety==2.3.1
 flake8==4.0.1
 black==21.12b0
 isort==5.10.1

--- a/tasks/request_from_archive/requirements-dev.txt
+++ b/tasks/request_from_archive/requirements-dev.txt
@@ -7,7 +7,6 @@ fastjsonschema==2.15.0
 psycopg2-binary==2.8.6
 
 ## Application libraries
-cumulus-process==0.8.0
 boto3~=1.18.40
 aws_lambda_powertools==1.31.0
 ../../shared_libraries[recovery]

--- a/tasks/request_from_archive/requirements.txt
+++ b/tasks/request_from_archive/requirements.txt
@@ -1,4 +1,3 @@
-cumulus-process==0.8.0
 aws_lambda_powertools==1.31.0
 boto3~=1.18.40
 ../../shared_libraries[recovery]

--- a/tasks/request_from_archive/test/testevents/RestoreTestFiles.json
+++ b/tasks/request_from_archive/test/testevents/RestoreTestFiles.json
@@ -72,16 +72,14 @@
       "provider": "CUMULUS"
     }
   },
-  "payload": {
-    "granules": [
-      {
-        "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
-        "keys": [
-          "L0A_LR_RAW_product_0010-of-0092.h5"
-        ]
-      }
-    ]
-  },
+  "granules": [
+    {
+      "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+      "keys": [
+        "L0A_LR_RAW_product_0010-of-0092.h5"
+      ]
+    }
+  ],
   "exception": "None",
   "workflow_config": {
     "Report": {

--- a/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
+++ b/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
@@ -1,34 +1,120 @@
 {
-  "config": {
-    "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
-    "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-    "defaultBucketOverride": "{$.meta.collection.meta.defaultBucketOverride}",
-    "defaultRecoveryTypeOverride": "{$.meta.collection.meta.defaultRecoveryTypeOverride}"
+  "optionalValues": {
+    "config.defaultRecoveryTypeOverride": "event.meta.collection.meta.orca.defaultRecoveryTypeOverride",
+    "config.defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",
+    "config.s3MultipartChunksizeMb": "event.meta.collection.meta.s3MultipartChunksizeMb",
+    "config.asyncOperationId": "event.cumulus_meta.asyncOperationId"
   },
-  "cumulus_meta": {
-    "task": "request_from_archive",
-    "message_source": "local",
-    "id": "id-123456"
-  },
-  "meta": {
-    "workflow_name": "OrcaRecoveryWorkflow",
-    "collection": {
-      "meta": {
-        "granuleRecoveryWorkflow": "OrcaRecoveryWorkflow",
-        "defaultBucketOverride": "lp-sndbx-cumulus-orca",
-        "s3MultipartChunksizeMb": 750
+  "input": {
+    "granules": [
+      {
+        "granuleId": "integrationGranuleId",
+        "version": "integrationGranuleVersion",
+        "files": [
+          {
+            "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+            "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+            "bucket": "rhrh-orca-primary"
+          }
+        ],
+        "keys": [
+          {
+            "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+            "destBucket": "rhrh-public"
+          }
+        ]
       }
-    }
+    ]
   },
-  "granules": [
-    {
-      "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
-      "keys": [
+  "event": {
+    "payload": {
+      "granules": [
         {
-          "key": "L0A_LR_RAW_product_0010-of-0092.h5",
-          "destBucket": "some_bucket_name"
+          "granuleId": "integrationGranuleId",
+          "version": "integrationGranuleVersion",
+          "files": [
+            {
+              "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+              "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+              "bucket": "rhrh-orca-primary"
+            }
+          ]
+        }
+      ]
+    },
+    "meta": {
+      "buckets": {
+        "protected": {
+          "name": "rhrh-protected",
+          "type": "protected"
+        },
+        "internal": {
+          "name": "rhrh-internal",
+          "type": "internal"
+        },
+        "private": {
+          "name": "rhrh-private",
+          "type": "private"
+        },
+        "public": {
+          "name": "rhrh-public",
+          "type": "public"
+        },
+        "orca_default": {
+          "name": "rhrh-orca-primary",
+          "type": "orca"
+        }
+      },
+      "collection": {
+        "meta": {
+          "orca": {
+            "excludedFileExtensions": [
+              ".xml"
+            ]
+          }
+        },
+        "files": [
+          {
+            "regex": ".*.tar.gz",
+            "sampleFileName": "blah.tar.gz",
+            "bucket": "public"
+          },
+          {
+            "regex": ".*.jpg",
+            "sampleFileName": "blah.tar.gz",
+            "bucket": "public"
+          },
+          {
+            "regex": ".*.hdf",
+            "sampleFileName": "blah.tar.gz",
+            "bucket": "public"
+          }
+        ]
+      }
+    },
+    "cumulus_meta": {
+      "system_bucket": "rhrh-internal"
+    },
+    "previous_step_output": {
+      "granules": [
+        {
+          "granuleId": "integrationGranuleId",
+          "version": "integrationGranuleVersion",
+          "files": [
+            {
+              "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+              "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+              "bucket": "rhrh-orca-primary"
+            }
+          ],
+          "keys": [
+            {
+              "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+              "destBucket": "rhrh-public"
+            }
+          ]
         }
       ]
     }
-  ]
+  }
 }

--- a/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
+++ b/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
@@ -1,9 +1,11 @@
 {
   "optionalValues": {
-    "config.defaultRecoveryTypeOverride": "event.meta.collection.meta.orca.defaultRecoveryTypeOverride",
-    "config.defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",
-    "config.s3MultipartChunksizeMb": "event.meta.collection.meta.s3MultipartChunksizeMb",
-    "config.asyncOperationId": "event.cumulus_meta.asyncOperationId"
+    "config": {
+      "defaultRecoveryTypeOverride": "event.meta.collection.meta.orca.defaultRecoveryTypeOverride",
+      "defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",
+      "s3MultipartChunksizeMb": "event.meta.collection.meta.s3MultipartChunksizeMb",
+      "asyncOperationId": "event.cumulus_meta.asyncOperationId"
+    }
   },
   "input": {
     "granules": [

--- a/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
+++ b/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
@@ -1,5 +1,5 @@
 {
-  "task_config": {
+  "config": {
     "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
     "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
     "defaultBucketOverride": "{$.meta.collection.meta.defaultBucketOverride}",
@@ -20,18 +20,15 @@
       }
     }
   },
-  "payload": {
-    "granules": [
-      {
-        "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
-        "keys": [
-          {
-            "key": "L0A_LR_RAW_product_0010-of-0092.h5",
-            "destBucket": "some_bucket_name"
-          }
-        ]
-      }
-    ],
-    "cumulus_meta": {"job_id": "ad6ed089-f020-4374-9174-0fb5a4a1ebc1"}
-  }
+  "granules": [
+    {
+      "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+      "keys": [
+        {
+          "key": "L0A_LR_RAW_product_0010-of-0092.h5",
+          "destBucket": "some_bucket_name"
+        }
+      ]
+    }
+  ]
 }

--- a/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
+++ b/tasks/request_from_archive/test/testevents/request_from_archive_fixture1.json
@@ -94,27 +94,6 @@
     },
     "cumulus_meta": {
       "system_bucket": "rhrh-internal"
-    },
-    "previous_step_output": {
-      "granules": [
-        {
-          "granuleId": "integrationGranuleId",
-          "version": "integrationGranuleVersion",
-          "files": [
-            {
-              "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-              "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-              "bucket": "rhrh-orca-primary"
-            }
-          ],
-          "keys": [
-            {
-              "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-              "destBucket": "rhrh-public"
-            }
-          ]
-        }
-      ]
     }
   }
 }

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -2173,9 +2173,8 @@ class TestRequestFromArchive(unittest.TestCase):
         self, mock_logger: MagicMock,
     ):
         """
-        Tests that set_optional_event_property sets asyncOperationId as None
-        if not present in event and uses the non-null value of
-        given defaultRecoveryTypeOverride.
+        Tests that set_optional_event_property sets asyncOperationId as the value
+        present in event and sets null value for other keys that are not present in event.
         """
         mock_event = create_handler_event()
         mock_target_path_cursor = {

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -1943,7 +1943,7 @@ class TestRequestFromArchive(unittest.TestCase):
         granule_id = "MOD09GQ.A0219114.N5aUCG.006.0656338553321"
         files = [key0, key1, key2, key3]
         input_event = {
-            "payload": {
+            "input": {
                 request_from_archive.INPUT_GRANULES_KEY: [
                     {
                         request_from_archive.GRANULE_GRANULE_ID_KEY: granule_id,
@@ -1951,7 +1951,7 @@ class TestRequestFromArchive(unittest.TestCase):
                     }
                 ]
             },
-            "task_config": {
+            "config": {
                 request_from_archive.CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY:
                     "my-dr-fake-archive-bucket",
                 request_from_archive.CONFIG_JOB_ID_KEY: job_id,
@@ -1969,8 +1969,6 @@ class TestRequestFromArchive(unittest.TestCase):
         context = Mock()
 
         result = request_from_archive.handler(input_event, context)
-
-        result_value = result["payload"]
 
         mock_boto3_client.assert_has_calls([call("s3")])
         mock_s3_cli.head_object.assert_any_call(
@@ -2069,16 +2067,16 @@ class TestRequestFromArchive(unittest.TestCase):
         }
 
         # Validate the output is correct
-        _OUTPUT_VALIDATE(result_value)
+        _OUTPUT_VALIDATE(result)
 
         # Check the values of the result less the times since those will never match
-        for granule in result_value["granules"]:
+        for granule in result["granules"]:
             for file in granule[request_from_archive.GRANULE_RECOVER_FILES_KEY]:
                 file.pop(request_from_archive.FILE_REQUEST_TIME_KEY, None)
                 file.pop(request_from_archive.FILE_LAST_UPDATE_KEY, None)
                 file.pop(request_from_archive.FILE_COMPLETION_TIME_KEY, None)
 
-        self.assertEqual(expected_result, result_value)
+        self.assertEqual(expected_result, result)
 
 
 if __name__ == "__main__":

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -83,7 +83,7 @@ class TestRequestFromArchive(unittest.TestCase):
             request_from_archive.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
         ] = exp_days.__str__()
 
-        request_from_archive.task(mock_event, None)
+        request_from_archive.task(mock_event)
 
         mock_get_default_archive_bucket_name.assert_called_once_with(config)
         mock_get_archive_recovery_type.assert_called_once_with(config)
@@ -136,7 +136,7 @@ class TestRequestFromArchive(unittest.TestCase):
             request_from_archive.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
         ] = exp_days.__str__()
 
-        request_from_archive.task(mock_event, None)
+        request_from_archive.task(mock_event)
 
         mock_get_default_archive_bucket_name.assert_called_once_with(config)
         mock_get_archive_recovery_type.assert_called_once_with(config)
@@ -189,7 +189,7 @@ class TestRequestFromArchive(unittest.TestCase):
             request_from_archive.OS_ENVIRON_RESTORE_EXPIRE_DAYS_KEY
         ] = exp_days.__str__()
 
-        request_from_archive.task(mock_event, None)
+        request_from_archive.task(mock_event)
 
         mock_get_default_archive_bucket_name.assert_called_once_with(config)
         mock_get_archive_recovery_type.assert_called_once_with(config)
@@ -242,7 +242,7 @@ class TestRequestFromArchive(unittest.TestCase):
         ] = retry_sleep_secs.__str__()
         os.environ[request_from_archive.OS_ENVIRON_DEFAULT_RECOVERY_TYPE_KEY] = recovery_type
 
-        request_from_archive.task(mock_event, None)
+        request_from_archive.task(mock_event)
 
         mock_get_default_archive_bucket_name.assert_called_once_with(config)
         mock_get_archive_recovery_type.assert_called_once_with(config)
@@ -300,7 +300,7 @@ class TestRequestFromArchive(unittest.TestCase):
         ] = exp_days.__str__()
 
         with patch.object(uuid, "uuid4", return_value=job_id):
-            request_from_archive.task(mock_event, None)
+            request_from_archive.task(mock_event)
 
         mock_get_default_archive_bucket_name.assert_called_once_with(config)
         mock_get_archive_recovery_type.assert_called_once_with(config)
@@ -1857,7 +1857,7 @@ class TestRequestFromArchive(unittest.TestCase):
     @patch("request_from_archive.task")
     def test_handler_happy_path(self, mock_task: MagicMock):
         """
-        Tests that between the handler and CMA, input is translated into what task expects.
+        Happy path for handler.
         """
         # todo: Remove these hardcoded keys
         file0 = "MOD09GQ___006/2017/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5"
@@ -1865,7 +1865,7 @@ class TestRequestFromArchive(unittest.TestCase):
 
         input_event = create_handler_event()
         expected_task_input = {
-            request_from_archive.EVENT_INPUT_KEY: input_event["payload"],
+            request_from_archive.EVENT_INPUT_KEY: input_event["input"],
             # Values here are based on the event task_config values that are mapped
             request_from_archive.EVENT_CONFIG_KEY: {
                 request_from_archive.CONFIG_JOB_ID_KEY: None,
@@ -1897,11 +1897,10 @@ class TestRequestFromArchive(unittest.TestCase):
         }
         context = Mock()
         result = request_from_archive.handler(input_event, context)
-        mock_task.assert_called_once_with(expected_task_input, context)
+        mock_task.assert_called_once_with(expected_task_input)
 
         self.assertEqual(mock_task.return_value, result["payload"])
 
-    # noinspection PyUnusedLocal
     @patch("request_from_archive.shared_recovery.create_status_for_job")
     @patch("boto3.client")
     def test_handler_output_json_schema(
@@ -1967,8 +1966,8 @@ class TestRequestFromArchive(unittest.TestCase):
             {"ResponseMetadata": {"HTTPStatusCode": 202}},
             {"ResponseMetadata": {"HTTPStatusCode": 202}},
         ]
-
         context = Mock()
+
         result = request_from_archive.handler(input_event, context)
 
         result_value = result["payload"]

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -2173,7 +2173,9 @@ class TestRequestFromArchive(unittest.TestCase):
         self, mock_logger: MagicMock,
     ):
         """
-        Unit test for set_optional_event_property function.
+        Tests that set_optional_event_property sets asyncOperationId as None
+        if not present in event and uses the non-null value of
+        given defaultRecoveryTypeOverride.
         """
         mock_event = create_handler_event()
         mock_target_path_cursor = {
@@ -2191,24 +2193,22 @@ class TestRequestFromArchive(unittest.TestCase):
             }
         }
         mock_target_path_segments = []
-        request_from_archive.set_optional_event_property(
-            mock_event, mock_target_path_cursor, mock_target_path_segments
-            )
-        self.assertEqual(mock_logger.call_count, 4)
 
-        # reset mock_logger for next test
-        mock_logger.reset_mock()
-        event_key = mock_event["event"]["meta"]["collection"]["meta"]
+        # set asyncOperationId to non-null value
         mock_event["event"]["cumulus_meta"]["asyncOperationId"] = "123"
-        event_key["orca"]["defaultRecoveryTypeOverride"] = "Standard"
-        event_key["orca"]["defaultBucketOverride"] = "test-bucket"
-        event_key["s3MultipartChunksizeMb"] = 100
 
         request_from_archive.set_optional_event_property(
             mock_event, mock_target_path_cursor, mock_target_path_segments
             )
-        # test that logger is not called since all keys are present in input
-        self.assertEqual(mock_logger.call_count, 0)
+        self.assertEqual(mock_logger.call_count, 3)
+        self.assertEqual(mock_event["optionalValues"]["config"]["asyncOperationId"],
+                         mock_event["event"]["cumulus_meta"]["asyncOperationId"])
+        self.assertEqual(mock_event["optionalValues"]["config"]["defaultRecoveryTypeOverride"],
+                         None)
+        self.assertEqual(mock_event["optionalValues"]["config"]["defaultBucketOverride"],
+                         None)
+        self.assertEqual(mock_event["optionalValues"]["config"]["s3MultipartChunksizeMb"],
+                         None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-575: Remove run_cumulus_task from request_from_archive lambda](https://bugs.earthdata.nasa.gov/browse/ORCA-575)

## Changes

* updated request_from_archive lambda to check for optional variables
* updated step fn workflow

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] This change requires a documentation update

## How Has This Been Tested?

Recovery Step function runs successfully in aws. See `rhrh-OrcaRecoveryWorkflow` in aws.


## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x ] CHANGELOG.md
    - [ ] Testing documentation
    - [ ] Development documentation
    - [ x] User documentation
    - [ ] (Additional here)
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
    - [ ] Unit tests
    - [x ] Integration tests
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code has passed security scanning
    - [x ] Snyk
    - [ x] git-secrets

