### PR TITLE
Release 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and includes an additional section for migration notes.
 ### Added
 - *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581* GraphQL image, service, and Load Balancer will now be deployed by TF.
 
+## [7.0.1]
+### Changed
+- *ORCA-632* Fixed a bug where `excludedFileExtensions` was a required property in collection config. Restored default behavior of defaulting to an empty list.
+
 ## [7.0.0]
 ### Changed
 - *ORCA-336*

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -5,6 +5,7 @@
   "States": {
     "ExtractFilepaths": {
       "Parameters": {
+        "event.$": "$",
         "input.$": "$.payload",
         "config": {
           "buckets.$": "$.meta.buckets",

--- a/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
+++ b/modules/workflows/OrcaRecoveryWorkflow/orca_recover_workflow.asl.json
@@ -8,8 +8,12 @@
         "input.$": "$.payload",
         "config": {
           "buckets.$": "$.meta.buckets",
-          "fileBucketMaps.$": "$.meta.collection.files",
-          "excludedFileExtensions.$": "$.meta.collection.meta.orca.excludedFileExtensions"
+          "fileBucketMaps.$": "$.meta.collection.files"
+        },
+        "optionalValues": {
+          "config": {
+            "excludedFileExtensions": "event.meta.collection.meta.orca.excludedFileExtensions"
+          }
         }
       },
       "Type": "Task",

--- a/tasks/extract_filepaths_for_granule/API.md
+++ b/tasks/extract_filepaths_for_granule/API.md
@@ -5,6 +5,7 @@
   * [task](#extract_filepaths_for_granule.task)
   * [get\_regex\_buckets](#extract_filepaths_for_granule.get_regex_buckets)
   * [should\_exclude\_files\_type](#extract_filepaths_for_granule.should_exclude_files_type)
+  * [set\_optional\_event\_property](#extract_filepaths_for_granule.set_optional_event_property)
   * [handler](#extract_filepaths_for_granule.handler)
 
 <a id="extract_filepaths_for_granule"></a>
@@ -30,7 +31,7 @@ Exception to be raised if any errors occur
 #### task
 
 ```python
-def task(event)
+def task(task_input: Dict[str, Any], config: Dict[str, Any])
 ```
 
 Task called by the handler to perform the work.
@@ -39,7 +40,8 @@ This task will parse the input, removing the granuleId and file keys for a granu
 
 **Arguments**:
 
-- `event` _dict_ - passed through from the handler
+- `task_input` - See schemas/input.json
+- `config` - See schemas/config.json
   
 
 **Returns**:
@@ -56,7 +58,7 @@ This task will parse the input, removing the granuleId and file keys for a granu
 #### get\_regex\_buckets
 
 ```python
-def get_regex_buckets(event) -> Dict[str, str]
+def get_regex_buckets(config: Dict[str, Any]) -> Dict[str, str]
 ```
 
 Gets a dict of regular expressions and the corresponding archive bucket for files
@@ -64,7 +66,7 @@ matching the regex.
 
 **Arguments**:
 
-- `event` _dict_ - passed through from the handler
+- `config` - See schemas/config.json
   
 
 **Returns**:
@@ -96,21 +98,42 @@ Tests whether or not file is included in {excludedFileExtensions} from copy_to_a
 
   True if file should be excluded from copy, False otherwise.
 
+<a id="extract_filepaths_for_granule.set_optional_event_property"></a>
+
+#### set\_optional\_event\_property
+
+```python
+def set_optional_event_property(event: Dict[str,
+                                            Any], target_path_cursor: Dict,
+                                target_path_segments: List) -> None
+```
+
+Sets the optional variable value from event if present, otherwise sets to None.
+
+**Arguments**:
+
+- `event` - See schemas/input.json.
+- `target_path_cursor` - Cursor of the current section to check.
+- `target_path_segments` - The path to the current cursor.
+
+**Returns**:
+
+  None
+
 <a id="extract_filepaths_for_granule.handler"></a>
 
 #### handler
 
 ```python
 @LOGGER.inject_lambda_context
-def handler(event: Dict[str, Union[str, int]], context: LambdaContext)
+def handler(event: Dict[str, Dict[str, Any]], context: LambdaContext)
 ```
 
 Lambda handler. Extracts the key's for a granule from an input dict.
 
 **Arguments**:
 
-- `event` _dict_ - A dict with the following keys:
-  
+- `event` - A dict with the following keys:
   granules (list(dict)): A list of dict with the following keys:
 - `granuleId` _string_ - The id of a granule.
   files (list(dict)): list of dict with the following keys:
@@ -140,7 +163,6 @@ Lambda handler. Extracts the key's for a granule from an input dict.
   ]
   }
   }
-  
 - `context` - This object provides information about the lambda invocation, function,
   and execution env.
   

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -16,6 +16,8 @@ from fastjsonschema import JsonSchemaException
 # Set AWS powertools logger
 LOGGER = Logger()
 
+EVENT_OPTIONAL_VALUES_KEY = "optionalValues"
+
 CONFIG_EXCLUDED_FILE_EXTENSIONS_KEY = "excludedFileExtensions"
 CONFIG_FILE_BUCKETS_KEY = "fileBucketMaps"
 CONFIG_BUCKETS_KEY = "buckets"
@@ -189,6 +191,52 @@ def should_exclude_files_type(file_key: str, exclude_file_types: List[str]) -> b
     return False
 
 
+def set_optional_event_property(event: Dict[str, Any], target_path_cursor: Dict,
+                                target_path_segments: List) -> None:
+    """Sets the optional variable value from event if present, otherwise sets to None.
+    Args:
+        event: See schemas/input.json.
+        target_path_cursor: Cursor of the current section to check.
+        target_path_segments: The path to the current cursor.
+    Returns:
+        None
+    """
+    for optionalValueTargetPath in target_path_cursor:
+        temp_target_path_segments = target_path_segments.copy()
+        temp_target_path_segments.append(optionalValueTargetPath)
+        if isinstance(target_path_cursor[optionalValueTargetPath], dict):
+            set_optional_event_property(
+                event,
+                target_path_cursor[optionalValueTargetPath],
+                temp_target_path_segments
+            )
+        elif isinstance(target_path_cursor[optionalValueTargetPath], str):
+            source_path = target_path_cursor[optionalValueTargetPath]
+            source_path_segments = source_path.split(".")
+
+            # ensure that the path up to the target_path exists
+            event_cursor = event
+            for target_path_segment in temp_target_path_segments[:-1]:
+                event_cursor[target_path_segment] =\
+                    event_cursor.get(target_path_segment, {})
+                event_cursor = event_cursor[target_path_segment]
+            event_cursor[temp_target_path_segments[-1]] = None
+
+            # get the value for the optional element
+            source_path_cursor = event
+            for source_path_segment in source_path_segments:
+                source_path_cursor = source_path_cursor.get(source_path_segment, None)
+                if source_path_cursor is None:
+                    LOGGER.info(f"When retrieving '{'.'.join(temp_target_path_segments)}', "
+                                f"no value found in '{source_path}' at key {source_path_segment}. "
+                                f"Defaulting to null.")
+                    break
+            event_cursor[temp_target_path_segments[-1]] = source_path_cursor
+        else:
+            raise Exception(f"Illegal type {type(target_path_cursor[optionalValueTargetPath])} "
+                            f"found at {'.'.join(temp_target_path_segments)}")
+
+
 @LOGGER.inject_lambda_context
 def handler(event: Dict[str, Dict[str, Any]],
             context: LambdaContext):  # pylint: disable-msg=unused-argument
@@ -242,6 +290,13 @@ def handler(event: Dict[str, Dict[str, Any]],
         ExtractFilePathsError: An error occurred parsing the input.
     """
     LOGGER.debug(f"event: {event}")
+    # set the optional variables to None if not configured
+    try:
+        set_optional_event_property(event, event.get(EVENT_OPTIONAL_VALUES_KEY, {}), [])
+    except Exception as ex:
+        LOGGER.error(ex)
+        raise ex
+
     task_input = event["input"]
     try:
         _VALIDATE_INPUT(task_input)

--- a/tasks/extract_filepaths_for_granule/schemas/config.json
+++ b/tasks/extract_filepaths_for_granule/schemas/config.json
@@ -5,8 +5,7 @@
     "type": "object",
     "required": [
       "buckets",
-      "fileBucketMaps",
-      "excludedFileExtensions"
+      "fileBucketMaps"
     ],
     "properties": {
       "buckets": {

--- a/tasks/extract_filepaths_for_granule/schemas/config.json
+++ b/tasks/extract_filepaths_for_granule/schemas/config.json
@@ -5,7 +5,8 @@
     "type": "object",
     "required": [
       "buckets",
-      "fileBucketMaps"
+      "fileBucketMaps",
+      "excludedFileExtensions"
     ],
     "properties": {
       "buckets": {

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -1966,6 +1966,11 @@ class TestRequestFromArchive(unittest.TestCase):
         }
         context = Mock()
         result = request_from_archive.handler(input_event, context)
+
+        mock_task.assert_called_once_with(
+            input_event["input"], input_event["config"]
+        )
+        mock_optional_property.assert_called_once_with(input_event, {}, [])
         self.assertEqual(mock_task.return_value, result)
 
     @patch("request_from_archive.task")

--- a/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
+++ b/tasks/request_from_archive/test/unit_tests/test_request_from_archive.py
@@ -1968,9 +1968,12 @@ class TestRequestFromArchive(unittest.TestCase):
         result = request_from_archive.handler(input_event, context)
 
         mock_task.assert_called_once_with(
-            input_event["input"], input_event["config"]
+            input_event
         )
-        mock_optional_property.assert_called_once_with(input_event, {}, [])
+        mock_optional_property.assert_called_once_with(
+            input_event,
+            input_event[request_from_archive.EVENT_OPTIONAL_VALUES_KEY],
+            [])
         self.assertEqual(mock_task.return_value, result)
 
     @patch("request_from_archive.task")


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-632: Make excludedFileExtensions optional again](https://bugs.earthdata.nasa.gov/browse/ORCA-632)

## Changes

* Moved `excludedFileExtensions` to an optional field and added accompanying code
* Repaired release url check

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Bug was reproducible in AWS until this fix was deployed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets

## What is the current behavior?

If `excludedFileExtensions` is not included in the collection config, the Recovery step function errors out.

## What is the expected correct/added behavior?

Step function should continue, using a default value of `[]`.
