### PR TITLE
feature/ORCA-564 fixed sql string injection

### DIFF
--- a/tasks/post_copy_request_to_queue/API.md
+++ b/tasks/post_copy_request_to_queue/API.md
@@ -121,14 +121,14 @@ metadata for posting to the recovery status SQS Queue.
 #### get\_metadata\_sql
 
 ```python
-def get_metadata_sql(key_path: str) -> text
+def get_metadata_sql() -> text
 ```
 
 Query for finding metadata based on key_path and PENDING status.
 
 **Arguments**:
 
-- `key_path` _str_ - s3 key for the file less the bucket name
+  None
 
 **Returns**:
 

--- a/tasks/post_copy_request_to_queue/API.md
+++ b/tasks/post_copy_request_to_queue/API.md
@@ -124,7 +124,7 @@ metadata for posting to the recovery status SQS Queue.
 def get_metadata_sql() -> text
 ```
 
-Query for finding metadata based on key_path and PENDING status.
+Query for finding metadata based on key_path and status_id.
 
 **Arguments**:
 

--- a/tasks/post_copy_request_to_queue/post_copy_request_to_queue.py
+++ b/tasks/post_copy_request_to_queue/post_copy_request_to_queue.py
@@ -202,7 +202,7 @@ def query_db(
         with engine.begin() as connection:
             # Query for all rows that contain that key and have a status of
             # PENDING
-            for row in connection.execute(get_metadata_sql(key_path)):
+            for row in connection.execute(get_metadata_sql(), {"key_path": key_path}):
                 # Create dictionary for with the info needed for the
                 # copy_from_archive lambda
                 row_dict = {
@@ -240,26 +240,26 @@ def query_db(
     return rows
 
 
-def get_metadata_sql(key_path: str) -> text:
+def get_metadata_sql() -> text:
     """
     Query for finding metadata based on key_path and PENDING status.
 
     Args:
-        key_path (str): s3 key for the file less the bucket name
+        None
     Returns:
         (sqlalchemy.text): SQL statement
     """
-    return text(  # nosec
-        f"""
+    return text(
+        """
             SELECT
                 job_id, granule_id, filename, restore_destination, multipart_chunksize_mb
             FROM
                 recovery_file
             WHERE
-                key_path = '{key_path}'
+                key_path = :key_path
             AND
-                status_id = {shared_recovery.OrcaStatus.PENDING.value}
-        """  # nosec
+                status_id = shared_recovery.OrcaStatus.PENDING.value
+        """
     )
 
 

--- a/tasks/post_copy_request_to_queue/post_copy_request_to_queue.py
+++ b/tasks/post_copy_request_to_queue/post_copy_request_to_queue.py
@@ -202,7 +202,13 @@ def query_db(
         with engine.begin() as connection:
             # Query for all rows that contain that key and have a status of
             # PENDING
-            for row in connection.execute(get_metadata_sql(), {"key_path": key_path}):
+            for row in connection.execute(
+                get_metadata_sql(),
+                {
+                    "key_path": key_path,
+                    "status_id": shared_recovery.OrcaStatus.PENDING.value
+                }
+            ):
                 # Create dictionary for with the info needed for the
                 # copy_from_archive lambda
                 row_dict = {
@@ -242,7 +248,7 @@ def query_db(
 
 def get_metadata_sql() -> text:
     """
-    Query for finding metadata based on key_path and PENDING status.
+    Query for finding metadata based on key_path and status_id.
 
     Args:
         None
@@ -258,7 +264,7 @@ def get_metadata_sql() -> text:
             WHERE
                 key_path = :key_path
             AND
-                status_id = shared_recovery.OrcaStatus.PENDING.value
+                status_id = :status_id
         """
     )
 

--- a/tasks/post_copy_request_to_queue/test/unit_tests/test_post_copy_request_to_queue.py
+++ b/tasks/post_copy_request_to_queue/test/unit_tests/test_post_copy_request_to_queue.py
@@ -649,8 +649,13 @@ class TestPostCopyRequestToQueue(TestCase):
             mock_get_configuration.return_value
         )
         mock_get_metadata_sql.assert_called_once_with()
-        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value,
-                                             {"key_path": key_path})
+        mock_execute.assert_called_once_with(
+            mock_get_metadata_sql.return_value,
+            {
+                "key_path": key_path,
+                "status_id": shared_recovery.OrcaStatus.PENDING.value
+            }
+        )
         self.assertEqual(
             [
                 {
@@ -723,8 +728,13 @@ class TestPostCopyRequestToQueue(TestCase):
             mock_get_configuration.return_value
         )
         mock_get_metadata_sql.assert_called_once_with()
-        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value,
-                                             {"key_path": key_path})
+        mock_execute.assert_called_once_with(
+            mock_get_metadata_sql.return_value,
+            {
+                "key_path": key_path,
+                "status_id": shared_recovery.OrcaStatus.PENDING.value
+            }
+        )
 
     @patch("post_copy_request_to_queue.shared_db.get_user_connection")
     @patch("post_copy_request_to_queue.shared_db.get_configuration")
@@ -768,8 +778,13 @@ class TestPostCopyRequestToQueue(TestCase):
             mock_get_configuration.return_value
         )
         mock_get_metadata_sql.assert_called_once()
-        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value,
-                                             {'key_path': key_path})
+        mock_execute.assert_called_once_with(
+            mock_get_metadata_sql.return_value,
+            {
+                "key_path": key_path,
+                "status_id": shared_recovery.OrcaStatus.PENDING.value
+            }
+        )
 
     def test_get_metadata_sql_happy_path(self):
         result = post_copy_request_to_queue.get_metadata_sql()
@@ -782,7 +797,7 @@ class TestPostCopyRequestToQueue(TestCase):
             WHERE
                 key_path = :key_path
             AND
-                status_id = shared_recovery.OrcaStatus.PENDING.value
+                status_id = :status_id
         """,
             result.text,
         )

--- a/tasks/post_copy_request_to_queue/test/unit_tests/test_post_copy_request_to_queue.py
+++ b/tasks/post_copy_request_to_queue/test/unit_tests/test_post_copy_request_to_queue.py
@@ -648,8 +648,9 @@ class TestPostCopyRequestToQueue(TestCase):
         mock_get_user_connection.assert_called_once_with(
             mock_get_configuration.return_value
         )
-        mock_get_metadata_sql.assert_called_once_with(key_path)
-        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value)
+        mock_get_metadata_sql.assert_called_once_with()
+        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value,
+                                             {"key_path": key_path})
         self.assertEqual(
             [
                 {
@@ -721,8 +722,9 @@ class TestPostCopyRequestToQueue(TestCase):
         mock_get_user_connection.assert_called_once_with(
             mock_get_configuration.return_value
         )
-        mock_get_metadata_sql.assert_called_once_with(key_path)
-        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value)
+        mock_get_metadata_sql.assert_called_once_with()
+        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value,
+                                             {"key_path": key_path})
 
     @patch("post_copy_request_to_queue.shared_db.get_user_connection")
     @patch("post_copy_request_to_queue.shared_db.get_configuration")
@@ -765,22 +767,22 @@ class TestPostCopyRequestToQueue(TestCase):
         mock_get_user_connection.assert_called_once_with(
             mock_get_configuration.return_value
         )
-        mock_get_metadata_sql.assert_called_once_with(key_path)
-        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value)
+        mock_get_metadata_sql.assert_called_once()
+        mock_execute.assert_called_once_with(mock_get_metadata_sql.return_value,
+                                             {'key_path': key_path})
 
     def test_get_metadata_sql_happy_path(self):
-        key_path = uuid.uuid4().__str__()
-        result = post_copy_request_to_queue.get_metadata_sql(key_path)
-        self.assertEqual(  # nosec
-            f"""
+        result = post_copy_request_to_queue.get_metadata_sql()
+        self.assertEqual(
+            """
             SELECT
                 job_id, granule_id, filename, restore_destination, multipart_chunksize_mb
             FROM
                 recovery_file
             WHERE
-                key_path = '{key_path}'
+                key_path = :key_path
             AND
-                status_id = {shared_recovery.OrcaStatus.PENDING.value}
-        """,  # nosec
+                status_id = shared_recovery.OrcaStatus.PENDING.value
+        """,
             result.text,
         )


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-564: Fix SQL string injection in post_copy_request_to_queue](https://bugs.earthdata.nasa.gov/browse/ORCA-564)

## Changes

* updated post_copy_request_to_queue and unit tests to fix sql injection

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

ran unit tests and deployed in aws

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the necessary documentation (remove those that do not apply)

    - [ x] User documentation
- [ x] My changes generate no new warnings
- [x ] My code has passed security scanning
    - [x ] Snyk
    - [ x] git-secrets
