### PR TITLE
Feature/orca 556 Implement internal_reconcile_report_phantom sql functionality into GraphQL prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and includes an additional section for migration notes.
 - *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581*
   - GraphQL image, service, and Load Balancer will now be deployed by TF.
   - *ORCA-420* Added Internal Reconcile Report Mismatch functionality to GraphQL.
+  - *ORCA-556* Added Internal Reconcile Report Phantom functionality to GraphQL.
   - *ORCA-592* GraphQL logs are json structures, and can thus be queried in CloudWatch.
 - *ORCA-597*
   - Server access logging is now enabled for graphql application load balancer.

--- a/graphql/src/adapters/graphql/dataTypes/internal_reconcile_report.py
+++ b/graphql/src/adapters/graphql/dataTypes/internal_reconcile_report.py
@@ -3,7 +3,12 @@ import strawberry
 
 from src.adapters.graphql.dataTypes.common import InternalServerErrorGraphqlType
 from src.entities.common import Page
-from src.entities.internal_reconcile_report import Mismatch
+from src.entities.internal_reconcile_report import Mismatch, Phantom
+
+GetPhantomPageStrawberryResponse = strawberry.union(
+    "GetPhantomPageStrawberryResponse",
+    [Page[Phantom], InternalServerErrorGraphqlType]
+)
 
 GetMismatchPageStrawberryResponse = strawberry.union(
     "GetMismatchPageStrawberryResponse",

--- a/graphql/src/adapters/graphql/resolvers/internal_reconcile_report.py
+++ b/graphql/src/adapters/graphql/resolvers/internal_reconcile_report.py
@@ -2,7 +2,7 @@ import logging
 
 from src.adapters.graphql.dataTypes.common import InternalServerErrorGraphqlType
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
-    GetMismatchPageStrawberryResponse,
+    GetMismatchPageStrawberryResponse, GetPhantomPageStrawberryResponse,
 )
 from src.entities.common import PageParameters
 from src.use_cases.adapter_interfaces.storage import (
@@ -11,14 +11,27 @@ from src.use_cases.adapter_interfaces.storage import (
 from src.use_cases.internal_reconcile_report import InternalReconcileReport
 
 
+def get_phantom_page(
+    job_id: int,
+    page_parameters: PageParameters,
+    storage_irr: StorageInternalReconcileReportInterface,
+    logger: logging.Logger,
+) -> GetPhantomPageStrawberryResponse:
+    try:
+        return InternalReconcileReport(storage_irr) \
+            .get_phantom_page(job_id, page_parameters, logger)
+    except Exception as ex:
+        return InternalServerErrorGraphqlType(ex)
+
+
 def get_mismatch_page(
     job_id: int,
     page_parameters: PageParameters,
     storage_irr: StorageInternalReconcileReportInterface,
-    logger: logging.Logger
+    logger: logging.Logger,
 ) -> GetMismatchPageStrawberryResponse:
     try:
-        return InternalReconcileReport(storage_irr)\
+        return InternalReconcileReport(storage_irr) \
             .get_mismatch_page(job_id, page_parameters, logger)
     except Exception as ex:
         return InternalServerErrorGraphqlType(ex)

--- a/graphql/src/adapters/graphql/resolvers/internal_reconcile_report.py
+++ b/graphql/src/adapters/graphql/resolvers/internal_reconcile_report.py
@@ -2,7 +2,8 @@ import logging
 
 from src.adapters.graphql.dataTypes.common import InternalServerErrorGraphqlType
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
-    GetMismatchPageStrawberryResponse, GetPhantomPageStrawberryResponse,
+    GetMismatchPageStrawberryResponse,
+    GetPhantomPageStrawberryResponse,
 )
 from src.entities.common import PageParameters
 from src.use_cases.adapter_interfaces.storage import (

--- a/graphql/src/adapters/graphql/schemas/queries.py
+++ b/graphql/src/adapters/graphql/schemas/queries.py
@@ -8,13 +8,14 @@ from strawberry import argument, field, type
 
 from src.adapters.graphql.adapters import AdaptersStorage
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
-    GetMismatchPageStrawberryResponse,
+    GetMismatchPageStrawberryResponse, GetPhantomPageStrawberryResponse,
 )
 from src.adapters.graphql.dataTypes.sample import GetEchoStrawberryResponse
 from src.adapters.graphql.dataTypes.storage_metadata import (
     GetStorageSchemaVersionStrawberryResponse,
 )
-from src.adapters.graphql.resolvers.internal_reconcile_report import get_mismatch_page
+from src.adapters.graphql.resolvers.internal_reconcile_report import get_mismatch_page, \
+    get_phantom_page
 from src.adapters.graphql.resolvers.sample import get_echo
 from src.adapters.graphql.resolvers.storage_metadata import (
     get_storage_migration_version,
@@ -52,6 +53,33 @@ class Queries:
         self,
     ) -> GetStorageSchemaVersionStrawberryResponse:
         return get_storage_migration_version(
+            Queries.adapters_storage.storage,
+            Queries.adapters_storage.logger_provider.get_logger(
+                uuid.uuid4().__str__()
+            )
+        )
+
+    @field(
+        description="""Gets a page of phantom reports for the given filter."""
+    )
+    def get_phantom_page(
+        self,
+        job_id: Annotated[
+            int,
+            argument(
+                description="""The unique job ID of the reconciliation job."""
+            )
+        ],
+        page_parameters: Annotated[
+            PageParameters,
+            argument(
+                description="""Parameters of the page to retrieve."""
+            )
+        ]
+    ) -> GetPhantomPageStrawberryResponse:
+        return get_phantom_page(
+            job_id,
+            page_parameters,
             Queries.adapters_storage.storage,
             Queries.adapters_storage.logger_provider.get_logger(
                 uuid.uuid4().__str__()

--- a/graphql/src/adapters/graphql/schemas/queries.py
+++ b/graphql/src/adapters/graphql/schemas/queries.py
@@ -8,14 +8,17 @@ from strawberry import argument, field, type
 
 from src.adapters.graphql.adapters import AdaptersStorage
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
-    GetMismatchPageStrawberryResponse, GetPhantomPageStrawberryResponse,
+    GetMismatchPageStrawberryResponse,
+    GetPhantomPageStrawberryResponse,
 )
 from src.adapters.graphql.dataTypes.sample import GetEchoStrawberryResponse
 from src.adapters.graphql.dataTypes.storage_metadata import (
     GetStorageSchemaVersionStrawberryResponse,
 )
-from src.adapters.graphql.resolvers.internal_reconcile_report import get_mismatch_page, \
-    get_phantom_page
+from src.adapters.graphql.resolvers.internal_reconcile_report import (
+    get_mismatch_page,
+    get_phantom_page,
+)
 from src.adapters.graphql.resolvers.sample import get_echo
 from src.adapters.graphql.resolvers.storage_metadata import (
     get_storage_migration_version,

--- a/graphql/src/entities/internal_reconcile_report.py
+++ b/graphql/src/entities/internal_reconcile_report.py
@@ -11,13 +11,15 @@ import strawberry
 @dataclasses.dataclass
 class Phantom(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
-    job_id: int
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    job_id: float
     collection_id: str
     granule_id: str
     filename: str
     key_path: str
     orca_etag: str
-    orca_last_update: int
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    orca_last_update: float
     orca_size_in_bytes: int
     orca_storage_class: str
 
@@ -66,7 +68,8 @@ class Phantom(pydantic.BaseModel):
 @dataclasses.dataclass
 class Mismatch(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
-    job_id: int
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    job_id: float
     collection_id: str
     granule_id: str
     filename: str
@@ -74,10 +77,14 @@ class Mismatch(pydantic.BaseModel):
     cumulus_archive_location: str
     orca_etag: str
     s3_etag: str
-    orca_last_update: int
-    s3_last_update: int
-    orca_size_in_bytes: int
-    s3_size_in_bytes: int
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    orca_last_update: float
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    s3_last_update: float
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    orca_size_in_bytes: float
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    s3_size_in_bytes: float
     orca_storage_class: str
     s3_storage_class: str
     discrepancy_type: str

--- a/graphql/src/entities/internal_reconcile_report.py
+++ b/graphql/src/entities/internal_reconcile_report.py
@@ -9,6 +9,61 @@ import strawberry
 
 @strawberry.type  # Not strictly clean, but alternative is duplicating classes in graphql adapter.
 @dataclasses.dataclass
+class Phantom(pydantic.BaseModel):
+    # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
+    job_id: int
+    collection_id: str
+    granule_id: str
+    filename: str
+    key_path: str
+    orca_etag: str
+    orca_last_update: int
+    orca_size_in_bytes: int
+    orca_storage_class: str
+
+    @dataclasses.dataclass
+    class Cursor:
+        job_id: int = None
+        collection_id: str = None
+        granule_id: str = None
+        key_path: str = None
+
+    # Overriding constructor to give us type/name hints for Pydantic class.
+    def __init__(self,
+                 job_id: int,
+                 collection_id: str,
+                 granule_id: str,
+                 filename: str,
+                 key_path: str,
+                 orca_etag: str,
+                 orca_last_update: int,
+                 orca_size_in_bytes: int,
+                 orca_storage_class: str,
+                 ):
+        # This call to __init__ will NOT automatically update when performing renames.
+        super().__init__(
+            job_id=job_id,
+            collection_id=collection_id,
+            granule_id=granule_id,
+            filename=filename,
+            key_path=key_path,
+            orca_etag=orca_etag,
+            orca_last_update=orca_last_update,
+            orca_size_in_bytes=orca_size_in_bytes,
+            orca_storage_class=orca_storage_class,
+        )
+
+    def get_cursor(self):
+        return Mismatch.Cursor(
+            job_id=self.job_id,
+            collection_id=self.collection_id,
+            granule_id=self.granule_id,
+            key_path=self.key_path,
+        )
+
+
+@strawberry.type  # Not strictly clean, but alternative is duplicating classes in graphql adapter.
+@dataclasses.dataclass
 class Mismatch(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     job_id: int

--- a/graphql/src/use_cases/adapter_interfaces/storage.py
+++ b/graphql/src/use_cases/adapter_interfaces/storage.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 
 from src.entities.common import DirectionEnum
-from src.entities.internal_reconcile_report import Mismatch
+from src.entities.internal_reconcile_report import Mismatch, Phantom
 
 
 class StorageMetadataInterface:
@@ -27,6 +27,33 @@ class StorageInternalReconcileReportInterface:
     """
     Generic storage class with methods that need to be implemented by database adapter.
     """
+    def get_phantom_page(
+        self,
+        job_id: int,
+        cursor_collection_id: str,
+        cursor_granule_id: str,
+        cursor_key_path: str,
+        direction: DirectionEnum,
+        limit: int,
+        logger: logging.Logger
+    ) -> List[Phantom]:
+        """
+        Returns a page of phantoms,
+        ordered by collection_id, granule_id, then key_path.
+
+        Args:
+            job_id: The job to return reports for.
+            cursor_collection_id: Points to start/end of the page (non-inclusive).
+            cursor_granule_id: Points to start/end of the page (non-inclusive).
+            cursor_key_path: Points to start/end of the page (non-inclusive).
+            direction: If `next`, cursor is the start of the page. Otherwise, end.
+            limit: Limits the number of rows returned.
+            logger: The logger to use.
+
+        Returns:
+            A list of phantoms.
+        """
+        ...
 
     def get_mismatch_page(
         self,
@@ -43,7 +70,7 @@ class StorageInternalReconcileReportInterface:
         ordered by collection_id, granule_id, then key_path.
 
         Args:
-            job_id: The job to return mismatches for.
+            job_id: The job to return reports for.
             cursor_collection_id: Points to start/end of the page (non-inclusive).
             cursor_granule_id: Points to start/end of the page (non-inclusive).
             cursor_key_path: Points to start/end of the page (non-inclusive).

--- a/graphql/src/use_cases/internal_reconcile_report.py
+++ b/graphql/src/use_cases/internal_reconcile_report.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 
 from src.entities.common import Page, PageParameters
-from src.entities.internal_reconcile_report import Mismatch
+from src.entities.internal_reconcile_report import Mismatch, Phantom
 from src.use_cases.adapter_interfaces.storage import (
     StorageInternalReconcileReportInterface,
 )
@@ -12,6 +12,52 @@ from src.use_cases.helpers.edge_cursor import EdgeCursor
 class InternalReconcileReport:
     def __init__(self, storage: StorageInternalReconcileReportInterface):
         self.storage = storage
+
+    def get_phantom_page(
+        self,
+        job_id: int,
+        page_parameters: PageParameters,
+        logger: logging.Logger
+    ) -> Page[Phantom]:
+        """
+        Returns a page of phantoms,
+        ordered by collection_id, granule_id, then key_path.
+
+        Args:
+            job_id: The unique job ID of the reconciliation job.
+            page_parameters: The parameters to use for paging.
+            logger: The logger to use.
+
+        Returns:
+            The indicated page of reports.
+        """
+        if page_parameters.cursor is None:
+            cursor = Phantom.Cursor()
+        else:
+            cursor = EdgeCursor.decode_cursor(page_parameters.cursor, Phantom.Cursor)
+
+        phantoms = self.storage.get_phantom_page(
+            job_id,
+            cursor.collection_id,
+            cursor.granule_id,
+            cursor.key_path,
+            page_parameters.direction,
+            page_parameters.limit,
+            logger
+        )
+
+        if len(phantoms) == 0:
+            start_cursor = None
+            end_cursor = None
+        else:
+            start_cursor = EdgeCursor.encode_cursor(
+                **dataclasses.asdict(phantoms[0].get_cursor()))
+            end_cursor = EdgeCursor.encode_cursor(
+                **dataclasses.asdict(phantoms[len(phantoms) - 1].get_cursor()))
+
+        return Page(items=phantoms,
+                    start_cursor=start_cursor,
+                    end_cursor=end_cursor)
 
     def get_mismatch_page(
         self,
@@ -29,7 +75,7 @@ class InternalReconcileReport:
             logger: The logger to use.
 
         Returns:
-            The indicated page of mismatch reports.
+            The indicated page of reports.
         """
         if page_parameters.cursor is None:
             cursor = Mismatch.Cursor()

--- a/graphql/test/unit_tests/adapters/graphql/resolvers/test_internal_reconcile_report.py
+++ b/graphql/test/unit_tests/adapters/graphql/resolvers/test_internal_reconcile_report.py
@@ -6,6 +6,56 @@ from src.adapters.graphql.resolvers import internal_reconcile_report
 
 class TestInternalReconcileReport(unittest.TestCase):
     @patch("src.adapters.graphql.resolvers.internal_reconcile_report.InternalReconcileReport")
+    def test_get_phantom_page_happy_path(
+        self,
+        mock_use_case: MagicMock,
+    ):
+        """
+        Arguments should be passed along.
+        """
+        mock_job_id = Mock()
+        mock_page_parameters = Mock()
+        mock_storage_irr = Mock()
+        mock_logger = Mock()
+
+        result = \
+            internal_reconcile_report.get_phantom_page(mock_job_id, mock_page_parameters,
+                                                       mock_storage_irr, mock_logger)
+
+        mock_use_case.assert_called_once_with(mock_storage_irr)
+        mock_use_case.return_value.get_phantom_page.assert_called_once_with(
+            mock_job_id, mock_page_parameters, mock_logger)
+        self.assertEqual(mock_use_case.return_value.get_phantom_page.return_value, result)
+
+    @patch("src.adapters.graphql.resolvers.internal_reconcile_report"
+           ".InternalServerErrorGraphqlType")
+    @patch("src.adapters.graphql.resolvers.internal_reconcile_report.InternalReconcileReport")
+    def test_get_phantom_page_error_wrapped(
+        self,
+        mock_use_case: MagicMock,
+        mock_error: MagicMock,
+    ):
+        """
+        When an error is raised, wrap in InternalServerErrorGraphqlType
+        """
+        mock_job_id = Mock()
+        mock_page_parameters = Mock()
+        mock_storage_irr = Mock()
+        mock_logger = Mock()
+        mock_exception = Exception()
+
+        mock_use_case.side_effect = mock_exception
+
+        result = \
+            internal_reconcile_report.get_phantom_page(mock_job_id, mock_page_parameters,
+                                                       mock_storage_irr, mock_logger)
+
+        mock_use_case.assert_called_once_with(mock_storage_irr)
+        mock_use_case.return_value.get_phantom_page.assert_not_called()
+        mock_error.assert_called_once_with(mock_exception)
+        self.assertEqual(mock_error.return_value, result)
+
+    @patch("src.adapters.graphql.resolvers.internal_reconcile_report.InternalReconcileReport")
     def test_get_mismatch_page_happy_path(
         self,
         mock_use_case: MagicMock,

--- a/graphql/test/unit_tests/adapters/graphql/schemas/test_queries.py
+++ b/graphql/test/unit_tests/adapters/graphql/schemas/test_queries.py
@@ -6,6 +6,31 @@ from src.adapters.graphql.schemas.queries import Queries
 
 class TestQueries(unittest.TestCase):
 
+    @patch("src.adapters.graphql.schemas.queries.get_phantom_page")
+    def test_get_phantom_page_happy_path(
+        self,
+        mock_get_phantom_page: MagicMock,
+    ):
+        """
+        Parameters should be passed along.
+        """
+        mock_adapters_storage = MagicMock()
+
+        mock_job_id = Mock()
+        mock_page_parameters = Mock()
+
+        # graphql limitations make construction interesting.
+        Queries.adapters_storage = mock_adapters_storage
+        queries = Queries(adapters_storage=mock_adapters_storage)
+
+        result = queries.get_phantom_page(mock_job_id, mock_page_parameters)
+
+        mock_get_phantom_page.assert_called_once_with(
+            mock_job_id, mock_page_parameters, mock_adapters_storage.storage,
+            mock_adapters_storage.logger_provider.get_logger.return_value
+        )
+        self.assertEqual(mock_get_phantom_page.return_value, result)
+
     @patch("src.adapters.graphql.schemas.queries.get_mismatch_page")
     def test_get_mismatch_page_happy_path(
         self,

--- a/graphql/test/unit_tests/entities/test_internal_reconcile_report.py
+++ b/graphql/test/unit_tests/entities/test_internal_reconcile_report.py
@@ -2,10 +2,81 @@ import random
 import unittest
 import uuid
 
-from src.entities.internal_reconcile_report import Mismatch
+from src.entities.internal_reconcile_report import Mismatch, Phantom
 
 
 class TestInternalReconcileReport(unittest.TestCase):
+    def test_phantom_constructor(
+        self,
+    ):
+        """
+        Constructor should properly store parameters.
+        """
+        job_id = random.randint(0, 10000)  # nosec
+        collection_id = uuid.uuid4().__str__()
+        granule_id = uuid.uuid4().__str__()
+        filename = uuid.uuid4().__str__()
+        key_path = uuid.uuid4().__str__()
+        orca_etag = uuid.uuid4().__str__()
+        orca_last_update = random.randint(0, 10000)  # nosec
+        orca_size_in_bytes = random.randint(0, 10000)  # nosec
+        orca_storage_class = uuid.uuid4().__str__()
+
+        result = Phantom(
+            job_id,
+            collection_id,
+            granule_id,
+            filename,
+            key_path,
+            orca_etag,
+            orca_last_update,
+            orca_size_in_bytes,
+            orca_storage_class,
+        )
+
+        # todo: Find a way to loop over properties and check them
+        self.assertEqual(job_id, result.job_id)
+        self.assertEqual(collection_id, result.collection_id)
+        self.assertEqual(granule_id, result.granule_id)
+        self.assertEqual(filename, result.filename)
+        self.assertEqual(key_path, result.key_path)
+        self.assertEqual(orca_etag, result.orca_etag)
+        self.assertEqual(orca_last_update, result.orca_last_update)
+        self.assertEqual(orca_size_in_bytes, result.orca_size_in_bytes)
+        self.assertEqual(orca_storage_class, result.orca_storage_class)
+
+    def test_phantom_get_cursor(self):
+        """
+        get_cursor should return information that identifies an individual row.
+        """
+        job_id = random.randint(0, 10000)  # nosec
+        collection_id = uuid.uuid4().__str__()
+        granule_id = uuid.uuid4().__str__()
+        filename = uuid.uuid4().__str__()
+        key_path = uuid.uuid4().__str__()
+        orca_etag = uuid.uuid4().__str__()
+        orca_last_update = random.randint(0, 10000)  # nosec
+        orca_size_in_bytes = random.randint(0, 10000)  # nosec
+        orca_storage_class = uuid.uuid4().__str__()
+
+        result = Phantom(
+            job_id,
+            collection_id,
+            granule_id,
+            filename,
+            key_path,
+            orca_etag,
+            orca_last_update,
+            orca_size_in_bytes,
+            orca_storage_class,
+        ).get_cursor()
+
+        # todo: Find a way to loop over properties and check them
+        self.assertEqual(job_id, result.job_id)
+        self.assertEqual(collection_id, result.collection_id)
+        self.assertEqual(granule_id, result.granule_id)
+        self.assertEqual(key_path, result.key_path)
+
     def test_mismatch_constructor(
         self,
     ):

--- a/graphql/test/unit_tests/use_cases/test_internal_reconcile_report.py
+++ b/graphql/test/unit_tests/use_cases/test_internal_reconcile_report.py
@@ -1,11 +1,70 @@
 import unittest
 from unittest.mock import MagicMock, Mock, call, patch
 
-from src.entities.internal_reconcile_report import Mismatch
+from src.entities.internal_reconcile_report import Mismatch, Phantom
 from src.use_cases.internal_reconcile_report import InternalReconcileReport
 
 
 class MyTestCase(unittest.TestCase):
+    @patch("src.use_cases.internal_reconcile_report.dataclasses.asdict")
+    @patch("src.use_cases.internal_reconcile_report.EdgeCursor.encode_cursor")
+    @patch("src.use_cases.internal_reconcile_report.EdgeCursor.decode_cursor")
+    def test_get_phantom_page_happy_path(
+        self,
+        mock_decode_cursor: MagicMock,
+        mock_encode_cursor: MagicMock,
+        mock_asdict: MagicMock,
+    ):
+        """
+        Happy path of getting a page of results from the database and returning the page.
+        """
+        mock_dict0 = {"key": Mock()}
+        mock_dict1 = {"key": Mock()}
+        mock_asdict.side_effect = [mock_dict0, mock_dict1]
+
+        mock_start_cursor = Mock()
+        mock_end_cursor = Mock()
+        mock_encode_cursor.side_effect = [mock_start_cursor, mock_end_cursor]
+
+        phantom0 = Mock()
+        phantom1 = Mock()
+        phantoms = [phantom0, phantom1]
+        mock_storage_get_phantom_page = Mock(return_value=phantoms)
+        mock_storage = Mock()
+        mock_storage.get_phantom_page = mock_storage_get_phantom_page
+        mock_job_id = Mock()
+        mock_page_parameters = Mock()
+        mock_logger = Mock()
+
+        result = InternalReconcileReport(mock_storage)\
+            .get_phantom_page(mock_job_id, mock_page_parameters, mock_logger)
+
+        mock_decode_cursor.assert_called_once_with(mock_page_parameters.cursor, Phantom.Cursor)
+        mock_storage_get_phantom_page.assert_called_once_with(
+            mock_job_id,
+            mock_decode_cursor.return_value.collection_id,
+            mock_decode_cursor.return_value.granule_id,
+            mock_decode_cursor.return_value.key_path,
+            mock_page_parameters.direction,
+            mock_page_parameters.limit,
+            mock_logger,
+        )
+
+        mock_asdict.assert_has_calls([
+            call(phantom0.get_cursor()),
+            call(phantom1.get_cursor()),
+        ])
+        self.assertEqual(2, mock_asdict.call_count)
+        mock_encode_cursor.assert_has_calls([
+            call(**mock_dict0),
+            call(**mock_dict1),
+        ])
+        self.assertEqual(2, mock_encode_cursor.call_count)
+
+        self.assertEqual([phantom0, phantom1], result.items)
+        self.assertEqual(mock_start_cursor, result.start_cursor)
+        self.assertEqual(mock_end_cursor, result.end_cursor)
+
     @patch("src.use_cases.internal_reconcile_report.dataclasses.asdict")
     @patch("src.use_cases.internal_reconcile_report.EdgeCursor.encode_cursor")
     @patch("src.use_cases.internal_reconcile_report.EdgeCursor.decode_cursor")

--- a/modules/graphql_1/main.tf
+++ b/modules/graphql_1/main.tf
@@ -188,7 +188,7 @@ resource "aws_ecs_task_definition" "gql_task" {
 [
   {
     "name": "orca-gql",
-    "image": "ghcr.io/nasa/cumulus-orca/graphql:0.0.29",
+    "image": "ghcr.io/nasa/cumulus-orca/graphql:0.0.30",
     "cpu": 512,
     "memory": 256,
     "networkMode": "awsvpc",


### PR DESCRIPTION
## Summary of Changes

Added phantom retrieval to GraphQL

Addresses [ORCA-556: Implement internal_reconcile_report_phantom sql functionality into GraphQL prototype](https://bugs.earthdata.nasa.gov/browse/ORCA-556)

## Changes

* Added phantom retrieval to GraphQL
* Fixed bug with mismatch between GraphQL and Python definitions of int

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Retrieval run against ORCA database both locally and in AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets