### PR TITLE
Feature/orca 533 extract_filepaths cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and includes an additional section for migration notes.
 - *ORCA-461*
   - Invalid database connection parameters will now be detected earlier and more consistently.
   - Postgres table/user names can now begin with an '_' and contain '$' if your Postgres DB version supports this.
+- *ORCA-533* RecoveryWorkflow no longer requires the `bucket` property on files. Was unused by ORCA.
 
 ### Added
 - *ORCA-336*

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -127,6 +127,7 @@ def task(task_input: Dict[str, Any], config: Dict[str, Any]):
     return {OUTPUT_GRANULES_KEY: result_granules}
 
 
+# todo: create dedicated unit tests
 def get_regex_buckets(config: Dict[str, Any]) -> Dict[str, str]:
     """
     Gets a dict of regular expressions and the corresponding archive bucket for files

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -6,7 +6,7 @@ Description:  Extracts the keys (filepaths) for a granule's files from a Cumulus
 
 import json
 import re
-from typing import Dict, List, Union
+from typing import Dict, List, Any
 
 import fastjsonschema as fastjsonschema
 from aws_lambda_powertools import Logger
@@ -22,7 +22,12 @@ CONFIG_BUCKETS_KEY = "buckets"
 
 INPUT_GRANULES_KEY = "granules"
 INPUT_GRANULE_RECOVERY_BUCKET_OVERRIDE_KEY = "recoveryBucketOverride"
+INPUT_GRANULE_ID_KEY = "granuleId"
+INPUT_GRANULE_FILES_KEY = "files"
+INPUT_GRANULE_FILE_FILENAME_KEY = "fileName"
+INPUT_GRANULE_FILE_KEY_KEY = "key"
 
+OUTPUT_GRANULES_KEY = "granules"
 OUTPUT_DESTINATION_BUCKET_KEY = "destBucket"
 OUTPUT_KEY_KEY = "key"
 
@@ -46,14 +51,15 @@ class ExtractFilePathsError(Exception):
     """Exception to be raised if any errors occur"""
 
 
-def task(event):
+def task(task_input: Dict[str, Any], config: Dict[str, Any]):
     """
     Task called by the handler to perform the work.
 
     This task will parse the input, removing the granuleId and file keys for a granule.
 
         Args:
-            event (dict): passed through from the handler
+            task_input: See schemas/input.json
+            config: See schemas/config.json
 
         Returns:
             dict: dict containing granuleId and keys. See handler for detail.
@@ -61,9 +67,7 @@ def task(event):
         Raises:
             ExtractFilePathsError: An error occurred parsing the input.
     """
-    LOGGER.debug(f"event: {event}")
     try:
-        config = event["config"]
         exclude_file_types = config.get(CONFIG_EXCLUDED_FILE_EXTENSIONS_KEY, None)
         if exclude_file_types is None:
             exclude_file_types = []
@@ -80,60 +84,56 @@ def task(event):
         message = f"Key {ke} is missing from the event configuration: {config}"
         LOGGER.error(message)
         raise KeyError(message)
-    result = {}
-    try:
-        regex_buckets = get_regex_buckets(event)
-        grans = []
-        for ev_granule in event["input"][INPUT_GRANULES_KEY]:
-            recovery_bucket_override = ev_granule.get(INPUT_GRANULE_RECOVERY_BUCKET_OVERRIDE_KEY, None)
-            gran = ev_granule.copy()
-            files = []
-            gran["granuleId"] = ev_granule["granuleId"]
-            for afile in ev_granule["files"]:
-                file_name = afile["fileName"]
-                LOGGER.debug(f"Validating file {file_name}")
-                # filtering excludedFileExtensions
-                if not should_exclude_files_type(file_name, exclude_file_types):
-                    LOGGER.debug(f"File {file_name} will be restored")
-                    file_key = afile["key"]
-                    LOGGER.debug(f"Retrieving information for {file_key}")
+    regex_buckets = get_regex_buckets(config)
+    result_granules = []
+    for a_granule in task_input[INPUT_GRANULES_KEY]:
+        recovery_bucket_override = \
+            a_granule.get(INPUT_GRANULE_RECOVERY_BUCKET_OVERRIDE_KEY, None)
+        files = []
+        for a_file in a_granule[INPUT_GRANULE_FILES_KEY]:
+            file_name = a_file[INPUT_GRANULE_FILE_FILENAME_KEY]
+            LOGGER.debug(f"Validating file {file_name}")
+            # filtering excludedFileExtensions
+            if not should_exclude_files_type(file_name, exclude_file_types):
+                LOGGER.debug(f"File {file_name} will be restored")
+                file_key = a_file[INPUT_GRANULE_FILE_KEY_KEY]
+                LOGGER.debug(f"Retrieving information for {file_key}")
 
-                    if recovery_bucket_override is not None:
-                        destination_bucket = recovery_bucket_override
-                    else:
-                        matching_regex = next(
-                            filter(lambda key: re.compile(key).match(file_name), regex_buckets),
-                            None
-                        )
-                        if matching_regex is None:
-                            raise ExtractFilePathsError(f"No matching regex for '{file_key}'")
-                        destination_bucket = regex_buckets[matching_regex]
-
-                    LOGGER.debug(
-                        f"Found retrieval destination {destination_bucket} for {file_name}"
+                if recovery_bucket_override is not None:
+                    destination_bucket = recovery_bucket_override
+                else:
+                    matching_regex = next(
+                        filter(lambda key: re.compile(key).match(file_name), regex_buckets),
+                        None
                     )
+                    if matching_regex is None:
+                        raise ExtractFilePathsError(f"No matching regex for '{file_key}'")
+                    destination_bucket = regex_buckets[matching_regex]
 
-                    files.append(
-                        {
-                            OUTPUT_KEY_KEY: file_key,
-                            OUTPUT_DESTINATION_BUCKET_KEY: destination_bucket,
-                        }
-                    )
-            gran["keys"] = files
-            grans.append(gran)
-        result["granules"] = grans
-    except KeyError as err:
-        raise ExtractFilePathsError(f'KeyError: "{level}[{str(err)}]" is required')
-    return result
+                LOGGER.debug(
+                    f"Found retrieval destination {destination_bucket} for {file_name}"
+                )
+
+                files.append(
+                    {
+                        OUTPUT_KEY_KEY: file_key,
+                        OUTPUT_DESTINATION_BUCKET_KEY: destination_bucket,
+                    }
+                )
+        result_granules.append({
+            "granuleId": a_granule[INPUT_GRANULE_ID_KEY],
+            "keys": files,
+        })
+    return {OUTPUT_GRANULES_KEY: result_granules}
 
 
-def get_regex_buckets(event) -> Dict[str, str]:
+def get_regex_buckets(config: Dict[str, Any]) -> Dict[str, str]:
     """
     Gets a dict of regular expressions and the corresponding archive bucket for files
     matching the regex.
 
         Args:
-            event (dict): passed through from the handler
+            config: See schemas/config.json
 
         Returns:
             dict: dict containing regex and bucket.
@@ -141,13 +141,13 @@ def get_regex_buckets(event) -> Dict[str, str]:
         Raises:
             ExtractFilePathsError: An error occurred parsing the input.
     """
-    file_buckets = event["config"][CONFIG_FILE_BUCKETS_KEY]
+    file_buckets = config[CONFIG_FILE_BUCKETS_KEY]
     # file_buckets example:
     # [{'regex': '.*.h5$', 'sampleFileName': 'L0A_0420.h5', 'bucket': 'protected'},
     # {'regex': '.*.iso.xml$', 'sampleFileName': 'L0A_0420.iso.xml', 'bucket': 'protected'},
     # {'regex': '.*.h5.mp$', 'sampleFileName': 'L0A_0420.h5.mp', 'bucket': 'public'},
     # {'regex': '.*.cmr.json$', 'sampleFileName': 'L0A_0420.cmr.json', 'bucket': 'public'}]
-    buckets = event["config"][CONFIG_BUCKETS_KEY]
+    buckets = config[CONFIG_BUCKETS_KEY]
     # buckets example:
     # {"protected": {"name": "sndbx-cumulus-protected", "type": "protected"},
     # "internal": {"name": "sndbx-cumulus-internal", "type": "internal"},
@@ -185,13 +185,12 @@ def should_exclude_files_type(file_key: str, exclude_file_types: List[str]) -> b
 
 
 @LOGGER.inject_lambda_context
-def handler(event: Dict[str, Union[str, int]],
+def handler(event: Dict[str, Dict[str, Any]],
             context: LambdaContext):  # pylint: disable-msg=unused-argument
     """Lambda handler. Extracts the key's for a granule from an input dict.
 
     Args:
-        event (dict): A dict with the following keys:
-
+        event: A dict with the following keys:
             granules (list(dict)): A list of dict with the following keys:
                 granuleId (string): The id of a granule.
                 files (list(dict)): list of dict with the following keys:
@@ -219,7 +218,6 @@ def handler(event: Dict[str, Union[str, int]],
                             ]
                         }
                     }
-
         context: This object provides information about the lambda invocation, function,
             and execution env.
 
@@ -238,19 +236,22 @@ def handler(event: Dict[str, Union[str, int]],
     Raises:
         ExtractFilePathsError: An error occurred parsing the input.
     """
+    LOGGER.debug(f"event: {event}")
+    task_input = event["input"]
     try:
-        _VALIDATE_INPUT(event["input"])
+        _VALIDATE_INPUT(task_input)
     except JsonSchemaException as json_schema_exception:
         LOGGER.error(json_schema_exception)
         raise
 
+    config = event["config"]
     try:
-        _VALIDATE_CONFIG(event["config"])
+        _VALIDATE_CONFIG(config)
     except JsonSchemaException as json_schema_exception:
         LOGGER.error(json_schema_exception)
         raise
 
-    result = task(event)
+    result = task(task_input, config)
 
     try:
         _VALIDATE_OUTPUT(result)

--- a/tasks/extract_filepaths_for_granule/requirements.txt
+++ b/tasks/extract_filepaths_for_granule/requirements.txt
@@ -1,2 +1,3 @@
 aws_lambda_powertools==1.31.0
 cumulus-process==0.8.0
+fastjsonschema~=2.15.1

--- a/tasks/extract_filepaths_for_granule/schemas/input.json
+++ b/tasks/extract_filepaths_for_granule/schemas/input.json
@@ -18,10 +18,6 @@
                 "description": "The ID of the granule.",
                 "type": "string"
               },
-              "version": {
-                "description": "The version of the granule.",
-                "type": "string"
-              },
               "files": {
                 "description": "Description of the files within the given granule.",
                 "type": "array",
@@ -36,24 +32,11 @@
                       "key": {
                         "description": "S3 Key for archived file (full path and file name less the bucket name).",
                         "type": "string"
-                      },
-                      "bucket": {
-                        "description": "Name of the bucket where file is archived in S3.",
-                        "type": "string"
-                      },
-                      "source": {
-                        "description": "Source URI of the file from origin system (e.g. S3, FTP, HTTP).",
-                        "type": "string"
-                      },
-                      "type": {
-                        "description": "Type of file (e.g. data, metadata, browse).",
-                        "type": "string"
                       }
                     },
                     "required": [
                       "fileName",
-                      "key",
-                      "bucket"
+                      "key"
                     ]
                   }
                 ]

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
@@ -6,16 +6,13 @@ Description:  Unit tests for extract_file_paths_for_granule.py.
 import json
 import unittest
 import uuid
-
-from fastjsonschema import JsonSchemaValueException
-
-from test.helpers import create_handler_event, create_task_event
 from unittest.mock import MagicMock, Mock, patch
 
 # noinspection PyPackageRequirements
 import fastjsonschema as fastjsonschema
 
 import extract_filepaths_for_granule
+from test.helpers import create_handler_event, create_task_event
 
 # Generating schema validators can take time, so do it once and reuse.
 with open("schemas/input.json", "r") as raw_schema:

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
@@ -579,7 +579,7 @@ class TestExtractFilePaths(unittest.TestCase):
         Test no 'granules' key in input event.
         """
         self.task_input_event["input"]["granules"][0][
-            extract_filepaths_for_granule.INPUT_RECOVERY_BUCKET_OVERRIDE_KEY
+            extract_filepaths_for_granule.INPUT_GRANULE_RECOVERY_BUCKET_OVERRIDE_KEY
                 ] = uuid.uuid4().__str__()
 
         result = extract_filepaths_for_granule.task(self.task_input_event)
@@ -587,7 +587,7 @@ class TestExtractFilePaths(unittest.TestCase):
             result["granules"][0]["keys"][0][
                 extract_filepaths_for_granule.OUTPUT_DESTINATION_BUCKET_KEY
                 ], self.task_input_event["input"]["granules"][0][
-                    extract_filepaths_for_granule.INPUT_RECOVERY_BUCKET_OVERRIDE_KEY])
+                    extract_filepaths_for_granule.INPUT_GRANULE_RECOVERY_BUCKET_OVERRIDE_KEY])
 
     def test_exclude_file_types(self):
         """

--- a/tasks/request_from_archive/requirements.txt
+++ b/tasks/request_from_archive/requirements.txt
@@ -1,3 +1,4 @@
 aws_lambda_powertools==1.31.0
 boto3~=1.18.40
 ../../shared_libraries[recovery]
+fastjsonschema~=2.15.1


### PR DESCRIPTION
## Summary of Changes

General cleanup of extract_filepaths.

Addresses [ORCA-533: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/ORCA-533)

## Changes

* Removed unused logic around key errors.
* Removed unused properties from input schema.

## Type of change

Tested locally. Not yet tested in AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets