### PR TITLE
added optional input property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,38 @@ and includes an additional section for migration notes.
 - *ORCA-336*
   - Added a new standard SQS between archive ORCA bucket and `post_copy_request_to_queue` lambda so that the bucket now triggers the SQS upon successful object retrieval from glacier.
 - *ORCA-554*, *ORCA-561*, *ORCA-579* GraphQL image, service, and Load Balancer will now be deployed by TF.
+- *ORCA-351*
+  - Added new optional `recoverybucketoverride` property to `extract_filepaths_for_granule` input schema so that data managers can now specify their own buckets for recovery if desired.
 
 ### Migration Notes
 - If utilizing the `copied_to_glacier` [output property](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/tasks/copy_to_glacier/schemas/output.json#L47) of `copy_to_glacier`, 
   rename to new key `copied_to_orca`.
 - If utilizing the `orca_lambda_copy_to_glacier_arn` [output of Terraform](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/outputs.tf#L8), likely as a means of pulling the lambda into your workflows, 
   rename to new key `orca_lambda_copy_to_archive_arn`
+- Use the optional `recoverybucketoverride` property in `extract_filepaths_for_granule` input schema to specify a recovery bucket. See example below.
+
+```json
+
+{
+  "input":
+    {
+      "granules": [
+        {
+          "granuleId": "MOD09GQ.A0219114.N5aUCG.006.0656338553321",
+          "recoverybucketoverride": "<YOUR_RECOVERY_BUCKET>",
+          "files": [
+            {
+              "key": "MOD09GQ___006/2017/MOD/MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5",
+              "bucket": "cumulus-test-sandbox-protected",
+              "fileName": "MOD09GQ.A0219114.N5aUCG.006.0656338553321.h5",
+            }
+          ]
+        }
+      ]
+  }
+}
+
+```
 
 ## [6.0.2]
 ### Changed

--- a/tasks/extract_filepaths_for_granule/API.md
+++ b/tasks/extract_filepaths_for_granule/API.md
@@ -123,6 +123,7 @@ Lambda handler. Extracts the key's for a granule from an input dict.
   "granules":[
   {
   "granuleId":"granxyz",
+- `"recoverybucketoverride"` - "test-recovery-bucket"
   "version":"006",
   "files":[
   {

--- a/tasks/extract_filepaths_for_granule/schemas/input.json
+++ b/tasks/extract_filepaths_for_granule/schemas/input.json
@@ -10,6 +10,10 @@
           {
             "type": "object",
             "properties": {
+              "recoverybucketoverride": {
+                "description": "The rocovery bucket to store recovered files",
+                "type": ["string", "null"]
+              },
               "granuleId": {
                 "description": "The ID of the granule.",
                 "type": "string"

--- a/tasks/extract_filepaths_for_granule/schemas/input.json
+++ b/tasks/extract_filepaths_for_granule/schemas/input.json
@@ -11,7 +11,7 @@
             "type": "object",
             "properties": {
               "recoverybucketoverride": {
-                "description": "The rocovery bucket to store recovered files",
+                "description": "The user specified recovery S3 bucket to store recovered files",
                 "type": ["string", "null"]
               },
               "granuleId": {

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
@@ -5,6 +5,7 @@ Description:  Unit tests for extract_file_paths_for_granule.py.
 """
 import json
 import unittest
+import uuid
 from test.helpers import create_handler_event, create_task_event
 from unittest.mock import MagicMock, Mock, patch
 
@@ -571,6 +572,19 @@ class TestExtractFilePaths(unittest.TestCase):
 
         # Validate the output is correct by matching with the output schema
         _OUTPUT_VALIDATE(exp_result)
+
+    @patch("extract_filepaths_for_granule.LOGGER.debug")
+    def test_task_use_recovery_override_bucket(self, mock_debug: MagicMock):
+        """
+        Test no 'granules' key in input event.
+        """
+        self.task_input_event[
+            "input"]["granules"][0]["recoverybucketoverride"] = uuid.uuid4().__str__()
+
+        result = extract_filepaths_for_granule.task(self.task_input_event)
+        self.assertEqual(
+            result["granules"][0]["keys"][0]["destBucket"],
+            self.task_input_event["input"]["granules"][0]["recoverybucketoverride"])
 
     def test_exclude_file_types(self):
         """


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-351: As a data manager, I would like to specify what bucket to recover files to for a recovery job in order to not overwrite the Cumulus primary copy of the file](https://bugs.earthdata.nasa.gov/browse/ORCA-351)

## Changes

* updated extract_filepath lambda and input schema

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)
- [ x] This change requires a documentation update

## How Has This Been Tested?

deployed in aws and ran recovery workflow

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x ] CHANGELOG.md
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
    - [ x] Unit tests
    - [ x] Integration tests
- [ x] My code has passed security scanning
    - [ x] Snyk
    - [ x] git-secrets


