### PR TITLE
Feature/orca 622 Research Adding big int support to graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,13 @@ and includes an additional section for migration notes.
 
 ## [Unreleased]
 ### Added
-- *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581*, *ORCA-622*
+- *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581*
   - GraphQL image, service, and Load Balancer will now be deployed by TF.
   - *ORCA-557* Added `orca_graphql_load_balancer_dns_name` to output variables for GraphQL integration.
   - *ORCA-420* Added Internal Reconcile Report Mismatch functionality to GraphQL.
   - *ORCA-556* Added Internal Reconcile Report Phantom functionality to GraphQL.
   - *ORCA-592* GraphQL logs are json structures, and can thus be queried in CloudWatch.
+  - *ORCA-622* Added support for integer sizes up to 8 bytes.
 - *ORCA-597*
   - Server access logging is now enabled for graphql application load balancer.
 - *ORCA-614*, *ORCA-428* Moved some Internal Reconciliation functionality to GraphQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and includes an additional section for migration notes.
 
 ## [Unreleased]
 ### Added
-- *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581*
+- *ORCA-554*, *ORCA-561*, *ORCA-579*, *ORCA-581*, *ORCA-622*
   - GraphQL image, service, and Load Balancer will now be deployed by TF.
   - *ORCA-557* Added `orca_graphql_load_balancer_dns_name` to output variables for GraphQL integration.
   - *ORCA-420* Added Internal Reconcile Report Mismatch functionality to GraphQL.

--- a/ecs_tasks/internal_reconcile_report_generate/src/adapters/api/aws.py
+++ b/ecs_tasks/internal_reconcile_report_generate/src/adapters/api/aws.py
@@ -95,7 +95,7 @@ class AWS:
         manifest = json.loads(file_str)
         return S3InventoryManifest(
             source_bucket_name=manifest["sourceBucket"],
-            manifest_creation_datetime=int(int(manifest["creationTimestamp"]) / 1000),
+            manifest_creation_datetime=int(manifest["creationTimestamp"]) / 1000,
             manifest_files=[
                 AWSS3FileLocation(key=f["key"], bucket_name=report_bucket_name)
                 for f in manifest["files"]

--- a/ecs_tasks/internal_reconcile_report_generate/src/entities/aws.py
+++ b/ecs_tasks/internal_reconcile_report_generate/src/entities/aws.py
@@ -49,7 +49,7 @@ class S3InventoryManifest:
 
     Contains:
         source_bucket_name: Name of the bucket the report was generated for.
-        manifest_creation_datetime: Milliseconds since epoch the report was generated.
+        manifest_creation_datetime: Seconds since epoch the report was generated.
         manifest_files: Locations of files that make up the report.
         manifest_files_columns: CSV string of column names in the report files.
     """

--- a/ecs_tasks/internal_reconcile_report_generate/test/adapters/api/test_aws.py
+++ b/ecs_tasks/internal_reconcile_report_generate/test/adapters/api/test_aws.py
@@ -143,7 +143,7 @@ class TestAWS(unittest.TestCase):
             Mock(),
         )
 
-        self.assertEqual(int(manifest_creation_timestamp / 1000), result.manifest_creation_datetime)
+        self.assertEqual(manifest_creation_timestamp / 1000, result.manifest_creation_datetime)
         self.assertEqual(manifest_source_bucket, result.source_bucket_name)
         self.assertEqual(2, len(result.manifest_files))
         self.assertEqual(manifest_file0_key, result.manifest_files[0].key)

--- a/graphql/src/adapters/graphql/dataTypes/common.py
+++ b/graphql/src/adapters/graphql/dataTypes/common.py
@@ -1,6 +1,8 @@
 import traceback
 
 # noinspection PyPackageRequirements
+from typing import NewType
+
 import strawberry
 
 
@@ -21,3 +23,28 @@ class InternalServerErrorGraphqlType(ErrorGraphqlTypeInterface):
                        "Please review the logs and contact support if needed."
         self.exception_message = str(ex)
         self.stack_trace = traceback.format_exc()
+
+
+int8 = strawberry.scalar(
+    NewType("int8", int),
+    # todo: add size limits -9223372036854775808 to +9223372036854775807
+    serialize=lambda v: int8_serialize(v),
+    parse_value=lambda v: int8_parse_value(v),
+)
+
+
+int8_max = 9223372036854775807
+int8_min = int8_max * -1
+
+
+def int8_serialize(v):
+    if v > int8_max or v < int8_min:
+        raise ValueError(f"Value {v} outside bounds of '{int8_min}' - '{int8_max}'.")
+    return v
+
+
+def int8_parse_value(v):
+    val = int(v)
+    if val > int8_max or val < int8_min:
+        raise ValueError(f"Value {v} outside bounds of '{int8_min}' - '{int8_max}'.")
+    return val

--- a/graphql/src/adapters/graphql/dataTypes/common.py
+++ b/graphql/src/adapters/graphql/dataTypes/common.py
@@ -25,13 +25,30 @@ class InternalServerErrorGraphqlType(ErrorGraphqlTypeInterface):
         self.stack_trace = traceback.format_exc()
 
 
-int8 = strawberry.scalar(
-    NewType("int8", int),
+# Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+# noinspection PyPep8Naming
+class int8(int):
+    @classmethod
+    def __get_validators__(cls):
+        # one or more validators may be yielded which will be called in the
+        # order to validate the input, each validator will receive as an input
+        # the value returned from the previous validator
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        return int8_parse_value(v)
+
+    def __repr__(self):
+        return f'PostCode({super().__repr__()})'
+
+
+strawberry_int8 = strawberry.scalar(
+    NewType("int8", int8),
     # todo: add size limits -9223372036854775808 to +9223372036854775807
     serialize=lambda v: int8_serialize(v),
     parse_value=lambda v: int8_parse_value(v),
 )
-
 
 int8_max = 9223372036854775807
 int8_min = int8_max * -1

--- a/graphql/src/adapters/graphql/dataTypes/common.py
+++ b/graphql/src/adapters/graphql/dataTypes/common.py
@@ -1,8 +1,6 @@
 import traceback
 
 # noinspection PyPackageRequirements
-from typing import NewType
-
 import strawberry
 
 
@@ -25,7 +23,6 @@ class InternalServerErrorGraphqlType(ErrorGraphqlTypeInterface):
         self.stack_trace = traceback.format_exc()
 
 
-# Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
 # noinspection PyPep8Naming
 class int8(int):
     @classmethod
@@ -44,8 +41,7 @@ class int8(int):
 
 
 strawberry_int8 = strawberry.scalar(
-    NewType("int8", int8),
-    # todo: add size limits -9223372036854775808 to +9223372036854775807
+    int8,
     serialize=lambda v: int8_serialize(v),
     parse_value=lambda v: int8_parse_value(v),
 )

--- a/graphql/src/adapters/graphql/schemas/mutations.py
+++ b/graphql/src/adapters/graphql/schemas/mutations.py
@@ -10,6 +10,7 @@ from orca_shared.reconciliation import OrcaStatus
 from strawberry import argument, field, type
 
 from src.adapters.graphql.adapters import AdaptersStorage
+from src.adapters.graphql.dataTypes.common import int8
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
     CreateInternalReconciliationJobStrawberryResponse,
     ImportCurrentArchiveListInternalReconciliationJobStrawberryResponse,
@@ -50,7 +51,7 @@ class Mutations:
     ) -> CreateInternalReconciliationJobStrawberryResponse:
         result = create_job(
             report_source,
-            int(creation_timestamp),
+            creation_timestamp,
             Mutations.adapters_storage.storage_internal_reconciliation,
             Mutations.adapters_storage.logger_provider.get_logger(
                 uuid.uuid4().__str__()

--- a/graphql/src/adapters/graphql/schemas/mutations.py
+++ b/graphql/src/adapters/graphql/schemas/mutations.py
@@ -10,7 +10,6 @@ from orca_shared.reconciliation import OrcaStatus
 from strawberry import argument, field, type
 
 from src.adapters.graphql.adapters import AdaptersStorage
-from src.adapters.graphql.dataTypes.common import int8
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
     CreateInternalReconciliationJobStrawberryResponse,
     ImportCurrentArchiveListInternalReconciliationJobStrawberryResponse,

--- a/graphql/src/adapters/graphql/schemas/queries.py
+++ b/graphql/src/adapters/graphql/schemas/queries.py
@@ -9,7 +9,7 @@ import strawberry
 from strawberry import argument, field, type
 
 from src.adapters.graphql.adapters import AdaptersStorage
-from src.adapters.graphql.dataTypes.common import int8
+from src.adapters.graphql.dataTypes.common import strawberry_int8
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
     GetMismatchPageStrawberryResponse,
     GetPhantomPageStrawberryResponse,
@@ -71,7 +71,7 @@ class Queries:
     def get_phantom_page(
         self,
         job_id: Annotated[
-            int8,
+            strawberry_int8,
             argument(
                 description="""The unique job ID of the reconciliation job."""
             )
@@ -86,7 +86,7 @@ class Queries:
         return get_phantom_page(
             job_id,
             page_parameters,
-            Queries.adapters_storage.storage,
+            Queries.adapters_storage.storage_internal_reconciliation,
             Queries.adapters_storage.logger_provider.get_logger(
                 uuid.uuid4().__str__()
             )
@@ -98,7 +98,7 @@ class Queries:
     def get_mismatch_page(
         self,
         job_id: Annotated[
-            int8,
+            strawberry_int8,
             argument(
                 description="""The unique job ID of the reconciliation job."""
             )
@@ -113,7 +113,7 @@ class Queries:
         return get_mismatch_page(
             job_id,
             page_parameters,
-            Queries.adapters_storage.storage,
+            Queries.adapters_storage.storage_internal_reconciliation,
             Queries.adapters_storage.logger_provider.get_logger(
                 uuid.uuid4().__str__()
             )

--- a/graphql/src/adapters/graphql/schemas/queries.py
+++ b/graphql/src/adapters/graphql/schemas/queries.py
@@ -9,6 +9,7 @@ import strawberry
 from strawberry import argument, field, type
 
 from src.adapters.graphql.adapters import AdaptersStorage
+from src.adapters.graphql.dataTypes.common import int8
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
     GetMismatchPageStrawberryResponse,
     GetPhantomPageStrawberryResponse,
@@ -70,7 +71,7 @@ class Queries:
     def get_phantom_page(
         self,
         job_id: Annotated[
-            float,
+            int8,
             argument(
                 description="""The unique job ID of the reconciliation job."""
             )
@@ -97,7 +98,7 @@ class Queries:
     def get_mismatch_page(
         self,
         job_id: Annotated[
-            float,
+            int8,
             argument(
                 description="""The unique job ID of the reconciliation job."""
             )

--- a/graphql/src/adapters/graphql/schemas/queries.py
+++ b/graphql/src/adapters/graphql/schemas/queries.py
@@ -9,7 +9,7 @@ import strawberry
 from strawberry import argument, field, type
 
 from src.adapters.graphql.adapters import AdaptersStorage
-from src.adapters.graphql.dataTypes.common import strawberry_int8
+from src.adapters.graphql.dataTypes.common import int8
 from src.adapters.graphql.dataTypes.internal_reconcile_report import (
     GetMismatchPageStrawberryResponse,
     GetPhantomPageStrawberryResponse,
@@ -71,7 +71,7 @@ class Queries:
     def get_phantom_page(
         self,
         job_id: Annotated[
-            strawberry_int8,
+            int8,
             argument(
                 description="""The unique job ID of the reconciliation job."""
             )
@@ -98,7 +98,7 @@ class Queries:
     def get_mismatch_page(
         self,
         job_id: Annotated[
-            strawberry_int8,
+            int8,
             argument(
                 description="""The unique job ID of the reconciliation job."""
             )

--- a/graphql/src/adapters/graphql/schemas/schemas.py
+++ b/graphql/src/adapters/graphql/schemas/schemas.py
@@ -8,12 +8,10 @@ from strawberry import Schema
 from strawberry.extensions import AddValidationRules
 
 from src.adapters.graphql.adapters import AdaptersStorage
+from src.adapters.graphql.dataTypes.common import int8, strawberry_int8
 from src.adapters.graphql.graphql_settings import GraphQLSettings
 from src.adapters.graphql.schemas.mutations import Mutations
 from src.adapters.graphql.schemas.queries import Queries
-
-# from server.adapters.api.graphql.schemas.mutations import Mutation
-# from server.adapters.api.graphql.schemas.subscriptions import Subscription
 
 
 def get_schema(graphql_settings: GraphQLSettings, adapters_storage: AdaptersStorage) -> Schema:
@@ -32,6 +30,8 @@ def get_schema(graphql_settings: GraphQLSettings, adapters_storage: AdaptersStor
         # types=
         extensions=[AddValidationRules([NoSchemaIntrospectionCustomRule])]
         if graphql_settings.GRAPHIQL is False else
-        []
-        # scalar_overrides=
+        [],
+        scalar_overrides={
+            int8: strawberry_int8
+        }
     )

--- a/graphql/src/entities/internal_reconcile_report.py
+++ b/graphql/src/entities/internal_reconcile_report.py
@@ -7,6 +7,7 @@ import pydantic
 # noinspection PyPackageRequirements
 import strawberry
 
+from src.adapters.graphql.dataTypes.common import int8
 from src.use_cases.helpers.edge_cursor import EdgeCursor
 
 
@@ -29,7 +30,7 @@ class ReconciliationStatus(Enum):
 class InternalReconcileReportCursor(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: float
+    job_id: int8
 
     # Overriding constructor to give us type/name hints for Pydantic class.
     def __init__(self,
@@ -61,20 +62,21 @@ class InternalReconcileReportCreationRecord(pydantic.BaseModel):
 class Phantom(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: float
+    job_id: int8
     collection_id: str
     granule_id: str
     filename: str
     key_path: str
     orca_etag: str
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_granule_last_update: float
-    orca_size_in_bytes: int
+    orca_granule_last_update: int8
+    # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
+    orca_size_in_bytes: int8
     orca_storage_class: str
 
     @dataclasses.dataclass
     class Cursor:
-        job_id: int = None
+        job_id: int8 = None
         collection_id: str = None
         granule_id: str = None
         key_path: str = None
@@ -118,7 +120,7 @@ class Phantom(pydantic.BaseModel):
 class Mismatch(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: float
+    job_id: int8
     collection_id: str
     granule_id: str
     filename: str
@@ -127,13 +129,13 @@ class Mismatch(pydantic.BaseModel):
     orca_etag: str
     s3_etag: str
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_granule_last_update: float
+    orca_granule_last_update: int8
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    s3_file_last_update: float
+    s3_file_last_update: int8
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_size_in_bytes: float
+    orca_size_in_bytes: int8
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    s3_size_in_bytes: float
+    s3_size_in_bytes: int8
     orca_storage_class: str
     s3_storage_class: str
     discrepancy_type: str
@@ -141,7 +143,7 @@ class Mismatch(pydantic.BaseModel):
 
     @dataclasses.dataclass
     class Cursor:
-        job_id: int = None
+        job_id: int8 = None
         collection_id: str = None
         granule_id: str = None
         key_path: str = None

--- a/graphql/src/entities/internal_reconcile_report.py
+++ b/graphql/src/entities/internal_reconcile_report.py
@@ -7,11 +7,10 @@ import pydantic
 # noinspection PyPackageRequirements
 import strawberry
 
-# Copied from shared_libraries/reconciliation
-from src.adapters.graphql.dataTypes.common import int8
 from src.use_cases.helpers.edge_cursor import EdgeCursor
 
 
+# Copied from shared_libraries/reconciliation
 @strawberry.enum  # Not strictly clean, but alternative is duplicating classes in graphql adapter.
 class ReconciliationStatus(Enum):
     """

--- a/graphql/src/entities/internal_reconcile_report.py
+++ b/graphql/src/entities/internal_reconcile_report.py
@@ -30,7 +30,7 @@ class ReconciliationStatus(Enum):
 class InternalReconcileReportCursor(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: int8
+    job_id: float
 
     # Overriding constructor to give us type/name hints for Pydantic class.
     def __init__(self,
@@ -62,14 +62,14 @@ class InternalReconcileReportCreationRecord(pydantic.BaseModel):
 class Phantom(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: int8
+    job_id: float
     collection_id: str
     granule_id: str
     filename: str
     key_path: str
     orca_etag: str
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_granule_last_update: int8
+    orca_granule_last_update: float
     orca_size_in_bytes: int
     orca_storage_class: str
 
@@ -119,7 +119,7 @@ class Phantom(pydantic.BaseModel):
 class Mismatch(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: int8
+    job_id: float
     collection_id: str
     granule_id: str
     filename: str
@@ -128,13 +128,13 @@ class Mismatch(pydantic.BaseModel):
     orca_etag: str
     s3_etag: str
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_granule_last_update: int8
+    orca_granule_last_update: float
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    s3_file_last_update: int8
+    s3_file_last_update: float
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_size_in_bytes: int8
+    orca_size_in_bytes: float
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    s3_size_in_bytes: int8
+    s3_size_in_bytes: float
     orca_storage_class: str
     s3_storage_class: str
     discrepancy_type: str

--- a/graphql/src/entities/internal_reconcile_report.py
+++ b/graphql/src/entities/internal_reconcile_report.py
@@ -8,6 +8,7 @@ import pydantic
 import strawberry
 
 # Copied from shared_libraries/reconciliation
+from src.adapters.graphql.dataTypes.common import int8
 from src.use_cases.helpers.edge_cursor import EdgeCursor
 
 
@@ -29,7 +30,7 @@ class ReconciliationStatus(Enum):
 class InternalReconcileReportCursor(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: float
+    job_id: int8
 
     # Overriding constructor to give us type/name hints for Pydantic class.
     def __init__(self,
@@ -61,14 +62,14 @@ class InternalReconcileReportCreationRecord(pydantic.BaseModel):
 class Phantom(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: float
+    job_id: int8
     collection_id: str
     granule_id: str
     filename: str
     key_path: str
     orca_etag: str
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_granule_last_update: float
+    orca_granule_last_update: int8
     orca_size_in_bytes: int
     orca_storage_class: str
 
@@ -118,7 +119,7 @@ class Phantom(pydantic.BaseModel):
 class Mismatch(pydantic.BaseModel):
     # IMPORTANT: Whenever properties are added/removed/modified/renamed, update constructor.
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    job_id: float
+    job_id: int8
     collection_id: str
     granule_id: str
     filename: str
@@ -127,13 +128,13 @@ class Mismatch(pydantic.BaseModel):
     orca_etag: str
     s3_etag: str
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_granule_last_update: float
+    orca_granule_last_update: int8
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    s3_file_last_update: float
+    s3_file_last_update: int8
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    orca_size_in_bytes: float
+    orca_size_in_bytes: int8
     # Python doesn't cap 32 bit/4 byte int size, but GraphQL can't handle larger ints.
-    s3_size_in_bytes: float
+    s3_size_in_bytes: int8
     orca_storage_class: str
     s3_storage_class: str
     discrepancy_type: str

--- a/graphql/test/unit_tests/adapters/graphql/dataTypes/test_common.py
+++ b/graphql/test/unit_tests/adapters/graphql/dataTypes/test_common.py
@@ -1,7 +1,9 @@
 import unittest
+import uuid
 from unittest.mock import MagicMock, Mock, patch
 
-from src.adapters.graphql.dataTypes.common import InternalServerErrorGraphqlType
+from src.adapters.graphql.dataTypes.common import InternalServerErrorGraphqlType, int8, \
+    int8_min, int8_max, strawberry_int8
 
 
 class TestCommon(unittest.TestCase):
@@ -21,3 +23,53 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(str(mock_ex), result.exception_message)
         mock_traceback.format_exc.assert_called_once_with()
         self.assertEqual(mock_traceback.format_exc.return_value, result.stack_trace)
+
+    def test_int8_validate_happy_path(
+        self
+    ):
+        """
+        If value is in valid range, return as int-compatible value.
+        """
+        values = [-9223372036854775807, 0, 9223372036854775807]
+        for value in values:
+            with self.subTest(value=value):
+                result = int8(value)
+                int8.validate(value)
+                self.assertEqual(value, result)
+
+    def test_int8_validate_out_of_bounds_raises_error(
+        self
+    ):
+        """
+        If value is beyond bounds, raise error.
+        """
+        values = [-9223372036854775808, 9223372036854775808]
+        for value in values:
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError) as cm:
+                    int8.validate(value)
+                self.assertEqual(f"Value {value} outside bounds of '{int8_min}' - '{int8_max}'.",
+                                 str(cm.exception))
+
+    def test_int8_validate_non_numeric_raises_error(
+        self
+    ):
+        """
+        Non-numeric values should raise an error.
+        """
+        value = uuid.uuid4().__str__()
+        with self.assertRaises(ValueError) as cm:
+            int8.validate(value)
+        self.assertEqual(f"invalid literal for int() with base 10: '{value}'",
+                         str(cm.exception))
+
+    def test_strawberry_int8(
+        self
+    ):
+        """
+        Ensure that strawberry_int8 implements int8
+        """
+        temp = strawberry_int8(5)
+        self.assertIsInstance(temp, int8)
+
+    # Parsing and serializing for strawberry scalars is automagical, and is not unit-testable.

--- a/graphql/test/unit_tests/adapters/graphql/dataTypes/test_common.py
+++ b/graphql/test/unit_tests/adapters/graphql/dataTypes/test_common.py
@@ -2,8 +2,13 @@ import unittest
 import uuid
 from unittest.mock import MagicMock, Mock, patch
 
-from src.adapters.graphql.dataTypes.common import InternalServerErrorGraphqlType, int8, \
-    int8_min, int8_max, strawberry_int8
+from src.adapters.graphql.dataTypes.common import (
+    InternalServerErrorGraphqlType,
+    int8,
+    int8_max,
+    int8_min,
+    strawberry_int8,
+)
 
 
 class TestCommon(unittest.TestCase):

--- a/graphql/test/unit_tests/adapters/graphql/schemas/test_queries.py
+++ b/graphql/test/unit_tests/adapters/graphql/schemas/test_queries.py
@@ -26,7 +26,8 @@ class TestQueries(unittest.TestCase):
         result = queries.get_phantom_page(mock_job_id, mock_page_parameters)
 
         mock_get_phantom_page.assert_called_once_with(
-            mock_job_id, mock_page_parameters, mock_adapters_storage.storage,
+            mock_job_id, mock_page_parameters,
+            mock_adapters_storage.storage_internal_reconciliation,
             mock_adapters_storage.logger_provider.get_logger.return_value
         )
         self.assertEqual(mock_get_phantom_page.return_value, result)
@@ -51,7 +52,8 @@ class TestQueries(unittest.TestCase):
         result = queries.get_mismatch_page(mock_job_id, mock_page_parameters)
 
         mock_get_mismatch_page.assert_called_once_with(
-            mock_job_id, mock_page_parameters, mock_adapters_storage.storage,
+            mock_job_id, mock_page_parameters,
+            mock_adapters_storage.storage_internal_reconciliation,
             mock_adapters_storage.logger_provider.get_logger.return_value
         )
         self.assertEqual(mock_get_mismatch_page.return_value, result)

--- a/graphql/test/unit_tests/adapters/graphql/schemas/test_schemas.py
+++ b/graphql/test/unit_tests/adapters/graphql/schemas/test_schemas.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 from graphql import NoSchemaIntrospectionCustomRule
+from src.adapters.graphql.dataTypes.common import int8, strawberry_int8
 from src.adapters.graphql.schemas.schemas import get_schema
 
 
@@ -43,7 +44,10 @@ class TestSchemas(unittest.TestCase):
                     mutation=mock_mutations,
                     extensions=[mock_add_validation_rules.return_value]
                     if graphiql_setting is False else
-                    []
+                    [],
+                    scalar_overrides={
+                        int8: strawberry_int8
+                    }
                 )
 
             mock_queries.reset_mock()

--- a/graphql/test/unit_tests/entities/test_internal_reconcile_report.py
+++ b/graphql/test/unit_tests/entities/test_internal_reconcile_report.py
@@ -43,7 +43,7 @@ class TestInternalReconcileReport(unittest.TestCase):
 
         record = InternalReconcileReportCreationRecord(InternalReconcileReportCursor(job_id))
 
-        self.assertEqual("eyJqb2JfaWQiOiA5NTQ2MDQ4OTY0MTUuMH0=", record.cursor)
+        self.assertEqual("eyJqb2JfaWQiOiA5NTQ2MDQ4OTY0MTV9", record.cursor)
         cursor = EdgeCursor.decode_cursor(record.cursor, InternalReconcileReportCursor)
         self.assertEqual(InternalReconcileReportCursor(job_id), cursor)
 

--- a/tasks/copy_to_archive/schemas/body.json
+++ b/tasks/copy_to_archive/schemas/body.json
@@ -135,6 +135,7 @@
                 "sizeInBytes",
                 "hash",
                 "hashType",
+                "storageClass",
                 "version",
                 "ingestTime",
                 "etag"


### PR DESCRIPTION
## Summary of Changes

Added bigint support to GraphQL.

Addresses [ORCA-622: Research Adding big int support to graphql](https://bugs.earthdata.nasa.gov/browse/ORCA-622)

## Changes

* Added int8 to graphql

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Run against AWS deployment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets