### PR TITLE
Feature/orca 580 Log descriptive error when request_from_archive receives no keys for a given granule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and includes an additional section for migration notes.
 - *ORCA-554*, *ORCA-561*, *ORCA-579* GraphQL image, service, and Load Balancer will now be deployed by TF.
 - *ORCA-351*
   - Added new optional `recoveryBucketOverride` property to `extract_filepaths_for_granule` input schema so that data managers can now specify their own buckets for recovery if desired.
-- *ORCA-574/580* Added additional logging to the `extract_filepaths_for_granule` and `request_from_archive` steps of the recovery workflow to identify when an input granule is entirely excluded, or otherwise has no files to request.
+- *ORCA-574/580* Added additional logging to the `extract_filepaths_for_granule` and `request_from_archive` steps of the recovery workflow to identify when an input granule is entirely excluded, or otherwise has no files to request. Status entries for these granules will display an `ERROR` status.
 
 ### Migration Notes
 - If utilizing the `copied_to_glacier` [output property](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/tasks/copy_to_glacier/schemas/output.json#L47) of `copy_to_glacier`, 

--- a/tasks/post_to_database/post_to_database.py
+++ b/tasks/post_to_database/post_to_database.py
@@ -150,6 +150,7 @@ def create_status_for_job_and_files(
         )
 
     if len(file_parameters) == 0:
+        LOGGER.info(f"No files given for job '{job_id}' granule '{granule_id}'. Creating error status entry.")
         # No files given. Assume that this is in error.
         job_status = OrcaStatus.FAILED
         job_completion_time = datetime.datetime.now(datetime.timezone.utc).isoformat().__str__()

--- a/tasks/post_to_database/post_to_database.py
+++ b/tasks/post_to_database/post_to_database.py
@@ -150,7 +150,8 @@ def create_status_for_job_and_files(
         )
 
     if len(file_parameters) == 0:
-        LOGGER.info(f"No files given for job '{job_id}' granule '{granule_id}'. Creating error status entry.")
+        LOGGER.info(f"No files given for job '{job_id}' granule '{granule_id}'. "
+                    "Creating error status entry.")
         # No files given. Assume that this is in error.
         job_status = OrcaStatus.FAILED
         job_completion_time = datetime.datetime.now(datetime.timezone.utc).isoformat().__str__()

--- a/tasks/post_to_database/post_to_database.py
+++ b/tasks/post_to_database/post_to_database.py
@@ -149,7 +149,11 @@ def create_status_for_job_and_files(
             }
         )
 
-    if found_pending:
+    if len(file_parameters) == 0:
+        # No files given. Assume that this is in error.
+        job_status = OrcaStatus.FAILED
+        job_completion_time = datetime.datetime.now(datetime.timezone.utc).isoformat().__str__()
+    elif found_pending:
         # Most jobs will be this. Some files are still pending.
         job_status = OrcaStatus.PENDING
         job_completion_time = None
@@ -174,7 +178,8 @@ def create_status_for_job_and_files(
                     }
                 ],
             )
-            connection.execute(create_file_sql(), file_parameters)
+            if len(file_parameters) > 0:
+                connection.execute(create_file_sql(), file_parameters)
     except Exception as sql_ex:
         # Can't use f"" because of '{}' bug in CumulusLogger.
         LOGGER.error(

--- a/tasks/post_to_database/test/unit_tests/test_post_to_database.py
+++ b/tasks/post_to_database/test/unit_tests/test_post_to_database.py
@@ -391,7 +391,7 @@ class TestPostToDatabase(
         mock_datetime: MagicMock,
     ):
         """
-        If all files failed, job should be marked as such.
+        If no files present for granule, job+granule should be marked as error.
         """
         job_id = uuid.uuid4().__str__()
         granule_id = uuid.uuid4().__str__()


### PR DESCRIPTION
## Summary of Changes

Added error status when attempting to restore 0 files for a granule.

Addresses [ORCA-580: Log descriptive error when request_from_archive receives no keys for a given granule.](https://bugs.earthdata.nasa.gov/browse/ORCA-580)

## Changes

* post_to_database now creates an error entry for a granule with 0 files.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployed and run in AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets