### PR TITLE
Feature/orca 520 Develop CMA adapter lambda for copy_to_archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and includes an additional section for migration notes.
 - Cumulus is not currently compatible with the changes to copy_to_archive.
   - This section will be updated when a compatible version is created.
   - deployment-with-cumulus.md will also be updated.
+  - copy_to_archive_adapter/README.md will also be updated.
 
 ### Migration Notes
 - Update the bucket policy for your `system-bucket` to allow load balancer to post server access logs to the bucket. See the instructions [here](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-s3-bucket#bucket-policy-for-load-balancer-server-access-loging).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and includes an additional section for migration notes.
 - *ORCA-597*
   - Server access logging is now enabled for graphql application load balancer.
 
+### Changed
+- *ORCA-520* Removed `run_cumulus_task` function from copy_to_archive to decouple ORCA from Cumulus.
+
+### Migration Notes
+- Cumulus is not currently compatible with the changes to copy_to_archive.
+  - This section will be updated when a compatible version is created.
+
 ### Migration Notes
 - Update the bucket policy for your `system-bucket` to allow load balancer to post server access logs to the bucket. See the instructions [here](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-s3-bucket#bucket-policy-for-load-balancer-server-access-loging).
 - InternalReconcileReport [Phantom](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#internal-reconcile-report-phantom-api) and [Mismatch](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#internal-reconcile-report-mismatch-api) reports are now available via GraphQL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and includes an additional section for migration notes.
 - *ORCA-520* Removed `run_cumulus_task` function from copy_to_archive to decouple ORCA from Cumulus.
 
 ### Migration Notes
+- The output format of `copy_to_archive` lambda and step-function has been simplified. If accessing these resources outside of a Cumulus perspective, instead of accessing `output["payload"]["granules"]` you now use `output["granules"]`.
 - Cumulus is not currently compatible with the changes to copy_to_archive.
   - This section will be updated when a compatible version is created.
   - deployment-with-cumulus.md will also be updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,8 @@ and includes an additional section for migration notes.
   rename to new key `copied_to_orca`.
 - If utilizing the `orca_lambda_copy_to_glacier_arn` [output of Terraform](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/outputs.tf#L8), likely as a means of pulling the lambda into your workflows, 
   rename to new key `orca_lambda_copy_to_archive_arn`
-- Use the optional `recoveryBucketOverride` property in `extract_filepaths_for_granule` input schema to specify a recovery bucket. See example below.
+- If utilizing the `orca_lambda_request_files_arn` [output of Terraform](https://github.com/nasa/cumulus-orca/blob/15e5868f2d1eead88fb5cc8f2e055a18ba0f1264/outputs.tf#L28), likely as a means of pulling the lambda into your workflows, rename to new key `orca_lambda_request_from_archive_arn`
+- If desired, use the optional `recoveryBucketOverride` property in `extract_filepaths_for_granule` input schema to to override the default recovery bucket. See example below.
 
 ```json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and includes an additional section for migration notes.
 ### Migration Notes
 - Cumulus is not currently compatible with the changes to copy_to_archive.
   - This section will be updated when a compatible version is created.
+  - deployment-with-cumulus.md will also be updated.
 
 ### Migration Notes
 - Update the bucket policy for your `system-bucket` to allow load balancer to post server access logs to the bucket. See the instructions [here](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-s3-bucket#bucket-policy-for-load-balancer-server-access-loging).

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_files_excluded.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_files_excluded.py
@@ -71,54 +71,19 @@ class TestMultipleGranules(TestCase):
             }
 
             expected_output = {
-                "payload": {
-                    "granules": [
-                        {
-                            "granuleId": granule_id,
-                            "createdAt": createdAt_time,
-                            "files": [
-                                {
-                                    "bucket": bucket_name,
-                                    "key": key_name
-                                }
-                            ]
-                        }
-                    ],
-                    "copied_to_orca": []
-                },
-                "meta": {
-                    "provider": {
-                        "id": provider_id,
-                        "name": provider_name
-                    },
-                    "collection": {
-                        "meta": {
-                            "orca": {
-                                "excludedFileExtensions":
-                                    excluded_filetype
+                "granules": [
+                    {
+                        "granuleId": granule_id,
+                        "createdAt": createdAt_time,
+                        "files": [
+                            {
+                                "bucket": bucket_name,
+                                "key": key_name
                             }
-                        },
-                        "name": collection_name,
-                        "version": collection_version
+                        ]
                     }
-                },
-                "cumulus_meta": {
-                    "execution_name": execution_id
-                },
-                "task_config": {
-                    "excludedFileExtensions":
-                        "{$.meta.collection.meta.orca.excludedFileExtensions}",
-                    "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-                    "providerId": "{$.meta.provider.id}",
-                    "providerName": "{$.meta.provider.name}",
-                    "executionId": "{$.cumulus_meta.execution_name}",
-                    "collectionShortname": "{$.meta.collection.name}",
-                    "collectionVersion": "{$.meta.collection.version}",
-                    "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}",
-                    "defaultStorageClassOverride":
-                        "{$.meta.collection.meta.orca.defaultStorageClassOverride}"
-                },
-                "exception": "None"
+                ],
+                "copied_to_orca": []
             }
 
             execution_info = boto3.client("stepfunctions").start_execution(
@@ -135,9 +100,10 @@ class TestMultipleGranules(TestCase):
                 step_function_results["status"],
                 "Error occurred while starting step function.",
             )
+            actual_output = json.loads(step_function_results["output"])
             self.assertEqual(
                 expected_output,
-                json.loads(step_function_results["output"]),
+                actual_output,
                 "Expected step function output not returned.",
             )
 

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
@@ -87,69 +87,34 @@ class TestMultipleGranulesHappyPath(TestCase):
             }
 
             expected_output = {
-                "payload": {
-                    "granules": [
-                        {
-                            "granuleId": granule_id_1,
-                            "createdAt": createdAt_time,
-                            "files": [
-                                {
-                                    "bucket": cumulus_bucket_name,
-                                    "key": key_name_1,
-                                    "checksum": file_1_hash,
-                                    "checksumType": file_1_hash_type
-                                }
-                            ]
-                        },
-                        {
-                            "granuleId": granule_id_2,
-                            "createdAt": createdAt_time,
-                            "files": [
-                                {
-                                    "bucket": cumulus_bucket_name,
-                                    "key": key_name_2,
-                                }
-                            ]
-                        }
-                    ],
-                    "copied_to_orca": [
-                        "s3://" + cumulus_bucket_name + "/" + key_name_1,
-                        "s3://" + cumulus_bucket_name + "/" + key_name_2
-                    ]
-                },
-                "meta": {
-                    "provider": {
-                        "id": provider_id,
-                        "name": provider_name
-                    },
-                    "collection": {
-                        "meta": {
-                            "orca": {
-                                "excludedFileExtensions":
-                                    excluded_filetype
+                "granules": [
+                    {
+                        "granuleId": granule_id_1,
+                        "createdAt": createdAt_time,
+                        "files": [
+                            {
+                                "bucket": cumulus_bucket_name,
+                                "key": key_name_1,
+                                "checksum": file_1_hash,
+                                "checksumType": file_1_hash_type
                             }
-                        },
-                        "name": collection_name,
-                        "version": collection_version
+                        ]
+                    },
+                    {
+                        "granuleId": granule_id_2,
+                        "createdAt": createdAt_time,
+                        "files": [
+                            {
+                                "bucket": cumulus_bucket_name,
+                                "key": key_name_2,
+                            }
+                        ]
                     }
-                },
-                "cumulus_meta": {
-                    "execution_name": execution_id
-                },
-                "task_config": {
-                    "excludedFileExtensions":
-                        "{$.meta.collection.meta.orca.excludedFileExtensions}",
-                    "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-                    "providerId": "{$.meta.provider.id}",
-                    "providerName": "{$.meta.provider.name}",
-                    "executionId": "{$.cumulus_meta.execution_name}",
-                    "collectionShortname": "{$.meta.collection.name}",
-                    "collectionVersion": "{$.meta.collection.version}",
-                    "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}",
-                    "defaultStorageClassOverride":
-                        "{$.meta.collection.meta.orca.defaultStorageClassOverride}"
-                },
-                "exception": "None"
+                ],
+                "copied_to_orca": [
+                    "s3://" + cumulus_bucket_name + "/" + key_name_1,
+                    "s3://" + cumulus_bucket_name + "/" + key_name_2
+                ]
             }
 
             execution_info = boto3.client("stepfunctions").start_execution(
@@ -207,58 +172,63 @@ class TestMultipleGranulesHappyPath(TestCase):
             self.assertEqual(
                 200, catalog_output.status_code, "Error occurred while contacting API."
             )
-            expected_catalog_output = {
-                    "anotherPage": False,
-                    "granules": [
+            expected_catalog_output_granules = [{
+                "providerId": provider_id,
+                "collectionId": collection_name + "___" + collection_version,
+                "id": granule_id_1,
+                "createdAt": createdAt_time,
+                "executionId": execution_id,
+                "files": [
+                    {
+                        "name": name_1,
+                        "cumulusArchiveLocation": cumulus_bucket_name,
+                        "orcaArchiveLocation": recovery_bucket_name,
+                        "keyPath": key_name_1,
+                        "sizeBytes": 205640819682,
+                        "hash": file_1_hash, "hashType": file_1_hash_type,
+                        "storageClass": "GLACIER",
+                        "version": s3_versions[0],
+                    }
+                ],
+                "ingestDate": mock.ANY,
+                "lastUpdate": mock.ANY
+            },
+                {
+                    "providerId": provider_id,
+                    "collectionId": collection_name + "___" + collection_version,
+                    "id": granule_id_2,
+                    "createdAt": createdAt_time,
+                    "executionId": execution_id,
+                    "files": [
                         {
-                            "providerId": provider_id,
-                            "collectionId": collection_name + "___" + collection_version,
-                            "id": granule_id_1,
-                            "createdAt": createdAt_time,
-                            "executionId": execution_id,
-                            "files": [
-                                {
-                                    "name": name_1,
-                                    "cumulusArchiveLocation": cumulus_bucket_name,
-                                    "orcaArchiveLocation": recovery_bucket_name,
-                                    "keyPath": key_name_1,
-                                    "sizeBytes": 205640819682,
-                                    "hash": file_1_hash, "hashType": file_1_hash_type,
-                                    "storageClass": "GLACIER",
-                                    "version": s3_versions[0],
-                                }
-                            ],
-                            "ingestDate": mock.ANY,
-                            "lastUpdate": mock.ANY
-                        },
-                        {
-                            "providerId": provider_id,
-                            "collectionId": collection_name + "___" + collection_version,
-                            "id": granule_id_2,
-                            "createdAt": createdAt_time,
-                            "executionId": execution_id,
-                            "files": [
-                                {
-                                    "name": name_2,
-                                    "cumulusArchiveLocation": cumulus_bucket_name,
-                                    "orcaArchiveLocation": recovery_bucket_name,
-                                    "keyPath": key_name_2,
-                                    "sizeBytes": 6,
-                                    "hash": None, "hashType": None,
-                                    "storageClass": "GLACIER",
-                                    "version": s3_versions[1],
-                                }
-                            ],
-                            "ingestDate": mock.ANY,
-                            "lastUpdate": mock.ANY
+                            "name": name_2,
+                            "cumulusArchiveLocation": cumulus_bucket_name,
+                            "orcaArchiveLocation": recovery_bucket_name,
+                            "keyPath": key_name_2,
+                            "sizeBytes": 6,
+                            "hash": None, "hashType": None,
+                            "storageClass": "GLACIER",
+                            "version": s3_versions[1],
                         }
-                    ]
-                }
+                    ],
+                    "ingestDate": mock.ANY,
+                    "lastUpdate": mock.ANY
+                }]
+            expected_catalog_output = {
+                "anotherPage": False,
+                "granules": mock.ANY
+            }
             catalog_output_json = catalog_output.json()
             self.assertEqual(
                 expected_catalog_output,
                 catalog_output_json,
                 "Expected API output not returned.",
+            )
+            # Make sure all given granules are present without checking order.
+            self.assertCountEqual(
+                expected_catalog_output_granules,
+                catalog_output_json["granules"],
+                "Expected API output not returned."
             )
         except Exception as ex:
             logging.error(ex)

--- a/integration_test/workflow_tests/test_packages/ingest/test_no_granules.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_no_granules.py
@@ -44,36 +44,7 @@ class TestNoGranules(TestCase):
             }
 
             expected_output = {
-                "payload": {"granules": [], "copied_to_orca": []},
-                "meta": {
-                    "collection": {
-                        "name": collection_name,
-                        "version": collection_version,
-                    },
-                    "provider": {"id": provider_id, "name": provider_name},
-                },
-                "cumulus_meta": {"execution_name": execution_id},
-                "task_config": {
-                    "excludedFileExtensions":
-                        "{$.meta.collection.meta.orca.excludedFileExtensions}",
-                    "s3MultipartChunksizeMb":
-                        "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-                    "providerId":
-                        "{$.meta.provider.id}",
-                    "providerName":
-                        "{$.meta.provider.name}",
-                    "executionId":
-                        "{$.cumulus_meta.execution_name}",
-                    "collectionShortname":
-                        "{$.meta.collection.name}",
-                    "collectionVersion":
-                        "{$.meta.collection.version}",
-                    "defaultBucketOverride":
-                        "{$.meta.collection.meta.orca.defaultBucketOverride}",
-                    "defaultStorageClassOverride":
-                        "{$.meta.collection.meta.orca.defaultStorageClassOverride}",
-                },
-                "exception": "None",
+                "granules": [], "copied_to_orca": []
             }
 
             execution_info = boto3.client("stepfunctions").start_execution(

--- a/modules/workflows/OrcaCopyToArchiveWorkflow/orca_copy_to_archive_workflow.asl.json
+++ b/modules/workflows/OrcaCopyToArchiveWorkflow/orca_copy_to_archive_workflow.asl.json
@@ -4,18 +4,20 @@
   "States": {
     "CopyToArchive": {
       "Parameters": {
-        "cma": {
-          "event.$": "$",
-          "task_config": {
-            "excludedFileExtensions": "{$.meta.collection.meta.orca.excludedFileExtensions}",
-            "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-            "providerId": "{$.meta.provider.id}",
-            "providerName": "{$.meta.provider.name}",
-            "executionId": "{$.cumulus_meta.execution_name}",
-            "collectionShortname": "{$.meta.collection.name}",
-            "collectionVersion": "{$.meta.collection.version}",
-            "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}",
-            "defaultStorageClassOverride": "{$.meta.collection.meta.orca.defaultStorageClassOverride}"
+        "input.$": "$.payload",
+        "config": {
+          "providerId": "{$.meta.provider.id}",
+          "executionId": "{$.cumulus_meta.execution_name}",
+          "collectionShortname": "{$.meta.collection.name}",
+          "collectionVersion": "{$.meta.collection.version}"
+        },
+        "optionalValues": {
+          "config": {
+            "excludedFileExtensions": "event.meta.collection.meta.orca.excludedFileExtensions",
+            "s3MultipartChunksizeMb": "event.meta.collection.meta.s3MultipartChunksizeMb",
+            "providerName": "event.meta.provider.name}",
+            "defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",
+            "defaultStorageClassOverride": "event.meta.collection.meta.orca.defaultStorageClassOverride"
           }
         }
       },

--- a/modules/workflows/OrcaCopyToArchiveWorkflow/orca_copy_to_archive_workflow.asl.json
+++ b/modules/workflows/OrcaCopyToArchiveWorkflow/orca_copy_to_archive_workflow.asl.json
@@ -7,10 +7,10 @@
         "event.$": "$",
         "input.$": "$.payload",
         "config": {
-          "providerId": "{$.meta.provider.id}",
-          "executionId": "{$.cumulus_meta.execution_name}",
-          "collectionShortname": "{$.meta.collection.name}",
-          "collectionVersion": "{$.meta.collection.version}"
+          "providerId.$": "$.meta.provider.id",
+          "executionId.$": "$.cumulus_meta.execution_name",
+          "collectionShortname.$": "$.meta.collection.name",
+          "collectionVersion.$": "$.meta.collection.version"
         },
         "optionalValues": {
           "config": {

--- a/modules/workflows/OrcaCopyToArchiveWorkflow/orca_copy_to_archive_workflow.asl.json
+++ b/modules/workflows/OrcaCopyToArchiveWorkflow/orca_copy_to_archive_workflow.asl.json
@@ -4,6 +4,7 @@
   "States": {
     "CopyToArchive": {
       "Parameters": {
+        "event.$": "$",
         "input.$": "$.payload",
         "config": {
           "providerId": "{$.meta.provider.id}",

--- a/tasks/copy_to_archive/API.md
+++ b/tasks/copy_to_archive/API.md
@@ -6,6 +6,7 @@
   * [task](#copy_to_archive.task)
   * [get\_destination\_bucket\_name](#copy_to_archive.get_destination_bucket_name)
   * [get\_storage\_class](#copy_to_archive.get_storage_class)
+  * [set\_optional\_event\_property](#copy_to_archive.set_optional_event_property)
   * [handler](#copy_to_archive.handler)
 * [sqs\_library](#sqs_library)
   * [retry\_error](#sqs_library.retry_error)
@@ -88,11 +89,10 @@ Also queries the destination_bucket to get additional metadata file info.
 #### task
 
 ```python
-def task(event: Dict[str, Union[List[str], Dict]],
-         context: object) -> Dict[str, Any]
+def task(task_input: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]
 ```
 
-Copies the files in {event}['input']
+Copies the files in input['files']
 to the ORCA archive bucket defined in ORCA_DEFAULT_BUCKET.
 
 Environment Variables:
@@ -107,8 +107,8 @@ SQS URL of the metadata queue.
 
 **Arguments**:
 
-- `event` - Passed through from {handler}
-- `context` - An object required by AWS Lambda. Unused.
+- `task_input` - See schemas/input.json
+- `config` - See schemas/config.json
   
 
 **Returns**:
@@ -168,16 +168,40 @@ Must match value in storage_class table.
 
   The name of the storage class to use.
 
+<a id="copy_to_archive.set_optional_event_property"></a>
+
+#### set\_optional\_event\_property
+
+```python
+def set_optional_event_property(event: Dict[str,
+                                            Any], target_path_cursor: Dict,
+                                target_path_segments: List) -> None
+```
+
+Sets the optional variable value from event if present, otherwise sets to None.
+
+**Arguments**:
+
+- `event` - See schemas/input.json.
+- `target_path_cursor` - Cursor of the current section to check.
+- `target_path_segments` - The path to the current cursor.
+
+**Returns**:
+
+  None
+
 <a id="copy_to_archive.handler"></a>
 
 #### handler
 
 ```python
-def handler(event: Dict[str, Union[List[str], Dict]], context: object) -> Any
+@LOGGER.inject_lambda_context
+def handler(event: Dict[str, Union[List[str], Dict]],
+            context: LambdaContext) -> Any
 ```
 
 Lambda handler. Runs a cumulus task that
-Copies the files in {event}['input']
+Copies the files in event['input']['files']
 to the default ORCA bucket. Environment variables must be set to
 provide a default ORCA bucket to store the files in.
 
@@ -199,13 +223,13 @@ METADATA_DB_QUEUE_URL (string, required): SQS URL of the metadata queue.
 - `event` - Event passed into the step from the aws workflow.
   See schemas/input.json and schemas/config.json for more information.
   
-  
-- `context` - An object required by AWS Lambda. Unused.
+- `context` - This object provides information about the lambda invocation, function,
+  and execution env.
   
 
 **Returns**:
 
-  The result of the cumulus task. See schemas/output.json for more information.
+  See schemas/output.json for more information.
 
 <a id="sqs_library"></a>
 

--- a/tasks/copy_to_archive/README.md
+++ b/tasks/copy_to_archive/README.md
@@ -246,10 +246,10 @@ These settings can often be derived from the collection configuration in Cumulus
       "Parameters": {
         "input.$": "$.payload",
         "config": {
-          "providerId": "{$.meta.provider.id}",
-          "executionId": "{$.cumulus_meta.execution_name}",
-          "collectionShortname": "{$.meta.collection.name}",
-          "collectionVersion": "{$.meta.collection.version}"
+          "providerId": "$.meta.provider.id",
+          "executionId": "$.cumulus_meta.execution_name",
+          "collectionShortname": "$.meta.collection.name",
+          "collectionVersion": "$.meta.collection.version"
         },
         "optionalValues": {
           "config": {

--- a/tasks/copy_to_archive/README.md
+++ b/tasks/copy_to_archive/README.md
@@ -13,13 +13,13 @@ It also sends additional metadata attributes to metadata SQS queue needed for Cu
 You are able to specify a list of file types (extensions) that you'd like to exclude from the backup/copy_to_archive functionality. This is done on a per-collection basis, configured in the Cumulus collection configuration under the `meta.orca.excludedFileExtensions` key:
 
 ```json
-      "collection": {
-        "meta": {
-            "orca":{
-                "excludedFileExtensions": [".xml", ".cmr", ".cmr.xml"]
-            }
+"collection": {
+    "meta": {
+        "orca": {
+            "excludedFileExtensions": [".xml", ".cmr", ".cmr.xml"]
         }
-
+    }
+}
 ```
 
 Note that this must be done for _each_ collection configured. If this list is empty or not included in the meta configuration, the `copy_to_archive` function will include files with all extensions in the backup.
@@ -228,7 +228,9 @@ The `providerId`, `executionId`, `collectionShortname`, and `collectionVersion` 
 `config` object as seen below, 
 while the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerName`, `defaultBucketOverride`, and `defaultStorageClassOverride` are stored as paths, and will be retrieved in-code.
 Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json), 
-the values of the keys are used the following ways. The `provider` key should contain an `id` key that returns the provider id from Cumulus. The `cumulus_meta` key should contain an `execution_name` key that returns the step function execution ID from AWS. 
+the values of the keys are used the following ways. 
+The `provider` key should contain an `id` key that returns the provider id from Cumulus. 
+The `cumulus_meta` key should contain an `execution_name` key that returns the step function execution ID from AWS. 
 The `collection` key value should contain a `name` key and a `version` key that return the required collection shortname and collection version from Cumulus respectively.
 The `collection` key value should also contain a `meta` key that includes an `orca` key having an optional `excludedFileExtensions` key that is used to determine file patterns that should not be 
 sent to ORCA.

--- a/tasks/copy_to_archive/README.md
+++ b/tasks/copy_to_archive/README.md
@@ -222,11 +222,11 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_orca`
 }
 ```
 
-## Configuration
+## Workflow Configuration
 
 The `providerId`, `executionId`, `collectionShortname`, and `collectionVersion` keys must be present under the 
-`config` object as seen below, 
-while the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerName`, `defaultBucketOverride`, and `defaultStorageClassOverride` are stored as paths, and will be retrieved in-code.
+`config` object as seen below.
+`excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerName`, `defaultBucketOverride`, and `defaultStorageClassOverride` are stored as paths, and will be retrieved in-code, defaulting to `null`.
 Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json), 
 the values of the keys are used the following ways. 
 The `provider` key should contain an `id` key that returns the provider id from Cumulus. 

--- a/tasks/copy_to_archive/README.md
+++ b/tasks/copy_to_archive/README.md
@@ -222,7 +222,7 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_orca`
 }
 ```
 
-## Workflow Configuration
+## Step Function Configuration
 
 The `providerId`, `executionId`, `collectionShortname`, and `collectionVersion` keys must be present under the 
 `config` object as seen below.

--- a/tasks/copy_to_archive/README.md
+++ b/tasks/copy_to_archive/README.md
@@ -4,7 +4,8 @@ Visit the [Developer Guide](https://nasa.github.io/cumulus-orca/docs/developer/d
 
 ## Description
 
-The `copy_to_archive` module is meant to be deployed as a lambda function that takes a Cumulus message, extracts a list of files, and copies those files from their current storage location into an ORCA archive bucket. It also sends additional metadata attributes to metadata SQS queue needed for Cumulus reconciliation.
+The `copy_to_archive` module is a lambda function that takes a message, extracts a list of files, and copies those files from their current storage location into an ORCA archive bucket. 
+It also sends additional metadata attributes to metadata SQS queue needed for Cumulus reconciliation.
 
 
 ## Exclude files by extension.
@@ -12,7 +13,7 @@ The `copy_to_archive` module is meant to be deployed as a lambda function that t
 You are able to specify a list of file types (extensions) that you'd like to exclude from the backup/copy_to_archive functionality. This is done on a per-collection basis, configured in the Cumulus collection configuration under the `meta.orca.excludedFileExtensions` key:
 
 ```json
-      "collection":{
+      "collection": {
         "meta": {
             "orca":{
                 "excludedFileExtensions": [".xml", ".cmr", ".cmr.xml"]
@@ -89,13 +90,13 @@ The `copy_to_archive` lambda function can be deployed using terraform using the 
 
 ## Input
 
-The `handler` function `handler(event, context)` expects input as a Cumulus Message. Event is passed from the AWS step function workflow. The actual format of that input may change over time, so we use the [cumulus-message-adapter](https://github.com/nasa/cumulus-message-adapter) package (check `requirements.txt`), which Cumulus develops and updates, to parse the input.
+The `handler` function `handler(event, context)` expects input as a Cumulus Message. Event is passed from the AWS step function workflow.
 
-The `copy_to_archive` lambda function expects that the input payload has a `granules` object, similar to the output of `MoveGranulesStep`:
+The `copy_to_archive` lambda function expects that the input has a `granules` object, similar to the output of `MoveGranulesStep`:
 
 ```json
 {
-  "payload": {
+  "input": {
     "granules": [
       {
         "granuleId": "MOD09GQ.A2017025.h21v00.006.2017034065109",
@@ -223,13 +224,17 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_orca`
 
 ## Configuration
 
-As part of the [Cumulus Message Adapter configuration](https://nasa.github.io/cumulus/docs/workflows/input_output#cma-configuration) 
-for `copy_to_archive`, the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerId`, `executionId`, `collectionShortname`, `collectionVersion` and `defaultBucketOverride` keys must be present under the 
-`task_config` object as seen below. Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json), 
+The `providerId`, `executionId`, `collectionShortname`, and `collectionVersion` and keys must be present under the 
+`config` object as seen below, 
+while the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerName`, `defaultBucketOverride`, and `defaultStorageClassOverride` are stored as paths, and will be retrieved in-code.
+Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json), 
 the values of the keys are used the following ways. The `provider` key should contain an `id` key that returns the provider id from Cumulus. The `cumulus_meta` key should contain an `execution_name` key that returns the step function execution ID from AWS. 
 The `collection` key value should contain a `name` key and a `version` key that return the required collection shortname and collection version from Cumulus respectively.
 The `collection` key value should also contain a `meta` key that includes an `orca` key having an optional `excludedFileExtensions` key that is used to determine file patterns that should not be 
-sent to ORCA. In addition, the `orca` key also contains optional `defaultBucketOverride` key that overrides the `ORCA_DEFAULT_BUCKET` set on deployment and optional `defaultStorageClassOverride` key that overrides the storage class to use when storing files in Orca. The optional `s3MultipartChunksizeMb` is used to override the default setting for the lambda s3 copy maximum multipart chunk size value when copying large files to ORCA.
+sent to ORCA.
+The `orca` key also contains optional `defaultBucketOverride` key that overrides the `ORCA_DEFAULT_BUCKET` set on deployment,
+and the optional `defaultStorageClassOverride` key that overrides the storage class to use when storing files in Orca.
+The optional `s3MultipartChunksizeMb` is used to override the default setting for the lambda s3 copy maximum multipart chunk size value when copying large files to ORCA.
 These settings can often be derived from the collection configuration in Cumulus as seen below:
 
 ```
@@ -237,17 +242,20 @@ These settings can often be derived from the collection configuration in Cumulus
   "States": {
     "CopyToArchive": {
       "Parameters": {
-        "cma": {
-          "event.$": "$",
-          "task_config": {
-            "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
-            "excludedFileExtensions": "{$.meta.collection.meta.orca.excludedFileExtensions}",
-            "providerId": "{$.meta.provider.id}",
-            "providerName": "{$.meta.provider.name}",
-            "executionId": "{$.cumulus_meta.execution_name}",
-            "collectionShortname": "{$.meta.collection.name}",
-            "collectionVersion": "{$.meta.collection.version}",
-            "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}"
+        "input.$": "$.payload",
+        "config": {
+          "providerId": "{$.meta.provider.id}",
+          "executionId": "{$.cumulus_meta.execution_name}",
+          "collectionShortname": "{$.meta.collection.name}",
+          "collectionVersion": "{$.meta.collection.version}"
+        },
+        "optionalValues": {
+          "config": {
+            "excludedFileExtensions": "event.meta.collection.meta.orca.excludedFileExtensions",
+            "s3MultipartChunksizeMb": "event.meta.collection.meta.s3MultipartChunksizeMb",
+            "providerName": "event.meta.provider.name}",
+            "defaultBucketOverride": "event.meta.collection.meta.orca.defaultBucketOverride",
+            "defaultStorageClassOverride": "event.meta.collection.meta.orca.defaultStorageClassOverride"
           }
         }
       },

--- a/tasks/copy_to_archive/README.md
+++ b/tasks/copy_to_archive/README.md
@@ -224,7 +224,7 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_orca`
 
 ## Configuration
 
-The `providerId`, `executionId`, `collectionShortname`, and `collectionVersion` and keys must be present under the 
+The `providerId`, `executionId`, `collectionShortname`, and `collectionVersion` keys must be present under the 
 `config` object as seen below, 
 while the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerName`, `defaultBucketOverride`, and `defaultStorageClassOverride` are stored as paths, and will be retrieved in-code.
 Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json), 

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -11,10 +11,10 @@ from typing import Any, Dict, List, Union
 
 # Third party libraries
 import boto3
+import fastjsonschema as fastjsonschema
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.s3.transfer import MB, TransferConfig
-import fastjsonschema as fastjsonschema
 from fastjsonschema import JsonSchemaException
 
 import sqs_library

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -202,7 +202,8 @@ def task(task_input: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
     try:
         metadata_queue_url = os.environ.get(OS_ENVIRON_METADATA_DB_QUEUE_URL_KEY)
         if metadata_queue_url is None or len(metadata_queue_url) == 0:
-            raise KeyError(f"{OS_ENVIRON_METADATA_DB_QUEUE_URL_KEY} environment variable is not set.")
+            raise KeyError(
+                f"{OS_ENVIRON_METADATA_DB_QUEUE_URL_KEY} environment variable is not set.")
     except KeyError:
         LOGGER.error(f"{OS_ENVIRON_METADATA_DB_QUEUE_URL_KEY} environment variable is not set.")
         raise
@@ -213,9 +214,9 @@ def task(task_input: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
     # initiate empty SQS body dict
     sqs_body = {"provider": {}, "collection": {}, "granule": {}}
     sqs_body["provider"]["name"] = config.get(CONFIG_PROVIDER_NAME_KEY, None)
-    sqs_body["provider"]["providerId"] = CONFIG_PROVIDER_ID_KEY
-    sqs_body["collection"]["shortname"] = CONFIG_COLLECTION_SHORT_NAME_KEY
-    sqs_body["collection"]["version"] = CONFIG_COLLECTION_VERSION_KEY
+    sqs_body["provider"]["providerId"] = config[CONFIG_PROVIDER_ID_KEY]
+    sqs_body["collection"]["shortname"] = config[CONFIG_COLLECTION_SHORT_NAME_KEY]
+    sqs_body["collection"]["version"] = config[CONFIG_COLLECTION_VERSION_KEY]
     # Cumulus currently creates collectionId by concatenating
     # shortname + ___ + version
     # See https://github.com/nasa/cumulus-dashboard/blob/
@@ -345,9 +346,6 @@ def get_storage_class(config: Dict[str, Any]) -> str:
         The name of the storage class to use.
     """
     try:
-        # run_cumulus_task checked config against config.json,
-        # so the number of values this can be is limited.
-        storage_class = config[CONFIG_DEFAULT_STORAGE_CLASS_OVERRIDE_KEY]
         # run_cumulus_task checked config against config.json,
         # so the number of values this can be is limited.
         storage_class = config[CONFIG_DEFAULT_STORAGE_CLASS_OVERRIDE_KEY]

--- a/tasks/copy_to_archive/requirements-dev.txt
+++ b/tasks/copy_to_archive/requirements-dev.txt
@@ -1,8 +1,7 @@
-cumulus-process==0.8.0
 boto3==1.18.40
 pytest==6.2.5
 coverage==5.3
-fastjsonschema==2.15.0
+fastjsonschema=~2.15.1
 moto[sqs]==2.0.6
 aws_lambda_powertools==1.31.0
 

--- a/tasks/copy_to_archive/requirements-dev.txt
+++ b/tasks/copy_to_archive/requirements-dev.txt
@@ -1,9 +1,9 @@
 boto3==1.18.40
 pytest==6.2.5
+aws_lambda_powertools==1.31.0
 coverage==5.3
 fastjsonschema~=2.15.1
 moto[sqs]==2.0.6
-aws_lambda_powertools==1.31.0
 
 ## Additional validation libraries
 ## ---------------------------------------------------------------------------

--- a/tasks/copy_to_archive/requirements-dev.txt
+++ b/tasks/copy_to_archive/requirements-dev.txt
@@ -1,7 +1,7 @@
 boto3==1.18.40
 pytest==6.2.5
 coverage==5.3
-fastjsonschema=~2.15.1
+fastjsonschema~=2.15.1
 moto[sqs]==2.0.6
 aws_lambda_powertools==1.31.0
 

--- a/tasks/copy_to_archive/requirements.txt
+++ b/tasks/copy_to_archive/requirements.txt
@@ -1,4 +1,3 @@
-cumulus-process==0.8.0
 boto3==1.18.40
-fastjsonschema==2.15.0
+fastjsonschema=~2.15.1
 aws_lambda_powertools==1.31.0

--- a/tasks/copy_to_archive/requirements.txt
+++ b/tasks/copy_to_archive/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.18.40
-fastjsonschema=~2.15.1
+fastjsonschema~=2.15.1
 aws_lambda_powertools==1.31.0

--- a/tasks/copy_to_archive/test/unit_tests/test_copy_to_archive.py
+++ b/tasks/copy_to_archive/test/unit_tests/test_copy_to_archive.py
@@ -9,9 +9,11 @@ from unittest import TestCase
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import boto3
+
 # noinspection PyPackageRequirements
 import fastjsonschema as fastjsonschema
 from boto3.s3.transfer import MB
+
 # noinspection PyPackageRequirements
 from moto import mock_sqs
 

--- a/tasks/copy_to_archive_adapter/API.md
+++ b/tasks/copy_to_archive_adapter/API.md
@@ -1,0 +1,63 @@
+# Table of Contents
+
+* [copy\_to\_archive\_adapter](#copy_to_archive_adapter)
+  * [task](#copy_to_archive_adapter.task)
+  * [handler](#copy_to_archive_adapter.handler)
+
+<a id="copy_to_archive_adapter"></a>
+
+# copy\_to\_archive\_adapter
+
+Name: copy_to_archive.py
+Description: Lambda function that takes a Cumulus message, extracts a list of files,
+and copies those files from their current storage location into a staging/archive location.
+
+<a id="copy_to_archive_adapter.task"></a>
+
+#### task
+
+```python
+def task(event: Dict[str, Union[List[str], Dict]],
+         context: object) -> Dict[str, Any]
+```
+
+Converts event to a format accepted by ORCA's copy_to_archive lambda.
+
+**Arguments**:
+
+- `event` - Passed through from {handler}
+- `context` - An object required by AWS Lambda. Unused.
+  
+
+**Returns**:
+
+  A dict representing files to copy. See schemas/output.json for more information.
+
+<a id="copy_to_archive_adapter.handler"></a>
+
+#### handler
+
+```python
+@LOGGER.inject_lambda_context
+def handler(event: Dict[str, Union[List[str], Dict]],
+            context: LambdaContext) -> Any
+```
+
+Lambda handler. Runs a cumulus task that
+Formats the input from the Cumulus format
+to the format required by ORCA's copy_to_archive Lambda.
+
+**Arguments**:
+
+- `event` - Event passed into the step from the aws workflow.
+  See schemas/input.json and schemas/config.json for more information.
+  
+  
+- `context` - This object provides information about the lambda invocation, function,
+  and execution env.
+  
+
+**Returns**:
+
+  The result of the cumulus task. See schemas/output.json for more information.
+

--- a/tasks/copy_to_archive_adapter/API.md
+++ b/tasks/copy_to_archive_adapter/API.md
@@ -21,17 +21,22 @@ def task(event: Dict[str, Union[List[str], Dict]],
          context: object) -> Dict[str, Any]
 ```
 
-Converts event to a format accepted by ORCA's copy_to_archive lambda.
+Converts event to a format accepted by ORCA's copy_to_archive lambda,
+then calls copy_to_archive and returns the result.
 
 **Arguments**:
 
 - `event` - Passed through from {handler}
 - `context` - An object required by AWS Lambda. Unused.
   
+  Environment Variables:
+  COPY_TO_ARCHIVE_ARN (string, required):
+  ARN of ORCA's copy_to_archive lambda.
+  
 
 **Returns**:
 
-  A dict representing files to copy. See schemas/output.json for more information.
+  A dict representing input and copied files. See schemas/output.json for more information.
 
 <a id="copy_to_archive_adapter.handler"></a>
 
@@ -45,16 +50,20 @@ def handler(event: Dict[str, Union[List[str], Dict]],
 
 Lambda handler. Runs a cumulus task that
 Formats the input from the Cumulus format
-to the format required by ORCA's copy_to_archive Lambda.
+to the format required by ORCA's copy_to_archive Lambda,
+then calls copy_to_archive and returns the result.
 
 **Arguments**:
 
 - `event` - Event passed into the step from the aws workflow.
   See schemas/input.json and schemas/config.json for more information.
   
-  
 - `context` - This object provides information about the lambda invocation, function,
   and execution env.
+  
+  Environment Variables:
+  COPY_TO_ARCHIVE_ARN (string, required):
+  ARN of ORCA's copy_to_archive lambda.
   
 
 **Returns**:

--- a/tasks/copy_to_archive_adapter/README.md
+++ b/tasks/copy_to_archive_adapter/README.md
@@ -1,13 +1,28 @@
-[![Known Vulnerabilities](https://snyk.io/test/github/nasa/cumulus-orca/badge.svg?targetFile=tasks/copy_to_archive/requirements.txt)](https://snyk.io/test/github/nasa/cumulus-orca?targetFile=tasks/copy_to_archive/requirements.txt)
+[![Known Vulnerabilities](https://snyk.io/test/github/nasa/cumulus-orca/badge.svg?targetFile=tasks/copy_to_archive_adapter/requirements.txt)](https://snyk.io/test/github/nasa/cumulus-orca?targetFile=tasks/copy_to_archive_adapter/requirements.txt)
 
 Visit the [Developer Guide](https://nasa.github.io/cumulus-orca/docs/developer/development-guide/code/contrib-code-intro) for information on environment setup and testing.
 
 ## Description
 
-The `copy_to_archive_adapter` module is meant to be deployed as a lambda function that takes a Cumulus message 
-and runs it through the cumulus-process library to remove Cumulus-specific formatting.
+The `copy_to_archive` module is meant to be deployed as a lambda function that takes a Cumulus message, extracts a list of files, and copies those files from their current storage location into an ORCA archive bucket. 
+It also sends additional metadata attributes to metadata SQS queue needed for Cumulus reconciliation.
 
-The next step in your workflow should be the `copy_to_archive` lambda, which takes this lambda's output as input.
+
+## Exclude files by extension.
+
+You are able to specify a list of file types (extensions) that you'd like to exclude from the backup/copy_to_archive functionality. This is done on a per-collection basis, configured in the Cumulus collection configuration under the `meta.orca.excludedFileExtensions` key:
+
+```json
+"collection": {
+    "meta": {
+        "orca": {
+            "excludedFileExtensions": [".xml", ".cmr", ".cmr.xml"]
+        }
+    }
+}
+```
+
+Note that this must be done for _each_ collection configured. If this list is empty or not included in the meta configuration, the `copy_to_archive` function will include files with all extensions in the backup.
 
 ## Build
 
@@ -148,11 +163,128 @@ See the schema [input file](https://github.com/nasa/cumulus-orca/blob/master/tas
 
 ## Output
 
-Output will match the format accepted in https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/input.json
+The `copy_to_archive` lambda will, as the name suggests, copy a file from its current source destination. The destination location is defined as 
+`${archive_bucket}/${filepath}`, where `${archive_bucket}` is pulled from the environment variable `ORCA_DEFAULT_BUCKET` and `${filepath}` is pulled from the Cumulus granule object input.
+
+The output of this lambda is a dictionary with a `granules` and `copied_to_orca` attributes.  See the schema [output file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/output.json) for more information. Below is an example of the output:
 
 ```json
-todo
+{
+	"granules": [
+    {
+      "granuleId": "MOD09GQ.A2017025.h21v00.006.2017034065109",
+      "dataType": "MOD09GQ",
+      "version": "006",
+      "createdAt": 628021800000,
+      "files": [
+        {
+          "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+          "path": "MOD09GQ/006",
+          "size": 6,
+          "time": 1608318366000,
+          "bucket": "orca-sandbox-internal",
+          "url_path": "MOD09GQ/006/",
+          "type": "",
+          "filename": "s3://orca-sandbox-internal/file-staging/orca-sandbox/MOD09GQ___006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+          "fileStagingDir": "file-staging/orca-sandbox/MOD09GQ___006"
+        },
+        {
+          "name": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+          "path": "MOD09GQ/006",
+          "size": 6,
+          "time": 1608318366000,
+          "bucket": "orca-sandbox-internal",
+          "url_path": "MOD09GQ/006",
+          "type": "",
+          "filename": "s3://orca-sandbox-internal/file-staging/orca-sandbox/MOD09GQ___006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+          "fileStagingDir": "file-staging/orca-sandbox/MOD09GQ___006"
+        },
+        {
+          "name": "MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+          "path": "MOD09GQ/006",
+          "size": 6,
+          "time": 1608318372000,
+          "bucket": "orca-sandbox-internal",
+          "url_path": "MOD09GQ/006",
+          "type": "",
+          "filename": "s3://orca-sandbox-internal/file-staging/orca-sandbox/MOD09GQ___006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+          "fileStagingDir": "file-staging/orca-sandbox/MOD09GQ___006"
+        }
+      ],
+      "sync_granule_duration": 1676
+    }
+  ],
+	"copied_to_orca": [
+      "s3://orca-sandbox-protected/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+      "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+      "s3://orca-sandbox-public/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+      "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml"
+  ]
+}
 ```
+
+## Configuration
+
+As part of the [Cumulus Message Adapter configuration](https://nasa.github.io/cumulus/docs/workflows/input_output#cma-configuration) 
+for `copy_to_archive`, the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerId`, `executionId`, `collectionShortname`, `collectionVersion`, `defaultBucketOverride`, and `defaultStorageClassOverride` keys must be present under the 
+`task_config` object as seen below. 
+Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json), 
+the values of the keys are used the following ways. 
+The `provider` key should contain an `id` key that returns the provider id from Cumulus. 
+The `cumulus_meta` key should contain an `execution_name` key that returns the step function execution ID from AWS. 
+The `collection` key value should contain a `name` key and a `version` key that return the required collection shortname and collection version from Cumulus respectively.
+The `collection` key value should also contain a `meta` key that includes an `orca` key having an optional `excludedFileExtensions` key that is used to determine file patterns that should not be 
+sent to ORCA. In addition, the `orca` key also contains optional `defaultBucketOverride` key that overrides the `ORCA_DEFAULT_BUCKET` set on deployment and optional `defaultStorageClassOverride` key that overrides the storage class to use when storing files in Orca. 
+The optional `s3MultipartChunksizeMb` is used to override the default setting for the lambda s3 copy maximum multipart chunk size value when copying large files to ORCA.
+These settings can often be derived from the collection configuration in Cumulus as seen below:
+
+```
+{
+  "States": {
+    "CopyToArchive": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
+            "excludedFileExtensions": "{$.meta.collection.meta.orca.excludedFileExtensions}",
+            "providerId": "{$.meta.provider.id}",
+            "providerName": "{$.meta.provider.name}",
+            "executionId": "{$.cumulus_meta.execution_name}",
+            "collectionShortname": "{$.meta.collection.name}",
+            "collectionVersion": "{$.meta.collection.version}",
+            "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${orca_lambda_copy_to_archive_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.exception",
+          "Next": "WorkflowFailed"
+        }
+      ]
+    }
+  }
+}
+```
+See the schema [configuration file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json) for more information.
 
 ## pydoc copy_to_archive_adapter
 [See the API documentation for more details.](API.md)

--- a/tasks/copy_to_archive_adapter/README.md
+++ b/tasks/copy_to_archive_adapter/README.md
@@ -225,7 +225,7 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_orca`
 }
 ```
 
-## Workflow Configuration
+## Step Function Configuration
 
 As part of the [Cumulus Message Adapter configuration](https://nasa.github.io/cumulus/docs/workflows/input_output#cma-configuration) 
 for `copy_to_archive`, the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerId`, `executionId`, `collectionShortname`, `collectionVersion`, `defaultBucketOverride`, and `defaultStorageClassOverride` keys must be present under the 

--- a/tasks/copy_to_archive_adapter/README.md
+++ b/tasks/copy_to_archive_adapter/README.md
@@ -225,7 +225,7 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_orca`
 }
 ```
 
-## Configuration
+## Workflow Configuration
 
 As part of the [Cumulus Message Adapter configuration](https://nasa.github.io/cumulus/docs/workflows/input_output#cma-configuration) 
 for `copy_to_archive`, the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerId`, `executionId`, `collectionShortname`, `collectionVersion`, `defaultBucketOverride`, and `defaultStorageClassOverride` keys must be present under the 

--- a/tasks/copy_to_archive_adapter/README.md
+++ b/tasks/copy_to_archive_adapter/README.md
@@ -7,6 +7,8 @@ Visit the [Developer Guide](https://nasa.github.io/cumulus-orca/docs/developer/d
 The `copy_to_archive` module is meant to be deployed as a lambda function that takes a Cumulus message, extracts a list of files, and copies those files from their current storage location into an ORCA archive bucket. 
 It also sends additional metadata attributes to metadata SQS queue needed for Cumulus reconciliation.
 
+This lambda calls copy_to_archive synchronously, returning results and raising errors as appropriate.
+This provides an injection seam to contact the ORCA managed copy_to_archive lambda with ORCA's formatting.
 
 ## Exclude files by extension.
 
@@ -158,7 +160,7 @@ The `copy_to_archive_adapter` lambda function expects that the input payload has
 ```
 From the json file, the `filepath` shows the current S3 location of files that need to be copied over to archive bucket such as `"filename": "s3://orca-sandbox-protected/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf"`.
 **Note:** We suggest that the `copy_to_archive_adapter` task be placed any time after the `MoveGranulesStep`. It will propagate the input `granules` object as output, so it can be used as the last task in the workflow.
-See the schema [input file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/input.json) for more information.
+See the schema [input file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/input.json) for more information.
 
 
 ## Output
@@ -166,7 +168,7 @@ See the schema [input file](https://github.com/nasa/cumulus-orca/blob/master/tas
 The `copy_to_archive` lambda will, as the name suggests, copy a file from its current source destination. The destination location is defined as 
 `${archive_bucket}/${filepath}`, where `${archive_bucket}` is pulled from the environment variable `ORCA_DEFAULT_BUCKET` and `${filepath}` is pulled from the Cumulus granule object input.
 
-The output of this lambda is a dictionary with a `granules` and `copied_to_orca` attributes.  See the schema [output file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/output.json) for more information. Below is an example of the output:
+The output of this lambda is a dictionary with a `granules` and `copied_to_orca` attributes.  See the schema [output file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/output.json) for more information. Below is an example of the output:
 
 ```json
 {
@@ -228,7 +230,7 @@ The output of this lambda is a dictionary with a `granules` and `copied_to_orca`
 As part of the [Cumulus Message Adapter configuration](https://nasa.github.io/cumulus/docs/workflows/input_output#cma-configuration) 
 for `copy_to_archive`, the `excludedFileExtensions`, `s3MultipartChunksizeMb`, `providerId`, `executionId`, `collectionShortname`, `collectionVersion`, `defaultBucketOverride`, and `defaultStorageClassOverride` keys must be present under the 
 `task_config` object as seen below. 
-Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json), 
+Per the [config schema](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/config.json), 
 the values of the keys are used the following ways. 
 The `provider` key should contain an `id` key that returns the provider id from Cumulus. 
 The `cumulus_meta` key should contain an `execution_name` key that returns the step function execution ID from AWS. 
@@ -284,7 +286,7 @@ These settings can often be derived from the collection configuration in Cumulus
   }
 }
 ```
-See the schema [configuration file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json) for more information.
+See the schema [configuration file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/config.json) for more information.
 
 ## pydoc copy_to_archive_adapter
 [See the API documentation for more details.](API.md)

--- a/tasks/copy_to_archive_adapter/README.md
+++ b/tasks/copy_to_archive_adapter/README.md
@@ -1,0 +1,158 @@
+[![Known Vulnerabilities](https://snyk.io/test/github/nasa/cumulus-orca/badge.svg?targetFile=tasks/copy_to_archive/requirements.txt)](https://snyk.io/test/github/nasa/cumulus-orca?targetFile=tasks/copy_to_archive/requirements.txt)
+
+Visit the [Developer Guide](https://nasa.github.io/cumulus-orca/docs/developer/development-guide/code/contrib-code-intro) for information on environment setup and testing.
+
+## Description
+
+The `copy_to_archive_adapter` module is meant to be deployed as a lambda function that takes a Cumulus message 
+and runs it through the cumulus-process library to remove Cumulus-specific formatting.
+
+The next step in your workflow should be the `copy_to_archive` lambda, which takes this lambda's output as input.
+
+## Build
+
+To build the **copy_to_archive_adapter** lambda, run the `bin/build.sh` script from the
+`tasks/copy_to_archive_adapter` directory in a docker
+container. The following shows setting up a container to run the script.
+
+```bash
+# Invoke a docker container in interactive mode.
+user$ docker run \
+      -it \
+      --rm \
+      -v /path/to/cumulus-orca/repo:/data \
+      amazonlinux:2 \
+      /bin/bash
+
+# Install the python development binaries
+bash-4.2# yum install python3-devel
+
+# In the container cd to /data
+bash-4.2# cd /data
+
+# Go to the task
+bash-4.2# cd tasks/copy_to_archive_adapter/
+
+# Run the tests
+bash-4.2# bin/build.sh
+```
+
+### Testing copy_to_archive_adapter
+
+To run unit tests for **copy_to_archive_adapter**, run the `bin/run_tests.sh` script from the
+`tasks/copy_to_archive_adapter` directory. Ideally, the tests should be run in a docker
+container. The following shows setting up a container to run the tests.
+
+```bash
+# Invoke a docker container in interactive mode.
+user$ docker run \
+      -it \
+      --rm \
+      -v /path/to/cumulus-orca/repo:/data \
+      amazonlinux:2 \
+      /bin/bash
+
+# Install the python development binaries
+bash-4.2# yum install python3-devel
+
+# In the container cd to /data
+bash-4.2# cd /data
+
+# Go to the task
+bash-4.2# cd tasks/copy_to_archive_adapter/
+
+# Run the tests
+bash-4.2# bin/run_tests.sh
+```
+
+Note that Bamboo will run this same script via the `bin/run_tests.sh` script found
+in the cumulus-orca base of the repo.
+
+## Deployment
+
+The `copy_to_archive_adapter` lambda function can be deployed using terraform using the example shown in TODO
+
+## Input
+
+The `handler` function `handler(event, context)` expects input as a Cumulus Message. 
+Event is passed from the AWS step function workflow. 
+The actual format of that input may change over time, so we use the [cumulus-message-adapter](https://github.com/nasa/cumulus-message-adapter) package (check `requirements.txt`), which Cumulus develops and updates, to parse the input.
+
+The `copy_to_archive_adapter` lambda function expects that the input payload has a `granules` object, similar to the output of `MoveGranulesStep`:
+
+```json
+{
+  "payload": {
+    "granules": [
+      {
+        "granuleId": "MOD09GQ.A2017025.h21v00.006.2017034065109",
+        "dataType": "MOD09GQ",
+        "version": "006",
+        "createdAt": 628021800000,
+        "files": [
+          {
+            "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+            "path": "MOD09GQ/006",
+            "size": 6,
+            "time": 1608318361000,
+            "bucket": "orca-sandbox-protected",
+            "url_path": "MOD09GQ/006/",
+            "type": "",
+            "source": "s3://orca-sandbox-protected/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+            "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf",
+            "duplicate_found": true
+          },
+          {
+            "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+            "path": "MOD09GQ/006",
+            "size": 6,
+            "time": 1608318366000,
+            "bucket": "orca-sandbox-private",
+            "url_path": "MOD09GQ/006",
+            "type": "",
+            "source": "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+            "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf.met",
+            "duplicate_found": true
+          },
+          {
+            "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+            "path": "MOD09GQ/006",
+            "size": 6,
+            "time": 1608318372000,
+            "bucket": "orca-sandbox-public",
+            "url_path": "MOD09GQ/006",
+            "type": "",
+            "source": "s3://orca-sandbox-public/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+            "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109_ndvi.jpg",
+            "duplicate_found": true
+          },
+          {
+            "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+            "bucket": "orca-sandbox-private",
+            "source": "s3://orca-sandbox-private/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+            "type": "metadata",
+            "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.cmr.xml",
+            "url_path": "MOD09GQ/006"
+          }
+        ],
+        "sync_granule_duration": 1728
+      }
+    ]
+  }
+}
+```
+From the json file, the `filepath` shows the current S3 location of files that need to be copied over to archive bucket such as `"filename": "s3://orca-sandbox-protected/MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065109.hdf"`.
+**Note:** We suggest that the `copy_to_archive_adapter` task be placed any time after the `MoveGranulesStep`. It will propagate the input `granules` object as output, so it can be used as the last task in the workflow.
+See the schema [input file](https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/input.json) for more information.
+
+
+## Output
+
+Output will match the format accepted in https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/input.json
+
+```json
+todo
+```
+
+## pydoc copy_to_archive_adapter
+[See the API documentation for more details.](API.md)

--- a/tasks/copy_to_archive_adapter/bin/build.sh
+++ b/tasks/copy_to_archive_adapter/bin/build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+## =============================================================================
+## NAME: build.sh
+##
+##
+## DESCRIPTION
+## -----------------------------------------------------------------------------
+## Builds the lambda (task) zip file for copy_to_archive_adapter.
+##
+##
+## USAGE
+## -----------------------------------------------------------------------------
+## bin/build.sh
+##
+## This must be called from the (root) lambda directory /tasks/copy_to_archive_adapter
+## =============================================================================
+
+## Set this for Debugging only
+#set -ex
+
+## Make sure we are calling the script the correct way.
+BASEDIR=$(dirname $0)
+if [ "$BASEDIR" != "bin" ]; then
+  >&2 echo "ERROR: This script must be called from the root directory of the task lambda [bin/build.sh]."
+  exit 1
+fi
+
+
+source ../../bin/common/check_returncode.sh
+source ../../bin/common/venv_management.sh
+
+## MAIN
+## -----------------------------------------------------------------------------
+## Create the build directory. Remove it if it exists.
+echo "INFO: Creating build directory ..."
+if [ -d build ]; then
+    rm -rf build
+fi
+
+run_and_check_returncode "mkdir build"
+trap 'rm -rf build' EXIT
+
+run_and_check_returncode "create_and_activate_venv"
+trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
+run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+
+## Install the requirements
+pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org
+check_returncode $? "ERROR: pip install encountered an error."
+
+## Copy the lambda files to build
+echo "INFO: Creating the Lambda package ..."
+cp *.py build/
+check_returncode $? "ERROR: Failed to copy lambda files to build directory."
+
+## Copy the schema files to build
+echo "INFO: Copying schema files ..."
+cp -r schemas/ build/
+check_returncode $? "ERROR: Failed to copy schema files to build directory."
+
+## Create the zip archive
+cd build
+trap 'cd -;deactivate_and_delete_venv;rm -rf build;' EXIT
+run_and_check_returncode "zip -qr ../copy_to_archive_adapter.zip ."

--- a/tasks/copy_to_archive_adapter/bin/build_api.sh
+++ b/tasks/copy_to_archive_adapter/bin/build_api.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+## =============================================================================
+## NAME: build_api.sh
+##
+##
+## DESCRIPTION
+## -----------------------------------------------------------------------------
+## Builds the copy_to_archive_adapter API documentation.
+##
+##
+## USAGE
+## -----------------------------------------------------------------------------
+## bin/build_api.sh
+##
+## This must be called from the (root) lambda directory /tasks/copy_to_archive_adapter
+## =============================================================================
+
+## Set this for Debugging only
+#set -ex
+
+## Make sure we are calling the script the correct way.
+BASEDIR=$(dirname $0)
+if [ "$BASEDIR" != "bin" ]; then
+  >&2 echo "ERROR: This script must be called from the root directory copy_to_archive_adapter [bin/build_api.sh]."
+  exit 1
+fi
+
+
+source ../../bin/common/check_returncode.sh
+source ../../bin/common/venv_management.sh
+
+
+## MAIN
+## -----------------------------------------------------------------------------
+run_and_check_returncode "create_and_activate_venv"
+trap 'deactivate_and_delete_venv' EXIT
+run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+
+## Install the requirements
+pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org
+check_returncode $? "ERROR: pip install encountered an error."
+
+## Run the documentation command
+echo "INFO: Creating API documentation ..."
+pydoc-markdown -I . -m copy_to_archive_adapter --render-toc > API.md
+check_returncode $? "ERROR: Failed to create API.md file."

--- a/tasks/copy_to_archive_adapter/bin/run_tests.sh
+++ b/tasks/copy_to_archive_adapter/bin/run_tests.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+## =============================================================================
+## NAME: run_tests.sh
+##
+##
+## DESCRIPTION
+## -----------------------------------------------------------------------------
+## Tests the lambda (task) for copy_to_archive_adapter using unit tests.
+##
+##
+## USAGE
+## -----------------------------------------------------------------------------
+## bin/run_tests.sh
+##
+## This must be called from the (root) lambda directory /tasks/copy_to_archive_adapter
+## =============================================================================
+
+## Set this for Debugging only
+#set -ex
+
+## Make sure we are calling the script the correct way.
+BASEDIR=$(dirname $0)
+if [ "$BASEDIR" != "bin" ]; then
+  >&2 echo "ERROR: This script must be called from the root directory of the task lambda [bin/run_tests.sh]."
+  exit 1
+fi
+
+
+source ../../bin/common/check_returncode.sh
+source ../../bin/common/venv_management.sh
+
+## MAIN
+## -----------------------------------------------------------------------------
+run_and_check_returncode "create_and_activate_venv"
+trap 'deactivate_and_delete_venv' EXIT
+run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+
+## Install the requirements
+pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org
+check_returncode $? "ERROR: pip install encountered an error."
+
+## Check code formatting and styling
+echo "INFO: Checking formatting and style of code ..."
+echo "INFO: Sorting imports ..."
+isort \
+    --trailing-comma \
+    --ensure-newline-before-comments \
+    --line-length 88 \
+    --use-parentheses \
+    --force-grid-wrap 0 \
+    -m 3 \
+    *.py test
+
+
+echo "INFO: Formatting with black ..."
+black *.py test
+
+
+echo "INFO: Checking lint rules ..."
+flake8 \
+    --max-line-length 99 \
+    *.py test
+
+check_returncode $? "ERROR: Linting issues found."
+
+
+## Run code smell and security tests using bandit
+echo "INFO: Running code smell security tests ..."
+bandit -r *.py test
+check_returncode $? "ERROR: Potential security or code issues found."
+
+
+## Run unit tests and check Coverage
+echo "INFO: Running unit and coverage tests ..."
+
+# Currently just running unit tests until we fix/support large tests
+coverage run --source=copy_to_archive_adapter -m pytest
+check_returncode $? "ERROR: Unit tests encountered failures."
+
+# Unit tests expected to cover minimum of 80%.
+coverage report --fail-under=80
+check_returncode $? "ERROR: Unit tests coverage is less than 80%"

--- a/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
+++ b/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
@@ -42,7 +42,7 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     """
     # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html
     # 600s for copy_to_archive operation
-    config = Config(read_timeout=600, retries={'max_attempts': 0})
+    config = Config(read_timeout=600, retries={'total_max_attempts': 1})
     client = boto3.client("lambda", config=config)
     response = client.invoke(
         FunctionName=os.environ[OS_ENVIRON_COPY_TO_ARCHIVE_ARN_KEY],

--- a/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
+++ b/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
@@ -10,6 +10,11 @@ from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from run_cumulus_task import run_cumulus_task
 
+CONFIG_MULTIPART_CHUNKSIZE_MB_KEY = "s3MultipartChunksizeMb"
+CONFIG_EXCLUDED_FILE_EXTENSIONS_KEY = "excludedFileExtensions"
+CONFIG_DEFAULT_BUCKET_OVERRIDE_KEY = "defaultBucketOverride"
+CONFIG_DEFAULT_STORAGE_CLASS_OVERRIDE_KEY = "defaultStorageClassOverride"
+
 # Set AWS powertools logger
 LOGGER = Logger()
 
@@ -17,7 +22,8 @@ LOGGER = Logger()
 # noinspection PyUnusedLocal
 def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str, Any]:
     """
-    Converts event to a format accepted by ORCA's copy_to_archive lambda.
+    Converts event to a format accepted by ORCA's copy_to_archive lambda,
+    then calls copy_to_archive and returns the result.
 
     Args:
         event: Passed through from {handler}
@@ -33,7 +39,8 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
 def handler(event: Dict[str, Union[List[str], Dict]], context: LambdaContext) -> Any:
     """Lambda handler. Runs a cumulus task that
     Formats the input from the Cumulus format
-    to the format required by ORCA's copy_to_archive Lambda.
+    to the format required by ORCA's copy_to_archive Lambda,
+    then calls copy_to_archive and returns the result.
 
     Args:
         event: Event passed into the step from the aws workflow.

--- a/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
+++ b/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
@@ -1,0 +1,49 @@
+"""
+Name: copy_to_archive.py
+Description: Lambda function that takes a Cumulus message, extracts a list of files,
+and copies those files from their current storage location into a staging/archive location.
+"""
+from typing import Any, Dict, List, Union
+
+# Third party libraries
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from run_cumulus_task import run_cumulus_task
+
+# Set AWS powertools logger
+LOGGER = Logger()
+
+
+# noinspection PyUnusedLocal
+def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str, Any]:
+    """
+    Converts event to a format accepted by ORCA's copy_to_archive lambda.
+
+    Args:
+        event: Passed through from {handler}
+        context: An object required by AWS Lambda. Unused.
+
+    Returns:
+        A dict representing files to copy. See schemas/output.json for more information.
+    """
+    return event["input"]
+
+
+@LOGGER.inject_lambda_context
+def handler(event: Dict[str, Union[List[str], Dict]], context: LambdaContext) -> Any:
+    """Lambda handler. Runs a cumulus task that
+    Formats the input from the Cumulus format
+    to the format required by ORCA's copy_to_archive Lambda.
+
+    Args:
+        event: Event passed into the step from the aws workflow.
+            See schemas/input.json and schemas/config.json for more information.
+
+
+        context: This object provides information about the lambda invocation, function,
+            and execution env.
+
+    Returns:
+        The result of the cumulus task. See schemas/output.json for more information.
+    """
+    return run_cumulus_task(task, event, context)

--- a/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
+++ b/tasks/copy_to_archive_adapter/copy_to_archive_adapter.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Union
 import boto3
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
+
+# noinspection PyPackageRequirements
 from botocore.client import Config
 from run_cumulus_task import run_cumulus_task
 
@@ -47,15 +49,14 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
     response = client.invoke(
         FunctionName=os.environ[OS_ENVIRON_COPY_TO_ARCHIVE_ARN_KEY],
         InvocationType="RequestResponse",  # Synchronous
-        Payload=
-        json.dumps({
+        Payload=json.dumps({
             ORCA_INPUT_KEY: event["input"],
             ORCA_CONFIG_KEY: event["config"]
         }, indent=4).encode("utf-8")
     )
 
     if response["StatusCode"] != 200:
-        raise Exception(response["FunctionError"])
+        raise Exception(response.get("FunctionError", None))
 
     result = json.loads(response["Payload"].read())
     return result

--- a/tasks/copy_to_archive_adapter/requirements-dev.txt
+++ b/tasks/copy_to_archive_adapter/requirements-dev.txt
@@ -1,0 +1,12 @@
+cumulus-process==0.8.0
+pytest==6.2.5
+coverage==5.3
+fastjsonschema==2.15.0
+aws_lambda_powertools==1.31.0
+
+## Additional validation libraries
+## ---------------------------------------------------------------------------
+bandit==1.7.0
+flake8==4.0.1
+black==21.12b0
+isort==5.10.1

--- a/tasks/copy_to_archive_adapter/requirements-dev.txt
+++ b/tasks/copy_to_archive_adapter/requirements-dev.txt
@@ -1,8 +1,9 @@
+boto3==1.18.40
 cumulus-process==0.8.0
+aws_lambda_powertools==1.31.0
 pytest==6.2.5
 coverage==5.3
 fastjsonschema==2.15.0
-aws_lambda_powertools==1.31.0
 
 ## Additional validation libraries
 ## ---------------------------------------------------------------------------

--- a/tasks/copy_to_archive_adapter/requirements.txt
+++ b/tasks/copy_to_archive_adapter/requirements.txt
@@ -1,2 +1,3 @@
+boto3==1.18.40
 cumulus-process==0.8.0
 aws_lambda_powertools==1.31.0

--- a/tasks/copy_to_archive_adapter/requirements.txt
+++ b/tasks/copy_to_archive_adapter/requirements.txt
@@ -1,0 +1,2 @@
+cumulus-process==0.8.0
+aws_lambda_powertools==1.31.0

--- a/tasks/copy_to_archive_adapter/schemas/config.json
+++ b/tasks/copy_to_archive_adapter/schemas/config.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json",
-  "title": "copy_to_archive Lambda Config",
-  "description": "The config for the copy_to_archive Lambda.",
+  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/config.json",
+  "title": "copy_to_archive_adapter Lambda Config",
+  "description": "The config for the copy_to_archive_adapter Lambda.",
   "type": "object",
   "properties": {
     "excludedFileExtensions": {

--- a/tasks/copy_to_archive_adapter/schemas/config.json
+++ b/tasks/copy_to_archive_adapter/schemas/config.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/config.json",
+  "title": "copy_to_archive Lambda Config",
+  "description": "The config for the copy_to_archive Lambda.",
+  "type": "object",
+  "properties": {
+    "excludedFileExtensions": {
+      "type": ["array", "null"],
+      "description": "A list of file extensions to ignore when copying files.",
+      "items": {
+        "type": "string",
+        "pattern": "\\..+"
+      }
+    },
+    "s3MultipartChunksizeMb": {
+      "type": ["integer", "null"],
+      "description": "The collection's maximum size of chunks to use when copying. Defaults to environment variable."
+    },
+    "providerId": {
+      "type": "string",
+      "description": "Provider ID supplied by Cumulus"
+    },
+    "providerName": {
+      "type": ["string", "null"],
+      "description": "Provider Name supplied by Cumulus"
+    },
+    "executionId": {
+      "type": "string",
+      "description": "AWS step function execution id"
+    },
+    "collectionShortname": {
+      "type": "string",
+      "description": "Collection shortname from Cumulus"
+    },
+    "collectionVersion": {
+      "type": "string",
+      "description": "Collection version from Cumulus."
+    },
+    "defaultBucketOverride": {
+      "type": ["string", "null"],
+      "description": "Overrides the default bucket to copy to in os.environ['ORCA_DEFAULT_BUCKET']."
+    },
+    "defaultStorageClassOverride": {
+      "type": ["string", "null"],
+      "description": "The class of storage to use when ingesting files. Can be overridden by collection config. Must match value in storage_class table.",
+      "pattern": "^(GLACIER|DEEP_ARCHIVE)$"
+    }
+  },
+  "required": [ "providerId", "executionId", "collectionShortname", "collectionVersion"]
+}

--- a/tasks/copy_to_archive_adapter/schemas/input.json
+++ b/tasks/copy_to_archive_adapter/schemas/input.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/input.json",
+  "title": "copy_to_archive_adapter Lambda Input",
+  "description": "The input for the copy_to_archive_adapter Lambda.",
+  "type": "object",
+  "required": ["granules"],
+  "properties": {
+    "granules": {
+      "description": "A list of objects representing individual files to copy.",
+      "type": "array",
+      "items": {
+        "required": ["granuleId", "createdAt", "files"],
+        "properties": {
+          "granuleId": {
+            "description": "The granule's ID.",
+            "type": "string"
+          },
+          "createdAt": {
+            "description": "The time, in milliseconds since 1 January 1970 UTC, data was originally ingested into Cumulus.",
+            "type": "integer"
+          },
+          "files": {
+            "description": "The files to copy.",
+            "type": "array",
+            "items": {
+              "required": ["bucket", "key"],
+              "properties": {
+                "bucket": {
+                  "type": "string",
+                  "description": "Name of the Bucket where file is archived in S3."
+                },
+                "key": {
+                  "type": "string",
+                  "description": "S3 Key for archived file."
+                },
+                "checksum": {
+                  "type": ["string", "null"],
+                  "description": "Hash of the object from Cumulus"
+                },
+                "checksumType": {
+                  "type": ["string", "null"],
+                  "description": "Hash type used to hash the object. Supplied by Cumulus."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tasks/copy_to_archive_adapter/schemas/output.json
+++ b/tasks/copy_to_archive_adapter/schemas/output.json
@@ -1,24 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/output.json",
-  "title": "copy_to_archive_adapter Lambda Output",
-  "description": "The output for the copy_to_archive Lambda. Matches the input for ORCA's copy_to_archive Lambda.",
+  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/output.json",
+  "title": "copy_to_archive Lambda Output",
+  "description": "The output for the copy_to_archive Lambda.",
   "type": "object",
-  "required": ["granules"],
+  "required": ["granules", "copied_to_orca"],
   "properties": {
     "granules": {
-      "description": "A list of objects representing individual files to copy.",
+      "description": "The 'granules' property from the input.",
       "type": "array",
       "items": {
-        "required": ["granuleId", "createdAt", "files"],
+        "required": ["granuleId", "files"],
         "properties": {
           "granuleId": {
             "description": "The granule's ID.",
             "type": "string"
-          },
-          "createdAt": {
-            "description": "The time, in milliseconds since 1 January 1970 UTC, data was originally ingested into Cumulus.",
-            "type": "integer"
           },
           "files": {
             "description": "The files to copy.",
@@ -26,6 +22,10 @@
             "items": {
               "required": ["bucket", "key"],
               "properties": {
+                "fileName": {
+                  "type": "string",
+                  "description": "Name of file (e.g. file.txt)."
+                },
                 "bucket": {
                   "type": "string",
                   "description": "Name of the Bucket where file is archived in S3."
@@ -34,18 +34,21 @@
                   "type": "string",
                   "description": "S3 Key for archived file."
                 },
-                "checksum": {
-                  "type": ["string", "null"],
-                  "description": "Hash of the object from Cumulus"
-                },
-                "checksumType": {
-                  "type": ["string", "null"],
-                  "description": "Hash type used to hash the object. Supplied by Cumulus."
+                "source": {
+                  "type": "string",
+                  "description": "Source URI of the file from origin system (e.g. S3, FTP, HTTP)."
                 }
               }
             }
           }
         }
+      }
+    },
+    "copied_to_orca": {
+      "description": "Source URI of the file from origin s3 bucket.",
+      "type": "array",
+      "items": {
+        "type": "string"
       }
     }
   }

--- a/tasks/copy_to_archive_adapter/schemas/output.json
+++ b/tasks/copy_to_archive_adapter/schemas/output.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive/schemas/output.json",
-  "title": "copy_to_archive Lambda Output",
-  "description": "The output for the copy_to_archive Lambda.",
+  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/output.json",
+  "title": "copy_to_archive_adapter Lambda Output",
+  "description": "The output for the copy_to_archive_adapter Lambda.",
   "type": "object",
   "required": ["granules", "copied_to_orca"],
   "properties": {

--- a/tasks/copy_to_archive_adapter/schemas/output.json
+++ b/tasks/copy_to_archive_adapter/schemas/output.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/nasa/cumulus-orca/blob/master/tasks/copy_to_archive_adapter/schemas/output.json",
+  "title": "copy_to_archive_adapter Lambda Output",
+  "description": "The output for the copy_to_archive Lambda. Matches the input for ORCA's copy_to_archive Lambda.",
+  "type": "object",
+  "required": ["granules"],
+  "properties": {
+    "granules": {
+      "description": "A list of objects representing individual files to copy.",
+      "type": "array",
+      "items": {
+        "required": ["granuleId", "createdAt", "files"],
+        "properties": {
+          "granuleId": {
+            "description": "The granule's ID.",
+            "type": "string"
+          },
+          "createdAt": {
+            "description": "The time, in milliseconds since 1 January 1970 UTC, data was originally ingested into Cumulus.",
+            "type": "integer"
+          },
+          "files": {
+            "description": "The files to copy.",
+            "type": "array",
+            "items": {
+              "required": ["bucket", "key"],
+              "properties": {
+                "bucket": {
+                  "type": "string",
+                  "description": "Name of the Bucket where file is archived in S3."
+                },
+                "key": {
+                  "type": "string",
+                  "description": "S3 Key for archived file."
+                },
+                "checksum": {
+                  "type": ["string", "null"],
+                  "description": "Hash of the object from Cumulus"
+                },
+                "checksumType": {
+                  "type": ["string", "null"],
+                  "description": "Hash type used to hash the object. Supplied by Cumulus."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tasks/copy_to_archive_adapter/test/unit_tests/test_copy_to_archive.py
+++ b/tasks/copy_to_archive_adapter/test/unit_tests/test_copy_to_archive.py
@@ -1,0 +1,151 @@
+import json
+import random
+import uuid
+from unittest import TestCase
+from unittest.mock import MagicMock, Mock, patch
+
+import fastjsonschema as fastjsonschema
+from jsonschema.exceptions import ValidationError
+
+import copy_to_archive_adapter
+
+# Generating schema validators can take time, so do it once and reuse.
+with open("schemas/output.json", "r") as raw_schema:
+    _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
+
+
+class TestCopyToArchive(TestCase):
+    """
+    Test copy_to_archive_adapter functionality and business logic.
+    """
+
+    @patch("copy_to_archive_adapter.task")
+    def test_handler_happy_path(self, mock_task: MagicMock):
+        granules = [
+            {
+                "granuleId": uuid.uuid4().__str__(),
+                "dataType": uuid.uuid4().__str__(),
+                "version": uuid.uuid4().__str__(),
+                "createdAt": random.randint(0, 628021800000),  # nosec
+                "files": [
+                    {
+                        "bucket": uuid.uuid4().__str__(),
+                        "key": uuid.uuid4().__str__(),
+                        "checksum": uuid.uuid4().__str__(),
+                        "checksumType": uuid.uuid4().__str__(),
+                    }
+                ],
+            }
+        ]
+
+        config = {}  # Required by run_cumulus_task
+        handler_input_event = {
+            "payload": {"granules": granules},
+            "task_config": config,
+        }
+        handler_input_context = Mock()
+
+        expected_task_input = {
+            "input": handler_input_event["payload"],
+            "config": config,
+        }
+        mock_task.return_value = {
+            "granules": [
+                {
+                    "granuleId": uuid.uuid4().__str__(),
+                    "createdAt": random.randint(0, 999999999),
+                    "files": [
+                        {
+                            "bucket": uuid.uuid4().__str__(),
+                            "key": uuid.uuid4().__str__(),
+                            "checksum": uuid.uuid4().__str__(),
+                            "checksumType": uuid.uuid4().__str__(),
+                        }
+                    ]
+                },
+            ],
+            "copied_to_orca": [uuid.uuid4().__str__()],
+        }
+
+        result = copy_to_archive_adapter.handler(handler_input_event, handler_input_context)
+        mock_task.assert_called_once_with(expected_task_input, handler_input_context)
+
+        self.assertEqual(mock_task.return_value, result["payload"])
+
+    @patch("copy_to_archive_adapter.task")
+    def test_handler_rejects_bad_output(self, mock_task: MagicMock):
+        granules = [
+            {
+                "granuleId": uuid.uuid4().__str__(),
+                "dataType": uuid.uuid4().__str__(),
+                "version": uuid.uuid4().__str__(),
+                "createdAt": random.randint(0, 628021800000),  # nosec
+                "files": [
+                    {
+                        "bucket": uuid.uuid4().__str__(),
+                        "key": uuid.uuid4().__str__(),
+                        "checksum": uuid.uuid4().__str__(),
+                        "checksumType": uuid.uuid4().__str__(),
+                    }
+                ],
+            }
+        ]
+
+        config = {}  # Required by run_cumulus_task
+        handler_input_event = {
+            "payload": {"granules": granules},
+            "task_config": config,
+        }
+        handler_input_context = Mock()
+
+        expected_task_input = {
+            "input": handler_input_event["payload"],
+            "config": config,
+        }
+        mock_task.return_value = {
+            "granules": [
+                {
+                    "granuleId": uuid.uuid4().__str__(),
+                    "createdAt": random.randint(0, 999999999),
+                },
+            ],
+            "copied_to_orca": [uuid.uuid4().__str__()],
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            copy_to_archive_adapter.handler(handler_input_event, handler_input_context)
+        self.assertTrue(
+            str(cm.exception).startswith("output schema: 'files' is a required property"))
+        mock_task.assert_called_once_with(expected_task_input, handler_input_context)
+
+    def test_handler_integration(self):
+        """
+        Full run-through to make sure output is truly formatted input.
+        """
+        granules = [
+            {
+                "granuleId": uuid.uuid4().__str__(),
+                "dataType": uuid.uuid4().__str__(),
+                "version": uuid.uuid4().__str__(),
+                "createdAt": random.randint(0, 628021800000),  # nosec
+                "files": [
+                    {
+                        "bucket": uuid.uuid4().__str__(),
+                        "key": uuid.uuid4().__str__(),
+                        "checksum": uuid.uuid4().__str__(),
+                        "checksumType": uuid.uuid4().__str__(),
+                    }
+                ],
+            }
+        ]
+
+        config = {}  # Required by run_cumulus_task
+        handler_input_event = {
+            "payload": {"granules": granules},
+            "task_config": config,
+        }
+        handler_input_context = Mock()
+
+        result = copy_to_archive_adapter.handler(handler_input_event, handler_input_context)
+
+        self.assertEqual({"granules": granules}, result["payload"])

--- a/tasks/copy_to_archive_adapter/test/unit_tests/test_copy_to_archive_adapter.py
+++ b/tasks/copy_to_archive_adapter/test/unit_tests/test_copy_to_archive_adapter.py
@@ -1,13 +1,19 @@
 import json
+import os
 import random
 import uuid
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
+# noinspection PyPackageRequirements
 import fastjsonschema as fastjsonschema
+
+# noinspection PyPackageRequirements
 from jsonschema.exceptions import ValidationError
 
 import copy_to_archive_adapter
+
+# noinspection PyPackageRequirements
 
 # Generating schema validators can take time, so do it once and reuse.
 with open("schemas/output.json", "r") as raw_schema:
@@ -18,6 +24,135 @@ class TestCopyToArchiveAdapter(TestCase):
     """
     Test copy_to_archive_adapter functionality and business logic.
     """
+
+    @patch("copy_to_archive_adapter.Config")
+    @patch("boto3.client")
+    def test_task_happy_path(
+        self,
+        mock_boto3_client: MagicMock,
+        mock_boto3_config: MagicMock,
+    ):
+        """
+        Basic happy-path test for invoking the target lambda and receiving a 200 response.
+        """
+        copy_to_archive_arn = uuid.uuid4().__str__()
+
+        payload = {
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+        }
+        mock_payload = Mock()
+        mock_payload.read = Mock(return_value=json.dumps(payload))
+        response = {
+            "StatusCode": 200,
+            "Payload": mock_payload
+        }
+
+        mock_invoke = Mock(return_value=response)
+        mock_lambda_client = Mock()
+        mock_lambda_client.invoke = mock_invoke
+        mock_boto3_client.return_value = mock_lambda_client
+
+        mock_input = {
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+        }
+        mock_config = {
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+        }
+
+        event = {
+            "input": mock_input,
+            "config": mock_config,
+        }
+
+        with patch.dict(os.environ,
+                        {
+                            copy_to_archive_adapter.OS_ENVIRON_COPY_TO_ARCHIVE_ARN_KEY:
+                                copy_to_archive_arn
+                        }):
+            result = copy_to_archive_adapter.task(event, None)
+
+        mock_boto3_config.assert_called_once_with(
+            read_timeout=600, retries={'total_max_attempts': 1}
+        )
+        mock_boto3_client.assert_called_once_with(
+            "lambda",
+            config=mock_boto3_config.return_value
+        )
+        mock_invoke.assert_called_once_with(
+            FunctionName=copy_to_archive_arn,
+            InvocationType="RequestResponse",  # Synchronous
+            Payload=json.dumps({
+                copy_to_archive_adapter.ORCA_INPUT_KEY: mock_input,
+                copy_to_archive_adapter.ORCA_CONFIG_KEY: mock_config
+            }, indent=4).encode("utf-8")
+        )
+        mock_payload.read.assert_called_once_with()
+        self.assertEqual(payload, result)
+
+    @patch("copy_to_archive_adapter.Config")
+    @patch("boto3.client")
+    def test_task_status_code_not_200_raises_exception(
+        self,
+        mock_boto3_client: MagicMock,
+        mock_boto3_config: MagicMock,
+    ):
+        """
+        If a non-200 status code is returned, raise an error with the attached error message.
+        """
+        copy_to_archive_arn = uuid.uuid4().__str__()
+
+        error_message = uuid.uuid4().__str__()
+        response = {
+            "StatusCode": 201,  # We only expect 200, so even 201 should fail.
+            "FunctionError": error_message
+        }
+
+        mock_invoke = Mock(return_value=response)
+        mock_lambda_client = Mock()
+        mock_lambda_client.invoke = mock_invoke
+        mock_boto3_client.return_value = mock_lambda_client
+
+        mock_input = {
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+        }
+        mock_config = {
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+            uuid.uuid4().__str__(): uuid.uuid4().__str__(),
+        }
+
+        event = {
+            "input": mock_input,
+            "config": mock_config,
+        }
+
+        with patch.dict(os.environ,
+                        {
+                            copy_to_archive_adapter.OS_ENVIRON_COPY_TO_ARCHIVE_ARN_KEY:
+                                copy_to_archive_arn
+                        }):
+            with self.assertRaises(Exception) as cm:
+                copy_to_archive_adapter.task(event, None)
+
+        mock_boto3_config.assert_called_once_with(
+            read_timeout=600, retries={'total_max_attempts': 1}
+        )
+        mock_boto3_client.assert_called_once_with(
+            "lambda",
+            config=mock_boto3_config.return_value
+        )
+        mock_invoke.assert_called_once_with(
+            FunctionName=copy_to_archive_arn,
+            InvocationType="RequestResponse",  # Synchronous
+            Payload=json.dumps({
+                copy_to_archive_adapter.ORCA_INPUT_KEY: mock_input,
+                copy_to_archive_adapter.ORCA_CONFIG_KEY: mock_config
+            }, indent=4).encode("utf-8")
+        )
+        self.assertEqual(str(cm.exception), error_message)
 
     @patch("copy_to_archive_adapter.task")
     def test_handler_happy_path(self, mock_task: MagicMock):
@@ -38,7 +173,12 @@ class TestCopyToArchiveAdapter(TestCase):
             }
         ]
 
-        config = {}  # Required by run_cumulus_task
+        config = {
+            "providerId": uuid.uuid4().__str__(),
+            "executionId": uuid.uuid4().__str__(),
+            "collectionShortname": uuid.uuid4().__str__(),
+            "collectionVersion": uuid.uuid4().__str__(),
+        }
         handler_input_event = {
             "payload": {"granules": granules},
             "task_config": config,
@@ -91,7 +231,12 @@ class TestCopyToArchiveAdapter(TestCase):
             }
         ]
 
-        config = {}  # Required by run_cumulus_task
+        config = {
+            "providerId": uuid.uuid4().__str__(),
+            "executionId": uuid.uuid4().__str__(),
+            "collectionShortname": uuid.uuid4().__str__(),
+            "collectionVersion": uuid.uuid4().__str__(),
+        }
         handler_input_event = {
             "payload": {"granules": granules},
             "task_config": config,
@@ -117,35 +262,3 @@ class TestCopyToArchiveAdapter(TestCase):
         self.assertTrue(
             str(cm.exception).startswith("output schema: 'files' is a required property"))
         mock_task.assert_called_once_with(expected_task_input, handler_input_context)
-
-    def test_handler_integration(self):
-        """
-        Full run-through to make sure output is truly formatted input.
-        """
-        granules = [
-            {
-                "granuleId": uuid.uuid4().__str__(),
-                "dataType": uuid.uuid4().__str__(),
-                "version": uuid.uuid4().__str__(),
-                "createdAt": random.randint(0, 628021800000),  # nosec
-                "files": [
-                    {
-                        "bucket": uuid.uuid4().__str__(),
-                        "key": uuid.uuid4().__str__(),
-                        "checksum": uuid.uuid4().__str__(),
-                        "checksumType": uuid.uuid4().__str__(),
-                    }
-                ],
-            }
-        ]
-
-        config = {}  # Required by run_cumulus_task
-        handler_input_event = {
-            "payload": {"granules": granules},
-            "task_config": config,
-        }
-        handler_input_context = Mock()
-
-        result = copy_to_archive_adapter.handler(handler_input_event, handler_input_context)
-
-        self.assertEqual({"granules": granules}, result["payload"])

--- a/tasks/copy_to_archive_adapter/test/unit_tests/test_copy_to_archive_adapter.py
+++ b/tasks/copy_to_archive_adapter/test/unit_tests/test_copy_to_archive_adapter.py
@@ -14,7 +14,7 @@ with open("schemas/output.json", "r") as raw_schema:
     _OUTPUT_VALIDATE = fastjsonschema.compile(json.loads(raw_schema.read()))
 
 
-class TestCopyToArchive(TestCase):
+class TestCopyToArchiveAdapter(TestCase):
     """
     Test copy_to_archive_adapter functionality and business logic.
     """
@@ -53,7 +53,7 @@ class TestCopyToArchive(TestCase):
             "granules": [
                 {
                     "granuleId": uuid.uuid4().__str__(),
-                    "createdAt": random.randint(0, 999999999),
+                    "createdAt": random.randint(0, 999999999),  # nosec
                     "files": [
                         {
                             "bucket": uuid.uuid4().__str__(),
@@ -106,7 +106,7 @@ class TestCopyToArchive(TestCase):
             "granules": [
                 {
                     "granuleId": uuid.uuid4().__str__(),
-                    "createdAt": random.randint(0, 999999999),
+                    "createdAt": random.randint(0, 999999999),  # nosec
                 },
             ],
             "copied_to_orca": [uuid.uuid4().__str__()],

--- a/tasks/extract_filepaths_for_granule/API.md
+++ b/tasks/extract_filepaths_for_granule/API.md
@@ -133,38 +133,8 @@ Lambda handler. Extracts the key's for a granule from an input dict.
 
 **Arguments**:
 
-- `event` - A dict with the following keys:
-  granules (list(dict)): A list of dict with the following keys:
-- `granuleId` _string_ - The id of a granule.
-  files (list(dict)): list of dict with the following keys:
-- `key` _string_ - The key of the file to be returned.
-  other dictionary keys may be included, but are not used.
-  other dictionary keys may be included, but are not used.
-  
-
-**Example**:
-
-  {
-- `"event"` - {
-- `"granules"` - [
-  {
-- `"granuleId"` - "granxyz",
-- `"recoveryBucketOverride"` - "test-recovery-bucket",
-- `"version"` - "006",
-- `"files"` - [
-  {
-- `"fileName"` - "file1",
-- `"key"` - "key1",
-- `"source"` - "s3://dr-test-sandbox-protected/file1",
-- `"type"` - "metadata"
-  }
-  ]
-  }
-  ]
-  }
-  }
-- `context` - This object provides information about the lambda invocation, function,
-  and execution env.
+- `event` - Event passed into the step from the aws workflow.
+  See schemas/input.json and schemas/config.json for more information.
   
 
 **Returns**:

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -189,6 +189,7 @@ def should_exclude_files_type(file_key: str, exclude_file_types: List[str]) -> b
     return False
 
 
+# noinspection PyUnusedLocal
 @LOGGER.inject_lambda_context
 def handler(event: Dict[str, Dict[str, Any]],
             context: LambdaContext):  # pylint: disable-msg=unused-argument

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -246,7 +246,7 @@ def handler(event: Dict[str, Dict[str, Any]],
     Args:
         event: Event passed into the step from the aws workflow.
             See schemas/input.json and schemas/config.json for more information.
-            
+
         context: This object provides information about the lambda invocation, function,
             and execution env.
 

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -244,34 +244,9 @@ def handler(event: Dict[str, Dict[str, Any]],
     """Lambda handler. Extracts the key's for a granule from an input dict.
 
     Args:
-        event: A dict with the following keys:
-            granules (list(dict)): A list of dict with the following keys:
-                granuleId (string): The id of a granule.
-                files (list(dict)): list of dict with the following keys:
-                    key (string): The key of the file to be returned.
-                    other dictionary keys may be included, but are not used.
-                other dictionary keys may be included, but are not used.
-
-            Example:
-                    {
-                        "event": {
-                            "granules": [
-                                {
-                                    "granuleId": "granxyz",
-                                    "recoveryBucketOverride": "test-recovery-bucket",
-                                    "version": "006",
-                                    "files": [
-                                    {
-                                        "fileName": "file1",
-                                        "key": "key1",
-                                        "source": "s3://dr-test-sandbox-protected/file1",
-                                        "type": "metadata"
-                                    }
-                                    ]
-                                }
-                            ]
-                        }
-                    }
+        event: Event passed into the step from the aws workflow.
+            See schemas/input.json and schemas/config.json for more information.
+            
         context: This object provides information about the lambda invocation, function,
             and execution env.
 

--- a/tasks/extract_filepaths_for_granule/requirements.txt
+++ b/tasks/extract_filepaths_for_granule/requirements.txt
@@ -1,3 +1,2 @@
 aws_lambda_powertools==1.31.0
-cumulus-process==0.8.0
 fastjsonschema~=2.15.1

--- a/tasks/request_from_archive/API.md
+++ b/tasks/request_from_archive/API.md
@@ -281,7 +281,8 @@ The bucket to use if destBucket is not set.
 
 **Arguments**:
 
-- `event` - See schemas/input.json.
+- `event` - Event passed into the step from the aws workflow.
+  See schemas/input.json and schemas/config.json for more information.
 - `context` - This object provides information about the lambda invocation, function,
   and execution env.
 

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -704,7 +704,8 @@ def handler(event: Dict[str, Any], context: LambdaContext):  # pylint: disable-m
             ORCA_DEFAULT_BUCKET
                 The bucket to use if destBucket is not set.
         Args:
-            event: See schemas/input.json.
+            event: Event passed into the step from the aws workflow.
+                See schemas/input.json and schemas/config.json for more information.
             context: This object provides information about the lambda invocation, function,
                 and execution env.
         Returns:

--- a/tasks/request_from_archive/request_from_archive.py
+++ b/tasks/request_from_archive/request_from_archive.py
@@ -715,7 +715,6 @@ def handler(event: Dict[str, Any], context: LambdaContext):  # pylint: disable-m
             will be included in the message, with 'success' = False for
             the files for which the restore request failed to submit.
     """
-
     # set the optional variables to None if not configured
     try:
         set_optional_event_property(event, event.get(EVENT_OPTIONAL_VALUES_KEY, {}), [])
@@ -724,13 +723,13 @@ def handler(event: Dict[str, Any], context: LambdaContext):  # pylint: disable-m
         raise ex
 
     try:
-        _VALIDATE_INPUT(event["input"])
+        _VALIDATE_INPUT(event[EVENT_INPUT_KEY])
     except JsonSchemaException as json_schema_exception:
         LOGGER.error(json_schema_exception)
         raise
 
     try:
-        _VALIDATE_CONFIG(event["config"])
+        _VALIDATE_CONFIG(event[EVENT_CONFIG_KEY])
     except JsonSchemaException as json_schema_exception:
         LOGGER.error(json_schema_exception)
         raise


### PR DESCRIPTION
## Summary of Changes

Added copy_to_archive_adapter lambda that will call the copy_to_archive lambda.

Addresses [ORCA-520: Develop CMA adapter lambda for copy_to_archive](https://bugs.earthdata.nasa.gov/browse/ORCA-520)

## Changes

* copy_to_archive_adapter lambda created
* Unit tests created

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Manually deployed to AWS and run against real copy_to_glacier with real files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Development documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets