### PR TITLE
Feature/orca 678 db_deploy: Add collection_id for recovery jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and includes an additional section for migration notes.
 - *ORCA-597*
   - Server access logging is now enabled for graphql application load balancer.
 - *ORCA-614*, *ORCA-428* Moved some Internal Reconciliation functionality to GraphQL
+- *ORCA-679* Updated area in recovery where granule ID was treated as a globally unique key. Per Cumulus updates, uniqueness is no granule ID plus collection ID.
+  - *ORCA-678* `collection_id` column added to recovery status tables.
 
 ### Changed
 - *ORCA-573* Updated ORCA DB user password to now have a stronger password requirement. See migration notes for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and includes an additional section for migration notes.
 - *ORCA-597*
   - Server access logging is now enabled for graphql application load balancer.
 - *ORCA-614*, *ORCA-428* Moved some Internal Reconciliation functionality to GraphQL
-- *ORCA-679* Updated area in recovery where granule ID was treated as a globally unique key. Per Cumulus updates, uniqueness is no granule ID plus collection ID.
+- *ORCA-679* Updated area in recovery where granule ID was treated as a globally unique key. Per Cumulus updates, uniqueness is now granule ID plus collection ID.
   - *ORCA-678* `collection_id` column added to recovery status tables.
 
 ### Changed

--- a/tasks/db_deploy/install/orca_sql.py
+++ b/tasks/db_deploy/install/orca_sql.py
@@ -430,7 +430,8 @@ def recovery_file_table_sql() -> text:  # pragma: no cover
         , CONSTRAINT FK_recovery_file_status
             FOREIGN KEY (status_id) REFERENCES recovery_status (id)
         , CONSTRAINT FK_recovery_file_recoverjob
-            FOREIGN KEY (job_id, collection_id, granule_id) REFERENCES recovery_job (job_id, collection_id, granule_id)
+            FOREIGN KEY (job_id, collection_id, granule_id)
+            REFERENCES recovery_job (job_id, collection_id, granule_id)
         );
 
         -- Comments

--- a/tasks/db_deploy/install/orca_sql.py
+++ b/tasks/db_deploy/install/orca_sql.py
@@ -366,13 +366,14 @@ def recovery_job_table_sql() -> text:  # pragma: no cover
         CREATE TABLE IF NOT EXISTS recovery_job
         (
           job_id              text NOT NULL
+        , collection_id       text NOT NULL
         , granule_id          text NOT NULL
         , archive_destination text NOT NULL
         , status_id           int2 NOT NULL
         , request_time        timestamp with time zone NOT NULL
         , completion_time     timestamp with time zone NULL
         , CONSTRAINT PK_recovery_job
-            PRIMARY KEY (job_id, granule_id)
+            PRIMARY KEY (job_id, collection_id, granule_id)
         , CONSTRAINT FK_recovery_job_status
             FOREIGN KEY (status_id) REFERENCES recovery_status (id)
         );
@@ -413,6 +414,7 @@ def recovery_file_table_sql() -> text:  # pragma: no cover
         CREATE TABLE IF NOT EXISTS recovery_file
         (
           job_id                 text NOT NULL
+        , collection_id          text NOT NULL
         , granule_id             text NOT NULL
         , filename               text NOT NULL
         , key_path               text NOT NULL
@@ -424,11 +426,11 @@ def recovery_file_table_sql() -> text:  # pragma: no cover
         , last_update            timestamp with time zone NOT NULL
         , completion_time        timestamp with time zone NULL
         , CONSTRAINT PK_recovery_file
-            PRIMARY KEY (job_id, granule_id, filename)
+            PRIMARY KEY (job_id, collection_id, granule_id, filename)
         , CONSTRAINT FK_recovery_file_status
             FOREIGN KEY (status_id) REFERENCES recovery_status (id)
         , CONSTRAINT FK_recovery_file_recoverjob
-            FOREIGN KEY (job_id, granule_id) REFERENCES recovery_job (job_id, granule_id)
+            FOREIGN KEY (job_id, collection_id, granule_id) REFERENCES recovery_job (job_id, collection_id, granule_id)
         );
 
         -- Comments

--- a/tasks/db_deploy/migrations/migrate_db.py
+++ b/tasks/db_deploy/migrations/migrate_db.py
@@ -12,6 +12,7 @@ from migrations.migrate_versions_2_to_3.migrate import migrate_versions_2_to_3
 from migrations.migrate_versions_3_to_4.migrate import migrate_versions_3_to_4
 from migrations.migrate_versions_4_to_5.migrate import migrate_versions_4_to_5
 from migrations.migrate_versions_5_to_6.migrate import migrate_versions_5_to_6
+from migrations.migrate_versions_6_to_7.migrate import migrate_versions_6_to_7
 
 
 def perform_migration(
@@ -54,5 +55,10 @@ def perform_migration(
 
     if current_schema_version == 5:
         # Run migrations from version 5 to version 6
-        migrate_versions_5_to_6(config, True)
+        migrate_versions_5_to_6(config, False)
         current_schema_version = 6
+
+    if current_schema_version == 6:
+        # Run migrations from version 6 to version 7
+        migrate_versions_6_to_7(config, True)
+        current_schema_version = 7

--- a/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate.py
@@ -1,0 +1,54 @@
+"""
+Name: migrate.py
+
+Description: Migrates the ORCA schema from version 5 to version 6.
+"""
+
+from orca_shared.database.entities import PostgresConnectionInfo
+from orca_shared.database.shared_db import LOGGER
+from orca_shared.database.use_cases import create_admin_uri
+from sqlalchemy import create_engine
+
+import migrations.migrate_versions_6_to_7.migrate_sql as sql
+
+
+def migrate_versions_6_to_7(config: PostgresConnectionInfo, is_latest_version: bool) -> None:
+    """
+    Performs the migration of the ORCA schema from version 6 to version 7 of
+    the ORCA schema. This includes adding the collection_id column to recovery_jobs and
+    recovery_files and updating the relevant keys and relations.
+
+    Args:
+        config: Connection information for the database.
+        is_latest_version: Flag to determine if version 7 is the latest
+                                  schema version.
+    Returns:
+        None
+    """
+    # Get the admin engine to the app database
+    user_admin_engine = \
+        create_engine(create_admin_uri(config, LOGGER, config.user_database_name), future=True)
+
+    with user_admin_engine.connect() as connection:
+
+        # Change to DBO role and set search path
+        LOGGER.debug("Changing to the dbo role to create objects ...")
+        connection.execute(sql.text("SET ROLE orca_dbo;"))
+
+        # Set the search path
+        LOGGER.debug("Setting search path to the ORCA schema to create objects ...")
+        connection.execute(sql.text("SET search_path TO orca, public;"))
+
+        # Create storage_class table
+        LOGGER.debug("Adding collection_id to recovery status tables ...")
+        connection.execute(sql.add_collection_id_to_recovery_job_and_recovery_file_sql())
+        LOGGER.info("collection_id added.")
+
+        # If v7 is the latest version, update the schema_versions table.
+        if is_latest_version:
+            LOGGER.debug("Populating the schema_versions table with data ...")
+            connection.execute(sql.schema_versions_data_sql())
+            LOGGER.info("Data added to the schema_versions table.")
+
+        # Commit if there are no issues
+        connection.commit()

--- a/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate.py
@@ -1,7 +1,7 @@
 """
 Name: migrate.py
 
-Description: Migrates the ORCA schema from version 5 to version 6.
+Description: Migrates the ORCA schema from version 6 to version 7.
 """
 
 from orca_shared.database.entities import PostgresConnectionInfo

--- a/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate_sql.py
@@ -1,0 +1,67 @@
+"""
+Name: migrate_sql.py
+
+Description: All the SQL used for creating and migrating the ORCA schema to version 6.
+"""
+# Imports
+from sqlalchemy import text
+
+
+# ----------------------------------------------------------------------------
+# Version table information
+# ----------------------------------------------------------------------------
+def schema_versions_data_sql() -> text:  # pragma: no cover
+    """
+    Data for the schema_versions table. Inserts the current schema
+    version into the table.
+
+    Returns: SQL for populating schema_versions table.
+    """
+    return text(
+        """
+        -- Populate with the current version
+        -- Update is_latest to false for all records first to prevent error
+        UPDATE schema_versions
+        SET is_latest = False;
+
+        -- Upsert the current version
+        INSERT INTO schema_versions
+          VALUES
+            (7, 'Added collection_id to recovery job tables.', NOW(), True)
+        ON CONFLICT (version_id)
+        DO UPDATE SET is_latest = True;
+    """
+    )
+
+
+def add_collection_id_to_recovery_job_and_recovery_file_sql() -> text:
+    """
+
+    """
+    return text(  # nosec
+        """
+        ALTER TABLE orca.recovery_file
+            DROP CONSTRAINT IF EXISTS FK_recovery_file_recoverjob,
+            DROP CONSTRAINT IF EXISTS PK_recovery_file,
+            ADD COLUMN IF NOT EXISTS collection_id text;
+        ALTER TABLE orca.recovery_job
+            DROP CONSTRAINT IF EXISTS PK_recovery_job,
+            ADD COLUMN IF NOT EXISTS collection_id text;
+
+        UPDATE orca.recovery_file SET collection_id = granules.collection_id
+            FROM orca.granules WHERE granules.cumulus_granule_id = recovery_file.granule_id;
+        UPDATE orca.recovery_job SET collection_id = granules.collection_id
+            FROM orca.granules WHERE granules.cumulus_granule_id = recovery_job.granule_id;
+
+        ALTER TABLE orca.recovery_file
+            ALTER COLUMN collection_id SET NOT NULL,
+            ADD CONSTRAINT PK_recovery_file PRIMARY KEY (job_id, collection_id, granule_id, 
+            filename);
+        ALTER TABLE orca.recovery_job
+            ALTER COLUMN collection_id SET NOT NULL,
+            ADD CONSTRAINT PK_recovery_job PRIMARY KEY (job_id, collection_id, granule_id);
+        ALTER TABLE orca.recovery_file
+            ADD CONSTRAINT FK_recovery_file_recoverjob FOREIGN KEY (job_id, collection_id, 
+            granule_id) REFERENCES orca.recovery_job (job_id, collection_id, granule_id);
+        """
+    )

--- a/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate_sql.py
@@ -55,13 +55,14 @@ def add_collection_id_to_recovery_job_and_recovery_file_sql() -> text:
 
         ALTER TABLE orca.recovery_file
             ALTER COLUMN collection_id SET NOT NULL,
-            ADD CONSTRAINT PK_recovery_file PRIMARY KEY (job_id, collection_id, granule_id, 
-            filename);
+            ADD CONSTRAINT PK_recovery_file
+                PRIMARY KEY (job_id, collection_id, granule_id, filename);
         ALTER TABLE orca.recovery_job
             ALTER COLUMN collection_id SET NOT NULL,
             ADD CONSTRAINT PK_recovery_job PRIMARY KEY (job_id, collection_id, granule_id);
         ALTER TABLE orca.recovery_file
-            ADD CONSTRAINT FK_recovery_file_recoverjob FOREIGN KEY (job_id, collection_id, 
-            granule_id) REFERENCES orca.recovery_job (job_id, collection_id, granule_id);
+            ADD CONSTRAINT FK_recovery_file_recoverjob
+                FOREIGN KEY (job_id, collection_id, granule_id)
+                REFERENCES orca.recovery_job (job_id, collection_id, granule_id);
         """
     )

--- a/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate_sql.py
@@ -1,7 +1,7 @@
 """
 Name: migrate_sql.py
 
-Description: All the SQL used for creating and migrating the ORCA schema to version 6.
+Description: All the SQL used for creating and migrating the ORCA schema to version 7.
 """
 # Imports
 from sqlalchemy import text

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_sql_v7.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_sql_v7.py
@@ -1,0 +1,30 @@
+"""
+Name: test_migrate_sql_v6.py
+
+Description: Testing library for the migrations/migrate_versions_6_to_7/migrate_sql.py.
+"""
+
+import unittest
+from inspect import getmembers, isfunction
+
+from sqlalchemy.sql.elements import TextClause
+
+import migrations.migrate_versions_6_to_7.migrate_sql as sql
+
+
+class TestOrcaSqlLogic(unittest.TestCase):
+    """
+    Note that currently all the function calls in the migrate_sql.py
+    return a SQL text string. The tests below
+    validate the logic in the function.
+    """
+
+    def test_all_functions_return_text(self) -> None:
+        """
+        Validates that all functions return a type TextClause
+        """
+
+        for name, function in getmembers(sql, isfunction):
+            if name not in ["text"]:
+                with self.subTest(function=function):
+                    self.assertEqual(type(function()), TextClause)

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_sql_v7.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_sql_v7.py
@@ -1,5 +1,5 @@
 """
-Name: test_migrate_sql_v6.py
+Name: test_migrate_sql_v7.py
 
 Description: Testing library for the migrations/migrate_versions_6_to_7/migrate_sql.py.
 """

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_v7.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_v7.py
@@ -1,0 +1,110 @@
+"""
+Name: test_migrate.py
+
+Description: Runs unit tests for the migrations/migrate_versions_6_to_7/migrate.py
+"""
+
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from orca_shared.database.entities import PostgresConnectionInfo
+
+from migrations.migrate_versions_6_to_7 import migrate
+
+
+class TestMigrateDatabaseLibraries(unittest.TestCase):
+    """
+    Runs unit tests on the migrate_db functions.
+    """
+
+    def setUp(self):
+        """
+        Set up test.
+        """
+        # todo: Use randomized values on a per-test basis.
+        self.config = PostgresConnectionInfo(  # nosec
+            admin_database_name="admin_db",
+            admin_username="admin", admin_password="admin123",
+            user_username="user56789012", user_password="pass56789012",
+            user_database_name="user_db", host="aws.postgresrds.host", port="5432"
+        )
+
+    def tearDown(self):
+        """
+        Tear down test
+        """
+        self.config = None
+        self.orca_buckets = None
+
+    @patch("migrations.migrate_versions_6_to_7.migrate.sql.schema_versions_data_sql")
+    @patch("migrations.migrate_versions_6_to_7."
+           "migrate.sql.add_collection_id_to_recovery_job_and_recovery_file_sql")
+    @patch("migrations.migrate_versions_6_to_7.migrate.create_engine")
+    @patch("migrations.migrate_versions_6_to_7.migrate.create_admin_uri")
+    @patch("migrations.migrate_versions_6_to_7.migrate.sql.text")
+    def test_migrate_versions_6_to_7_happy_path(
+        self,
+        mock_text: MagicMock,
+        mock_create_admin_uri: MagicMock,
+        mock_create_engine: MagicMock,
+        mock_add_collection_id_to_recovery_job_and_recovery_file_sql: MagicMock,
+        mock_schema_versions_data_sql: MagicMock,
+    ):
+        """
+        Tests the migrate_versions_6_to_7 function happy path
+        """
+        for latest_version in [True, False]:
+            with self.subTest(latest_version=latest_version):
+                # Run the function
+                migrate.migrate_versions_6_to_7(self.config, latest_version)
+
+                # Check that all the functions were called the correct
+                # number of times with the proper values
+                mock_create_admin_uri.assert_called_once_with(
+                    self.config, migrate.LOGGER, self.config.user_database_name
+                )
+                mock_create_engine.assert_called_once_with(
+                    mock_create_admin_uri.return_value, future=True
+                )
+                mock_add_collection_id_to_recovery_job_and_recovery_file_sql.\
+                    assert_called_once_with()
+
+                # Check the text calls occur and in the proper order
+                text_calls = [
+                    call("SET ROLE orca_dbo;"),
+                    call("SET search_path TO orca, public;"),
+                ]
+                mock_text.assert_has_calls(text_calls, any_order=False)
+                self.assertEqual(len(text_calls), mock_text.call_count)
+                execution_order = [
+                    call.execute(mock_text("SET ROLE orca_dbo;")),
+                    call.execute(mock_text("SET search_path TO orca, public;")),
+                    call.execute(mock_add_collection_id_to_recovery_job_and_recovery_file_sql()),
+                ]
+
+                # Validate logic switch and set the execution order
+                if latest_version:
+                    mock_schema_versions_data_sql.assert_called_once_with()
+                    execution_order.append(
+                        call.execute(mock_schema_versions_data_sql())
+                    )
+
+                else:
+                    mock_schema_versions_data_sql.assert_not_called()
+
+                # Add the commit at the end
+                execution_order.append(call.commit())
+
+                # Check that items were called in the proper order
+                mock_conn_enter = mock_create_engine().connect().__enter__()
+                mock_conn_enter.assert_has_calls(execution_order, any_order=False)
+                self.assertEqual(
+                    len(execution_order), len(mock_conn_enter.method_calls)
+                )
+
+            # Reset the mocks for next loop
+            mock_create_admin_uri.reset_mock()
+            mock_create_engine.reset_mock()
+            mock_add_collection_id_to_recovery_job_and_recovery_file_sql.reset_mock()
+            mock_schema_versions_data_sql.reset_mock()
+            mock_text.reset_mock()

--- a/tasks/db_deploy/test/unit_tests/migrations/test_migrate_db.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/test_migrate_db.py
@@ -44,8 +44,10 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
     @patch("migrations.migrate_db.migrate_versions_3_to_4")
     @patch("migrations.migrate_db.migrate_versions_4_to_5")
     @patch("migrations.migrate_db.migrate_versions_5_to_6")
+    @patch("migrations.migrate_db.migrate_versions_6_to_7")
     def test_perform_migration_happy_path(
         self,
+        mock_migrate_v6_to_v7: MagicMock,
         mock_migrate_v5_to_v6: MagicMock,
         mock_migrate_v4_to_v5: MagicMock,
         mock_migrate_v3_to_v4: MagicMock,
@@ -55,7 +57,7 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
         """
         Tests the perform_migration function happy paths
         """
-        for version in [1, 2, 3, 4, 5, 6, 7]:
+        for version in [1, 2, 3, 4, 5, 6, 7, 8]:
             with self.subTest(version=version):
                 migrate_db.perform_migration(version, self.config, self.orca_buckets)
 
@@ -85,9 +87,14 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                     mock_migrate_v4_to_v5.assert_not_called()
 
                 if version < 6:
-                    mock_migrate_v5_to_v6.assert_called_once_with(self.config, True)
+                    mock_migrate_v5_to_v6.assert_called_once_with(self.config, False)
                 else:
                     mock_migrate_v5_to_v6.assert_not_called()
+
+                if version < 7:
+                    mock_migrate_v6_to_v7.assert_called_once_with(self.config, True)
+                else:
+                    mock_migrate_v6_to_v7.assert_not_called()
 
             # Reset for next loop
             mock_migrate_v1_to_v2.reset_mock()
@@ -95,3 +102,4 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
             mock_migrate_v3_to_v4.reset_mock()
             mock_migrate_v4_to_v5.reset_mock()
             mock_migrate_v5_to_v6.reset_mock()
+            mock_migrate_v6_to_v7.reset_mock()


### PR DESCRIPTION
## Summary of Changes

Added collection_id to recovery status tables.

Addresses [ORCA-678: db_deploy: Add collection_id for recovery jobs](https://bugs.earthdata.nasa.gov/browse/ORCA-678)

## Changes

* Added collection_id column to recovery_files and recovery_jobs
* Added migration to add column and populate with data from `granules` table
* Added tests

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Code run against AWS deployment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets