### PR TITLE
Feature/orca 516

### DIFF
--- a/integration_test/cleanup/cleanup-orca.sh
+++ b/integration_test/cleanup/cleanup-orca.sh
@@ -25,3 +25,5 @@ echo "Destroying Cumulus S3 buckets and dynamoDB table"
 terraform destroy \
   -auto-approve \
   -input=false
+
+aws rds delete-db-cluster-snapshot --db-cluster-snapshot-identifier ${bamboo_PREFIX}-cumulus-rds-serverless-default-cluster-final-snapshot

--- a/website/docs/developer/development-guide/code/versioning-releases.md
+++ b/website/docs/developer/development-guide/code/versioning-releases.md
@@ -238,5 +238,4 @@ Note that the jobs may need to be run multiple times to get past deployment erro
 
 `Clean up ORCA buckets and modules` and `Clean up DR ORCA buckets` can be run in sequence to remove most of the resources created by the deployment stages.
 State buckets and lock tables will be left intact to aid in any cleanup issues/debugging.
-Additionally, Cumulus's RDS module will automatically create a final-snapshot `PREFIX-cumulus-rds-serverless-default-cluster-final-snapshot` that must be manually deleted.
 To verify cleanup, check the stage logs for errors, and [check the AWS environment for additional resources](https://docs.aws.amazon.com/ARG/latest/userguide/find-resources-to-tag.html) with the tag `Deployment=PREFIX`.


### PR DESCRIPTION
## Summary of Changes

Added line in script to clean up db snapshot after integration testing.

Addresses [ORCA-516: Automatically clean up RDS cluster snapshot in integration testing](https://bugs.earthdata.nasa.gov/browse/ORCA-516)

## Changes

* Added line to ORCA cleanup integration script
* Documentation updated.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployment and cleanup run in Bamboo.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] Testing documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Integration tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets