### PR TITLE
Feature/orca 600 Disable GraphQL for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and includes an additional section for migration notes.
 - *Security* - Vulnerabilities fixes and changes.
 
 ## [Unreleased]
+### Added
+- *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581* GraphQL image, service, and Load Balancer will now be deployed by TF.
+
+## [7.0.0]
 ### Changed
 - *ORCA-336*
   - `request_from_archive` lambda now posts to the new SQS for files that have already been recovered from glacier instead of throwing an error.
@@ -47,7 +51,6 @@ and includes an additional section for migration notes.
 ### Added
 - *ORCA-336*
   - Added a new standard SQS between archive ORCA bucket and `post_copy_request_to_queue` lambda so that the bucket now triggers the SQS upon successful object retrieval from glacier.
-- *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581* GraphQL image, service, and Load Balancer will now be deployed by TF.
 - *ORCA-351*
   - Added new optional `recoveryBucketOverride` property to `extract_filepaths_for_granule` input schema so that data managers can now specify their own buckets for recovery if desired.
 - *ORCA-574/580* Added additional logging to the `extract_filepaths_for_granule` and `request_from_archive` steps of the recovery workflow to identify when an input granule is entirely excluded, or otherwise has no files to request. Status entries for these granules will display an `ERROR` status.

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -1,3 +1,8 @@
+locals {
+  # Used for Load Balancer, EC2 Service, and Container ports. Specifies how GQL will be hosted.
+  deploy_graphql = false
+}
+
 ## Referenced Modules
 
 ## orca_lambdas - lambdas module that calls iam and security_groups module
@@ -227,6 +232,7 @@ module "orca_sqs" {
 ## orca_ecs - ecs module that sets up ecs cluster
 ## =============================
 module "orca_ecs" {
+  count  = local.deploy_graphql ? 1 : 0
   source = "../ecs"
   ## --------------------------
   ## Cumulus Variables
@@ -241,6 +247,7 @@ module "orca_ecs" {
 ## orca_graphql_1 - graphql module that sets up centralized db code
 ## =============================
 module "orca_graphql_1" {
+  count      = local.deploy_graphql ? 1 : 0
   source     = "../graphql_1"
   depends_on = [module.orca_lambdas, module.orca_ecs, module.orca_graphql_0, module.orca_secretsmanager] ## secretsmanager sets up db connection secrets.
   ## --------------------------
@@ -260,7 +267,7 @@ module "orca_graphql_1" {
   ## --------------------------
   ## REQUIRED
   db_connect_info_secret_arn      = module.orca_secretsmanager.secretsmanager_arn
-  ecs_cluster_id                  = module.orca_ecs.ecs_cluster_id
+  ecs_cluster_id                  = local.deploy_graphql ? module.orca_ecs.ecs_cluster_id : null
   gql_ecs_task_execution_role_arn = module.orca_graphql_0.gql_ecs_task_execution_role_arn
   gql_ecs_task_execution_role_id  = module.orca_graphql_0.gql_ecs_task_execution_role_id
   gql_tasks_role_arn              = module.orca_graphql_0.gql_tasks_role_arn


### PR DESCRIPTION
## Summary of Changes

Disable GraphQL for release

Addresses [ORCA-600: Disable GraphQL for release](https://bugs.earthdata.nasa.gov/browse/ORCA-600)

## Changes

* Added variable in orca/main.tf to disable most GraphQL components.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Deployed to AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets