### PR TITLE
Feature/orca 630 Test ingesting data from both Glacier and regular buckets as part of integration test

### DIFF
--- a/integration_test/workflow_tests/test_packages/catalog/test_provider_does_not_exist.py
+++ b/integration_test/workflow_tests/test_packages/catalog/test_provider_does_not_exist.py
@@ -17,6 +17,7 @@ class TestProviderDoesNotExist(TestCase):
             # ---
             my_session = helpers.create_session()
 
+            # noinspection PyArgumentList
             catalog_output = helpers.post_to_api(
                 my_session,
                 helpers.api_url + "/catalog/reconcile/",

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_files_excluded.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_files_excluded.py
@@ -97,7 +97,8 @@ class TestMultipleGranules(TestCase):
             )
 
             step_function_results = helpers.get_state_machine_execution_results(
-                execution_info["executionArn"]
+                execution_info["executionArn"],
+                maximum_duration_seconds=30,
             )
 
             self.assertEqual(
@@ -124,6 +125,10 @@ class TestMultipleGranules(TestCase):
                     "404",
                     err.response["Error"]["Code"]
                 )
+
+            # Let the catalog update
+            time.sleep(1)
+            # noinspection PyArgumentList
             catalog_output = helpers.post_to_api(
                 my_session,
                 helpers.api_url + "/catalog/reconcile/",

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
@@ -13,8 +13,10 @@ class TestMultipleGranulesHappyPath(TestCase):
 
     def test_multiple_granules_happy_path(self):
         self.maxDiff = None
+        use_large_file = True  # This should not be checked in with any value other than `True`
         """
         - If multiple granules are provided, should store them in DB as well as in recovery bucket.
+        - Files stored in GLACIER are also ingest-able.
         - Large files should not cause timeout.
         """
         try:
@@ -33,7 +35,7 @@ class TestMultipleGranulesHappyPath(TestCase):
             cumulus_bucket_name = "orca-sandbox-s3-provider"
             recovery_bucket_name = helpers.recovery_bucket_name
             excluded_filetype = []
-            name_1 = uuid.uuid4().__str__() + ".hdf"    # refers to file1.hdf
+            name_1 = uuid.uuid4().__str__() + ".hdf"  # refers to file1.hdf
             key_name_1 = "test/" + uuid.uuid4().__str__() + "/" + name_1
             file_1_hash = uuid.uuid4().__str__()
             file_1_hash_type = uuid.uuid4().__str__()
@@ -43,7 +45,6 @@ class TestMultipleGranulesHappyPath(TestCase):
             )
             execution_id = uuid.uuid4().__str__()
 
-            use_large_file = True  # This should not be checked in with any value other than `True`
             if use_large_file:
                 # file for large file test
                 # Since this file is 191GB, it should already exist in the source bucket.
@@ -221,7 +222,7 @@ class TestMultipleGranulesHappyPath(TestCase):
                 ],
                 "ingestDate": mock.ANY,
                 "lastUpdate": mock.ANY
-                },
+            },
                 {
                     "providerId": provider_id,
                     "collectionId": collection_name + "___" + collection_version,

--- a/integration_test/workflow_tests/test_packages/ingest/test_no_granules.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_no_granules.py
@@ -53,7 +53,8 @@ class TestNoGranules(TestCase):
             )
 
             step_function_results = helpers.get_state_machine_execution_results(
-                execution_info["executionArn"]
+                execution_info["executionArn"],
+                maximum_duration_seconds=30,
             )
 
             self.assertEqual(
@@ -67,6 +68,8 @@ class TestNoGranules(TestCase):
                 "Expected step function output not returned.",
             )
 
+            # Let the catalog update
+            time.sleep(1)
             catalog_output = helpers.post_to_api(
                 my_session,
                 helpers.api_url + "/catalog/reconcile/",

--- a/integration_test/workflow_tests/test_packages/ingest/test_override_storage_class.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_override_storage_class.py
@@ -9,9 +9,9 @@ import boto3
 import helpers
 
 
-class TestMultipleGranulesHappyPath(TestCase):
+class TestOverrideStorageClassHappyPath(TestCase):
 
-    def test_overrides_storage_class(self):
+    def test_override_storage_class(self):
         self.maxDiff = None
         """
         - If storage class is overridden in config, should be respected.

--- a/website/docs/developer/development-guide/code/integration-tests.md
+++ b/website/docs/developer/development-guide/code/integration-tests.md
@@ -161,11 +161,6 @@ This is a list of tests that should be created for existing Orca architecture. T
      :::tip
      Include a large (bigger than 250 Gb) file to make sure timeouts do not prevent ingest.
      :::
-     :::tip
-     Test ingesting from Glacier buckets as well as regular buckets.
-     Make sure that Glacier data is less than 24 hours old.
-     If older, data will be moved out of `recovered` and `pre-archival` states, and ingest will incur additional costs and time penalties, possibly beyond timeout limits.
-     :::
   1. Call the OrcaCopyToArchiveWorkflow to ingest the granules to Orca.
      :::tip
      Make sure to cover excludedFileExtensions being set, being unset, and excluding/allowing proper files in either case.


### PR DESCRIPTION
## Summary of Changes

Added integration tests for different storage classes and granule id matches.

Addresses [ORCA-630: Test ingesting data from both Glacier and regular buckets as part of integration test](https://bugs.earthdata.nasa.gov/browse/ORCA-630)

## Changes

* Added integration test for ingesting deep_archive files
* Added integration test for ingesting two granules with the same id
* Fixed errors/race conditions in old tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Run against AWS installation.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Integration tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets