### PR TITLE
Feature/orca 561 Add GraphQL image to new AWS task and service definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and includes an additional section for migration notes.
   - Postgres table/user names can now begin with an '_' and contain '$' if your Postgres DB version supports this.
 - *ORCA-554* GraphQL image will now be deployed by TF.
 
+### Added
+- *ORCA-561* Initial GraphQL implementation added.
+
 ### Migration Notes
 - If utilizing the `copied_to_glacier` [output property](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/tasks/copy_to_glacier/schemas/output.json#L47) of `copy_to_glacier`, 
   rename to new key `copied_to_orca`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,9 @@ and includes an additional section for migration notes.
 - *ORCA-461*
   - Invalid database connection parameters will now be detected earlier and more consistently.
   - Postgres table/user names can now begin with an '_' and contain '$' if your Postgres DB version supports this.
-- *ORCA-554* GraphQL image will now be deployed by TF.
 
 ### Added
-- *ORCA-561* Initial GraphQL implementation added.
+- *ORCA-554*, *ORCA-561* GraphQL image and service will now be deployed by TF.
 
 ### Migration Notes
 - If utilizing the `copied_to_glacier` [output property](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/tasks/copy_to_glacier/schemas/output.json#L47) of `copy_to_glacier`, 

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,0 +1,9 @@
+resource "aws_ecs_cluster" "orca_ecs_cluster" {
+  name = "${var.prefix}_orca_ecs_cluster"
+  capacity_providers = ["FARGATE"]
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 100
+  }
+  tags                = var.tags
+}

--- a/modules/ecs/outputs.tf
+++ b/modules/ecs/outputs.tf
@@ -1,0 +1,4 @@
+output "ecs_cluster_id" {
+  value = aws_ecs_cluster.orca_ecs_cluster.id
+  description = "ID of the ECS cluster in AWS."
+}

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -1,0 +1,13 @@
+## Variables obtained by Cumulus deployment
+## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
+## REQUIRED
+variable "prefix" {
+  type        = string
+  description = "Prefix used to prepend to all object names and tags."
+}
+
+## OPTIONAL
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to resources that support tags."
+}

--- a/modules/graph_ql/main.tf
+++ b/modules/graph_ql/main.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy_document" "graphql_task_policy_document" {
+data "aws_iam_policy_document" "graphql_task_execution_policy_document" {
   statement {
     actions   = ["sts:AssumeRole"]
     resources = [aws_iam_role.orca_ecs_tasks_role.arn]
@@ -34,8 +34,8 @@ resource "aws_iam_role" "orca_ecs_tasks_role" {
 
 resource "aws_iam_role_policy" "graphql_task_role_policy" {
   name   = "${var.prefix}_orca_graphql_task_role_policy"
-  role   = aws_iam_role.orca_ecs_tasks_role.id
-  policy = data.aws_iam_policy_document.graphql_task_policy_document.json
+  role   = aws_iam_role.orca_ecs_task_execution_role.id
+  policy = data.aws_iam_policy_document.graphql_task_execution_policy_document.json
 }
 
 resource "aws_iam_role" "orca_ecs_task_execution_role" {

--- a/modules/graph_ql/main.tf
+++ b/modules/graph_ql/main.tf
@@ -1,8 +1,16 @@
-
 data "aws_iam_policy_document" "graphql_task_policy_document" {
   statement {
     actions   = ["sts:AssumeRole"]
     resources = [aws_iam_role.orca_ecs_tasks_role.arn]
+  }
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents"
+    ]
+    resources = ["*"]
   }
 }
 
@@ -46,13 +54,14 @@ resource "aws_ecs_task_definition" "graphql_task" {
   memory                   = "2048"
   task_role_arn            = aws_iam_role.orca_ecs_tasks_role.arn
   execution_role_arn       = aws_iam_role.orca_ecs_task_execution_role.arn
+  tags                     = var.tags
   container_definitions    = <<DEFINITION
 [
   {
     "name": "orca-graphql",
     "image": "ghcr.io/nasa/cumulus-orca/graphql:0.0.18",
-    "cpu": 1024,
-    "memory": 2048,
+    "cpu": 512,
+    "memory": 256,
     "networkMode": "awsvpc",
     "environment": [
     ],
@@ -68,4 +77,17 @@ resource "aws_ecs_task_definition" "graphql_task" {
   }
 ]
 DEFINITION
+}
+
+resource "aws_ecs_service" "graphql_service" {
+  name            = "${var.prefix}_graphql_service"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.graphql_task.arn
+  desired_count   = 3
+  launch_type     = "FARGATE"
+  propagate_tags  = "TASK_DEFINITION"
+  network_configuration {
+    subnets         = var.lambda_subnet_ids
+    security_groups = [var.vpc_postgres_ingress_all_egress_id]
+  }
 }

--- a/modules/graph_ql/variables.tf
+++ b/modules/graph_ql/variables.tf
@@ -15,6 +15,7 @@ variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
 }
+
 ## OPTIONAL
 variable "tags" {
   type        = map(string)

--- a/modules/graph_ql/variables.tf
+++ b/modules/graph_ql/variables.tf
@@ -1,11 +1,20 @@
 ## Variables obtained by Cumulus deployment
 ## Should exist in https://github.com/nasa/cumulus-template-deploy/blob/master/cumulus-tf/variables.tf
 ## REQUIRED
+variable "lambda_subnet_ids" {
+  type        = list(string)
+  description = "List of subnets the lambda functions have access to."
+}
+
+variable "permissions_boundary_arn" {
+  type        = string
+  description = "AWS ARN value for the permission boundary."
+}
+
 variable "prefix" {
   type        = string
   description = "Prefix used to prepend to all object names and tags."
 }
-
 ## OPTIONAL
 variable "tags" {
   type        = map(string)
@@ -14,7 +23,12 @@ variable "tags" {
 
 ## Variables unique to ORCA
 ## REQUIRED
-variable "permissions_boundary_arn" {
+variable "ecs_cluster_id" {
   type        = string
-  description = "AWS ARN value for the permission boundary."
+  description = "ID of the ECS cluster in AWS."
+}
+
+variable "vpc_postgres_ingress_all_egress_id" {
+  type        = string
+  description = "PostgreSQL security group id"
 }

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -202,20 +202,42 @@ module "orca_sqs" {
   status_update_queue_message_retention_time_seconds   = var.status_update_queue_message_retention_time_seconds
 }
 
-## orca_graph_ql - graphql module that sets up centralized db code
+## orca_ecs - ecs module that sets up ecs cluster
 ## =============================
-module "orca_graph_ql" {
-  source     = "../graph_ql"
-  depends_on = [module.orca_secretsmanager] ## secretsmanager sets up db connection secrets.
+module "orca_ecs" {
+  source     = "../ecs"
   ## --------------------------
   ## Cumulus Variables
   ## --------------------------
   ## REQUIRED
-  permissions_boundary_arn = var.permissions_boundary_arn
   prefix = var.prefix
 
   ## OPTIONAL
   tags = var.tags
+}
+
+## orca_graph_ql - graphql module that sets up centralized db code
+## =============================
+module "orca_graph_ql" {
+  source     = "../graph_ql"
+  depends_on = [module.orca_lambdas, module.orca_ecs, module.orca_secretsmanager] ## secretsmanager sets up db connection secrets.
+  ## --------------------------
+  ## Cumulus Variables
+  ## --------------------------
+  ## REQUIRED
+  lambda_subnet_ids        = var.lambda_subnet_ids
+  permissions_boundary_arn = var.permissions_boundary_arn
+  prefix                   = var.prefix
+
+  ## OPTIONAL
+  tags = var.tags
+
+  ## --------------------------
+  ## ORCA Variables
+  ## --------------------------
+  ## REQUIRED
+  ecs_cluster_id                     = module.orca_ecs.ecs_cluster_id
+  vpc_postgres_ingress_all_egress_id = module.orca_lambdas.vpc_postgres_ingress_all_egress_id
 }
 
 ## orca_api_gateway - api gateway module

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -74,7 +74,6 @@ module.exports = {
       'developer/research/research-graphql',
       'developer/research/research-multipart-chunksize',
       'developer/research/research-bamboo',
-      'developer/research/research-lambda-container',
       'developer/research/research-orca-delete-functionality',
       'developer/research/research-bamboo-integration-tests',
       'developer/research/research-lambda-container',


### PR DESCRIPTION
## Summary of Changes

GraphQL image is now deployed and run as an ECS service.

Addresses [ORCA-561: Add GraphQL image to new AWS task and service definition](https://bugs.earthdata.nasa.gov/browse/ORCA-561)

## Changes

* Added service to TF

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployed to AWS. Functionality largely untested; task for upcoming card.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets