### PR TITLE
Feature/orca 638 2

### DIFF
--- a/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
@@ -243,7 +243,7 @@ modifications, which will be detailed below.
       ]
     },
     {
-      "Sid": "Inventory-PREFIX-orca-reports",
+      "Sid": "Inventory-PREFIX-orca-archive-reports",
       "Effect": "Allow",
       "Principal": {
         "Service": "s3.amazonaws.com"
@@ -256,7 +256,7 @@ modifications, which will be detailed below.
       	  "aws:SourceAccount": "000000000000"
         },
       	"ArnLike": {
-      	  "aws:SourceArn": "arn:aws:s3:::PREFIX-orca-reports"
+      	  "aws:SourceArn": "arn:aws:s3:::PREFIX-orca-archive"
       	}
       }
     }
@@ -275,3 +275,9 @@ Replace the number `000000000000` with your DR account number.
 The Resource value is the bucket and bucket paths that the Cumulus application
 can access. Replace `PREFIX-orca-reports` with the name
 of the Orca reports bucket created in the previous section.
+
+Replace `PREFIX-orca-primary` with the name of your [ORCA archive bucket](#archive-bucket).
+If you have multiple ORCA buckets, duplicate the 'Inventory-PREFIX-orca-primary-reports' statement for each additional bucket.
+
+Replace `PREFIX-orca-primary` with the name of your [ORCA archive bucket](#archive-bucket).
+If you have multiple ORCA buckets, duplicate the 'Inventory-PREFIX-orca-primary-reports' statement for each additional bucket.

--- a/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
@@ -256,7 +256,7 @@ modifications, which will be detailed below.
       	  "aws:SourceAccount": "000000000000"
         },
       	"ArnLike": {
-      	  "aws:SourceArn": "arn:aws:s3:::PREFIX-orca-archive"
+      	  "aws:SourceArn": ["arn:aws:s3:::PREFIX-orca-archive"]
       	}
       }
     }
@@ -277,7 +277,12 @@ can access. Replace `PREFIX-orca-reports` with the name
 of the Orca reports bucket created in the previous section.
 
 Replace `PREFIX-orca-primary` with the name of your [ORCA archive bucket](#archive-bucket).
-If you have multiple ORCA buckets, duplicate the 'Inventory-PREFIX-orca-primary-reports' statement for each additional bucket.
+If you have multiple ORCA buckets, expand the `SourceArn` array with the following format:
+```json
+"ArnLike": {
+   "aws:SourceArn": ["arn:aws:s3:::BUCKET-NAME", "arn:aws:s3:::BUCKET-NAME"]
+}
+```
 
 Replace `PREFIX-orca-primary` with the name of your [ORCA archive bucket](#archive-bucket).
 If you have multiple ORCA buckets, duplicate the 'Inventory-PREFIX-orca-primary-reports' statement for each additional bucket.


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-638: Fix reports bucket documentation](https://bugs.earthdata.nasa.gov/browse/ORCA-638)

## Changes

* Fixed typo in reports bucket documentation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Policy tripple-checked in AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets

## What is the current behavior?

Access denied when posting inventory reports to reports bucket.

## What is the expected correct/added behavior?

Reports bucket populated with s3 inventory report.