### PR TITLE
Feature/orca 597 Add server access logging to graphql load balancer and update bucket policy doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and includes an additional section for migration notes.
   - GraphQL image, service, and Load Balancer will now be deployed by TF.
   - *ORCA-420* Added Internal Reconcile Report Mismatch functionality to GraphQL.
   - *ORCA-592* GraphQL logs are json structures, and can thus be queried in CloudWatch.
+- *ORCA-597*
+  - Server access logging is now enabled for graphql application load balancer.
 
 ## [7.0.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and includes an additional section for migration notes.
 - *ORCA-597*
   - Server access logging is now enabled for graphql application load balancer.
 
+### Migration Notes
+- Update the bucket policy for your `system-bucket` to allow load balancer to post server access logs to the bucket. See the instructions [here](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-s3-bucket#bucket-policy-for-load-balancer-server-access-loging).
+
 ## [7.0.0]
 ### Changed
 - *ORCA-336*

--- a/modules/graphql_1/main.tf
+++ b/modules/graphql_1/main.tf
@@ -76,8 +76,8 @@ resource "aws_lb" "gql_app_lb" {
   internal           = true
   load_balancer_type = "application"
   access_logs {
-    bucket  = "${var.prefix}-internal"
-    prefix  = "${var.prefix}-lb-logs"
+    bucket  = var.system_bucket
+    prefix  = "${var.prefix}-lb-gql-a-logs"
     enabled = true
     }
   security_groups    = [aws_security_group.gql_security_group.id]

--- a/modules/graphql_1/main.tf
+++ b/modules/graphql_1/main.tf
@@ -79,7 +79,7 @@ resource "aws_lb" "gql_app_lb" {
     bucket  = var.system_bucket
     prefix  = "${var.prefix}-lb-gql-a-logs"
     enabled = true
-    }
+  }
   security_groups    = [aws_security_group.gql_security_group.id]
   subnets            = var.lambda_subnet_ids
   idle_timeout       = 30 # API Gateway locks us to 30 seconds.

--- a/modules/graphql_1/main.tf
+++ b/modules/graphql_1/main.tf
@@ -75,6 +75,11 @@ resource "aws_lb" "gql_app_lb" {
   name               = "${var.prefix}-gql-a" # Max 32 characters. Some prefixes are 25 characters long.
   internal           = true
   load_balancer_type = "application"
+  access_logs {
+    bucket  = "${var.prefix}-internal"
+    prefix  = "${var.prefix}-lb-logs"
+    enabled = true
+    }
   security_groups    = [aws_security_group.gql_security_group.id]
   subnets            = var.lambda_subnet_ids
   idle_timeout       = 30 # API Gateway locks us to 30 seconds.

--- a/modules/graphql_1/variables.tf
+++ b/modules/graphql_1/variables.tf
@@ -16,6 +16,11 @@ variable "prefix" {
   description = "Prefix used to prepend to all object names and tags."
 }
 
+variable "system_bucket" {
+  type        = string
+  description = "Cumulus system bucket used to store internal files."
+}
+
 variable "vpc_id" {
   type        = string
   description = "Virtual Private Cloud AWS ID"

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -257,6 +257,7 @@ module "orca_graphql_1" {
   lambda_subnet_ids        = var.lambda_subnet_ids
   permissions_boundary_arn = var.permissions_boundary_arn
   prefix                   = var.prefix
+  system_bucket            = var.system_bucket
   vpc_id                   = var.vpc_id
 
   ## OPTIONAL

--- a/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
@@ -275,3 +275,31 @@ Replace the number `000000000000` with your DR account number.
 The Resource value is the bucket and bucket paths that the Cumulus application
 can access. Replace `PREFIX-orca-reports` with the name
 of the Orca reports bucket created in the previous section.
+
+##### Bucket policy for load balancer server access loging:
+
+You must add the following S3 bucket policy to your `<PREFIX>-internal` or some other bucket to give the load balancer access to write logs to the S3 bucket. Otherwise, the deployment will throw an `Acess Denied` error. If successful, a test log message will be posted to the bucket under the provided prefix.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::<LOAD_BALANCER_ACCOUNT_ID>:root"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::<BUCKET_NAME>/<PREFIX>/AWSLogs/<AWS_ACCOUNT_ID>/*"
+        }
+    ]
+}
+
+```
+Replace `<LOAD_BALANCER_ACCOUNT_ID>` with the ID of the AWS account for Elastic Load Balancing for your Region which can be found [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html).
+
+Replace `<BUCKET_NAME>` with the S3 bucket where the access logs will be stored.
+
+Replace `<PREFIX>` with the prefix under the bucket where access logs will be stored.
+
+Replace `<AWS_ACCOUNT_ID>` with your Cumulus OU account number.  

--- a/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
@@ -278,7 +278,7 @@ of the Orca reports bucket created in the previous section.
 
 ##### Bucket policy for load balancer server access loging:
 
-You must add the following S3 bucket policy to your `<PREFIX>-internal` or some other bucket to give the load balancer access to write logs to the S3 bucket. Otherwise, the deployment will throw an `Acess Denied` error. If successful, a test log message will be posted to the bucket under the provided prefix.
+You must add the following S3 bucket policy to your `system_bucket`, which will likely be named `<PREFIX>-internal`, to give the load balancer access to write logs to the S3 bucket. Otherwise, the deployment will throw an `Acess Denied` error. If successful, a test log message will be posted to the bucket under the provided prefix.
 
 ```json
 {
@@ -298,8 +298,12 @@ You must add the following S3 bucket policy to your `<PREFIX>-internal` or some 
 ```
 Replace `<LOAD_BALANCER_ACCOUNT_ID>` with the ID of the AWS account for Elastic Load Balancing for your Region which can be found [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html).
 
-Replace `<BUCKET_NAME>` with the S3 bucket where the access logs will be stored.
+:::note
+Note that `<LOAD_BALANCER_ACCOUNT_ID>` is different from your AWS account ID.
+:::
 
-Replace `<PREFIX>` with the prefix under the bucket where access logs will be stored.
+Replace `<BUCKET_NAME>` with your `system-bucket` name.
 
-Replace `<AWS_ACCOUNT_ID>` with your Cumulus OU account number.  
+Replace `<PREFIX>` with your prefix.
+
+Replace `<AWS_ACCOUNT_ID>` with your Cumulus OU account number.


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-597: Add server access logging to graphql load balancer and update bucket policy doc](https://bugs.earthdata.nasa.gov/browse/ORCA-597)

## Changes

* updated lb terraform and bucket policy doc

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)
- [ x] This change requires a documentation update

## How Has This Been Tested?

deployed in aws

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x ] CHANGELOG.md
    - [ x] Development documentation
- [ x] My changes generate no new warnings
- [ x] My code has passed security scanning
    - [ x] Snyk
    - [x ] git-secrets
