### PR TITLE
ORCA-553: Document s3_access_key and s3_secret_key generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,6 +354,7 @@ and includes an additional section for migration notes.
   - orca_reports_bucket_name
   - s3_access_key
   - s3_secret_key
+    - For generating these keys, see [documentation](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-s3-credentials/).
   
 - Update the collection configuration with the new optional key `orcaDefaultRecoveryTypeOverride` that can be added to override the default S3 glacier recovery type as shown below.
 

--- a/tasks/get_current_archive_list/get_current_archive_list.py
+++ b/tasks/get_current_archive_list/get_current_archive_list.py
@@ -421,6 +421,15 @@ def trigger_csv_load_from_s3_sql() -> text:  # pragma: no cover
     SQL for telling postgres where/how to copy in the s3 inventory data.
     """
     return text(
+        # table_name
+        # column_list
+        # options
+        # bucket
+        # file_path
+        # aws region
+        # access_key
+        # secret_key
+        # session_token
         """
         SELECT aws_s3.table_import_from_s3(
             's3_import',

--- a/website/docs/developer/deployment-guide/s3-credentials.md
+++ b/website/docs/developer/deployment-guide/s3-credentials.md
@@ -1,0 +1,22 @@
+---
+id: deployment-s3-credentials
+title: Generating S3 credentials
+description: Provides developer with information on archive storage solutions.
+---
+
+Postgres requires access to the [ORCA Reports bucket](./creating-orca-archive-bucket.md#reports-bucket) to pull in s3 inventory information.
+These values are stored in the [Required Variables](./deployment-with-cumulus.md#orca-required-variables) `s3_access_key` and `s3_secret_key`.
+Note that this only impacts [Internal Reconciliation reports](../api/api.md#internal-reconcile-report-jobs-api), which is not required for ingest or recovery, but is helpful for verifying data integrity.
+If you are unable to follow these instructions, or wish to avoid generating/managing credentials, blank values may be used and the impact will be isolated to Internal Reconciliation.
+
+To generate an access key:
+1. Go to https://cloud.earthdata.nasa.gov/portal/project
+1. Click the account containing your ORCA Reports bucket
+1. `CLOUD MANAGEMENT` -> `AWS Long-Term Access Keys`
+1. Under the revealed `AWS Long-Term Access Keys` sections, click the three dots, followed by `Create AWS long-term access keys`
+1. Select an account and role that can access the bucket
+1. Click `Generate API Key`
+1. Make sure to copy the secret value from this screen. This is your `s3_secret_key`. The `Key ID` is your `s3_access_key`
+1. Note that these keys will eventually expire and will need to be regenerated and redeployed
+
+We are looking into alternatives to this system to remove these manual steps and eliminate the need for manual redeployment of expired keys.

--- a/website/docs/developer/deployment-guide/s3-credentials.md
+++ b/website/docs/developer/deployment-guide/s3-credentials.md
@@ -10,6 +10,7 @@ Note that this only impacts [Internal Reconciliation reports](../api/api.md#inte
 If you are unable to follow these instructions, or wish to avoid generating/managing credentials, blank values may be used and the impact will be isolated to Internal Reconciliation.
 
 To generate an access key:
+1. Connect to the NASA VPN.
 1. Go to https://cloud.earthdata.nasa.gov/portal/project
 1. Click the account containing your ORCA Reports bucket
 1. `CLOUD MANAGEMENT` -> `AWS Long-Term Access Keys`

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -57,6 +57,7 @@ module.exports = {
         'developer/deployment-guide/deployment',
         'developer/deployment-guide/deployment-environment',
         'developer/deployment-guide/deployment-s3-bucket',
+        'developer/deployment-guide/deployment-s3-credentials',
         'developer/deployment-guide/deployment-with-cumulus',
         'developer/deployment-guide/deployment-upgrading-orca',
         'developer/deployment-guide/recovery-workflow',


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-553: Document s3_access_key and s3_secret_key generation](https://bugs.earthdata.nasa.gov/browse/ORCA-553)

## Changes

* Added new page with s3 key generation information.

## Type of change

- [x] This change requires a documentation update