### PR TITLE
Feature/orca 666 Create integration tests for recovery adapter lambda

### DIFF
--- a/base_images/Dockerfile.local
+++ b/base_images/Dockerfile.local
@@ -33,9 +33,11 @@ rm -rf Python-${PYTHON_VERSION}
 # Install and configure git-secrets
 RUN \
 cd /root && \
+yum install -y which && \
 git clone https://github.com/awslabs/git-secrets.git && \
 cd git-secrets && \
 make install && \
+ln -s "$(which echo)" /usr/local/bin/say && \
 git secrets --register-aws --global && \
 git secrets --install ~/.git-templates/git-secrets && \
 git config --global init.templateDir ~/.git-templates/git-secrets

--- a/bin/build_tasks.sh
+++ b/bin/build_tasks.sh
@@ -30,14 +30,17 @@ function build_task() {
   then
     echo "ERROR: Building of $1 failed with code $return_code"
   fi
+  echo "Completed building $1"
   return $return_code
 }
 export -f build_task
 
 task_dirs=$(ls -d tasks/* | egrep -v "package")
+echo "Build targets: $task_dirs"
 
 echo "Building in parallel..."
-parallel --jobs 0 -n 1 -X --halt now,fail=1 build_task ::: $task_dirs
+# todo: ORCA-681: Repair parallelism and switch back to `--jobs 0`
+parallel --jobs 1 -n 1 -X --halt now,fail=1 build_task ::: $task_dirs
 
 process_return_code=$?
 echo

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -41,7 +41,8 @@ task_dirs=$(ls -d tasks/* | egrep -v "package")
 ## Call each task's testing suite
 ## TODO: Add more logging output
 echo "Running unit tests in parallel..."
-parallel --jobs 0 -n 1 -X --halt now,fail=1 run_unit_tests ::: $task_dirs
+# todo: ORCA-681: Repair parallelism and switch back to `--jobs 0`
+parallel --jobs 1 -n 1 -X --halt now,fail=1 run_unit_tests ::: $task_dirs
 
 process_return_code=$?
 echo

--- a/modules/orca/output.tf
+++ b/modules/orca/output.tf
@@ -49,8 +49,10 @@ output "orca_lambda_post_copy_request_to_queue_arn" {
 
 ## Workflow Module Outputs (orca_workflows)
 ## =============================================================================
-## No workflow outputs currently requested/needed
-
+output "orca_sfn_recovery_workflow_arn" {
+  description = "The ARN of the recovery step function."
+  value       = module.orca_workflows.orca_sfn_recovery_workflow_arn
+}
 
 ## SQS Module Outputs (orca_sqs)
 ## =============================================================================

--- a/modules/workflows/OrcaRecoveryWorkflow/output.tf
+++ b/modules/workflows/OrcaRecoveryWorkflow/output.tf
@@ -1,0 +1,4 @@
+output "orca_sfn_recovery_workflow_arn" {
+  description = "The ARN of the recovery step function."
+  value       = module.orca_recovery_workflow.state_machine_arn
+}

--- a/modules/workflows/output.tf
+++ b/modules/workflows/output.tf
@@ -2,3 +2,8 @@ output "orca_sfn_internal_reconciliation_workflow_arn" {
   description = "The ARN of the internal_reconciliation step function."
   value       = module.orca_internal_reconciliation_workflow.orca_sfn_internal_reconciliation_workflow_arn
 }
+
+output "orca_sfn_recovery_workflow_arn" {
+  description = "The ARN of the recovery step function."
+  value       = module.orca_recovery_workflow.orca_sfn_recovery_workflow_arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,6 +84,13 @@ output "orca_sqs_status_update_queue_id" {
   value       = module.orca.orca_sqs_status_update_queue_id
 }
 
+## Workflow Module Outputs (orca_workflows)
+## =============================================================================
+output "orca_sfn_recovery_workflow_arn" {
+  description = "The ARN of the recovery step function."
+  value       = module.orca.orca_sfn_recovery_workflow_arn
+}
+
 ## Secretsmanager Module outputs
 ## =============================================================================
 output "orca_secretsmanager_arn" {

--- a/tasks/copy_to_archive_adapter/README.md
+++ b/tasks/copy_to_archive_adapter/README.md
@@ -89,7 +89,7 @@ To run integration test for **copy_to_archive_adapter**, run `bin/run_integratio
 `tasks/copy_to_archive_adapter` directory. Make sure the object to be copied exists in the source bucket first before running the test.
 Remember to export the following environment variables in your terminal before running the test.
 - ORCA_RECOVERY_BUCKET - S3 bucket where the object should be recovered. For example, `test-orca-primary`.
-- CUMULUS_BUCKET_NAME -S3 bucket where the object to be recovered exists. For example, `orca-sandbox-s3-provider`.
+- CUMULUS_BUCKET_NAME - S3 bucket where the object to be recovered exists. For example, `orca-sandbox-s3-provider`.
 - OBJECT_KEY_NAME - The S3 object url. For example, `MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf`.
 
 ## Environment Variables

--- a/tasks/copy_to_archive_adapter/test/integration_tests/integration_test_copy_to_archive_adapter.py
+++ b/tasks/copy_to_archive_adapter/test/integration_tests/integration_test_copy_to_archive_adapter.py
@@ -75,7 +75,7 @@ class TestCopyToArchiveAdapter(unittest.TestCase):
         }
         context = Mock()
         result = copy_to_archive_adapter.handler(copy_to_archive_adapter_input_event, context)
-        self.assertEqual(result, expected_output)
+        self.assertEqual(expected_output, result)
         # verify that the object exists in recovery bucket
         try:
             head_object_output = boto3.client("s3").head_object(

--- a/tasks/orca_recovery_adapter/README.md
+++ b/tasks/orca_recovery_adapter/README.md
@@ -71,8 +71,13 @@ in the cumulus-orca base of the repo.
 
 To run integration test for **orca_recovery_adapter**, run `bin/run_integration_tests.sh` script from the
 `tasks/orca_recovery_adapter` directory. Make sure the object to be restored exists in ORCA before running the test.
-Remember to export the following environment variables in your terminal before running the test.
-- TODO: https://bugs.earthdata.nasa.gov/browse/ORCA-666
+In addition to the [standard environment variables](#lambda-setup),
+export the following environment variables in your terminal before running the test.
+- ORCA_RECOVERY_BUCKET - S3 bucket where the object is stored in ORCA. For example, `test-orca-primary`.
+- CUMULUS_BUCKET_NAME - S3 bucket where the object will be recovered to. For example, `test-public`.
+- CUMULUS_SYSTEM_BUCKET_NAME - S3 bucket used by CMA. For example, `test-internal`.
+- OBJECT_KEY_NAME - The S3 object url. For example, `MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf`.
+- GRANULE_ID - The Cumulus Granule ID of the granule containing the file to be recovered.
 
 ## Environment Variables
 
@@ -150,12 +155,70 @@ The actual format of that input may change over time, so we use the [cumulus-mes
 }
 ```
 
+This is what the same input looks like for use with the [Step Function configuration](#step-function-configuration):
+
+```json
+{
+  "payload": {
+    "granules": [
+      {
+        "granuleId": "a3a94886-c11d-4c21-a942-a836b8e9aa75",
+        "files": [
+          {
+            "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+            "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+            "bucket": "PREFIX-orca-primary"
+          }
+        ]
+      }
+    ]
+  },
+  "meta": {
+    "buckets": {
+      "protected": {"name": "PREFIX-protected", "type": "protected"},
+      "internal": {"name": "PREFIX-internal", "type": "internal"},
+      "private": {"name": "PREFIX-private", "type": "private"},
+      "public": {"name": "PREFIX-public", "type": "public"},
+      "orca_default": {"name": "PREFIX-orca-primary", "type": "orca"}
+    },
+    "collection": {
+      "meta": {
+        "orca": {
+          "excludedFileExtensions": [".blah"]
+        }
+      },
+      "files": [
+        {
+          "regex": ".*.tar.gz",
+          "sampleFileName": "blah.tar.gz",
+          "bucket": "public"
+        },
+        {
+          "regex": ".*.jpg",
+          "sampleFileName": "blah.tar.gz",
+          "bucket": "public"
+        },
+        {
+          "regex": ".*.hdf",
+          "sampleFileName": "blah.tar.gz",
+          "bucket": "public"
+        }
+      ]
+    }
+  },
+  "cumulus_meta": {
+    "system_bucket": "PREFIX-internal"
+  }
+}
+```
+
 See the schema [configuration file](https://github.com/nasa/cumulus-orca/blob/master/tasks/orca_recovery_adapter/schemas/input.json) for more information.
 
 ## Output
 
 The `orca_recovery_adapter` lambda will request that files be restored from the ORCA archive.
 See [recovery documentation](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/recovery-workflow) for more information.
+Note that if a [Step Function](#step-function-configuration) is used, the output may be obfuscated by CMA.
 
 ```json
 {
@@ -164,13 +227,13 @@ See [recovery documentation](https://nasa.github.io/cumulus-orca/docs/developer/
       "granuleId": "a3a94886-c11d-4c21-a942-a836b8e9aa75", 
       "keys": [{
         "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf", 
-        "destBucket": "doctest-public"
+        "destBucket": "PREFIX-public"
       }], 
       "recoverFiles": [{
         "success": true, 
         "filename": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf", 
         "keyPath": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf", 
-        "restoreDestination": "doctest-public", 
+        "restoreDestination": "PREFIX-public", 
         "s3MultipartChunksizeMb": null, 
         "statusId": 1, 
         "requestTime": "2023-05-08T16:59:01.910817+00:00", 
@@ -189,11 +252,11 @@ See [recovery documentation](https://nasa.github.io/cumulus-orca/docs/developer/
   }, 
   "meta": {
     "buckets": {
-      "protected": {"name": "doctest-protected", "type": "protected"}, 
-      "internal": {"name": "doctest-internal", "type": "internal"}, 
-      "private": {"name": "doctest-private", "type": "private"}, 
-      "public": {"name": "doctest-public", "type": "public"}, 
-      "orca_default": {"name": "doctest-orca-primary", "type": "orca"}
+      "protected": {"name": "PREFIX-protected", "type": "protected"}, 
+      "internal": {"name": "PREFIX-internal", "type": "internal"}, 
+      "private": {"name": "PREFIX-private", "type": "private"}, 
+      "public": {"name": "PREFIX-public", "type": "public"}, 
+      "orca_default": {"name": "PREFIX-orca-primary", "type": "orca"}
     },
     "collection": {
       "meta": {
@@ -207,15 +270,23 @@ See [recovery documentation](https://nasa.github.io/cumulus-orca/docs/developer/
         {"regex": ".*.hdf", "sampleFileName": "blah.tar.gz", "bucket": "public"}
       ]
     }},
-  "cumulus_meta": {"system_bucket": "doctest-internal"}, 
+  "cumulus_meta": {"system_bucket": "PREFIX-internal"}, 
   "exception": "None"
 }
 ```
 
 See the schema [configuration file](https://github.com/nasa/cumulus-orca/blob/master/tasks/orca_recovery_adapter/schemas/output.json) for more information.
 
+## Lambda Setup
+- Create a new lambda in AWS with a `Python` runtime.
+- Assign the lambda an IAM role that has [StartExecution](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html)
+  permissions on the recovery Step Function.
+- Set the environment variable `ORCA_RECOVERY_STEP_FUNCTION_ARN` to the `orca_sfn_recovery_workflow_arn` output from ORCA.
+
 ## Step Function Configuration
 
+For minimum impact to integrators, it may be best to run the adapter lambda via a Step Function,
+mirroring how integrators call the ORCA Recovery Workflow via its Step Function.
 As part of the [Cumulus Message Adapter configuration](https://nasa.github.io/cumulus/docs/workflows/input_output#cma-configuration), 
 several properties must be passed into the lambda.
 See [input](https://github.com/nasa/cumulus-orca/blob/master/tasks/orca_recovery_adapter/schemas/input.json) 
@@ -228,7 +299,7 @@ schemas for more information.
   "StartAt": "OrcaRecovery",
   "TimeoutSeconds": 18000,
   "States": {
-    "OrcaRecovery": {
+    "OrcaRecoveryAdapter": {
       "Parameters": {
         "cma": {
           "event.$": "$",
@@ -270,10 +341,14 @@ schemas for more information.
           "Next": "WorkflowFailed"
         }
       ],
+      "Next": "WorkflowSucceeded"
     },
     "WorkflowFailed": {
       "Type": "Fail",
       "Cause": "Workflow failed"
+    },
+    "WorkflowSucceeded": {
+      "Type": "Succeed"
     }
   }
 }

--- a/tasks/orca_recovery_adapter/orca_recovery_adapter.py
+++ b/tasks/orca_recovery_adapter/orca_recovery_adapter.py
@@ -45,7 +45,7 @@ def task(event: Dict[str, Union[List[str], Dict]], context: object) -> Dict[str,
         A dict representing input and copied files. See schemas/output.json for more information.
     """
     # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html
-    config = Config(read_timeout=1800, retries={'total_max_attempts': 1})
+    config = Config(read_timeout=18000, retries={'total_max_attempts': 1})
     client = boto3.client("stepfunctions", config=config)
     execution_info = client.start_execution(
         stateMachineArn=os.environ[OS_ENVIRON_ORCA_RECOVERY_STEP_FUNCTION_ARN_KEY],
@@ -73,7 +73,7 @@ def get_state_machine_execution_results(
     client,
     execution_arn: str,
     retry_interval_seconds=5,
-    maximum_duration_seconds=1800,
+    maximum_duration_seconds=18000,
 ) -> Dict:
     """
     Synchronous running of step functions is not allowed via boto3

--- a/tasks/orca_recovery_adapter/test/integration_tests/integration_test_orca_recovery_adapter.py
+++ b/tasks/orca_recovery_adapter/test/integration_tests/integration_test_orca_recovery_adapter.py
@@ -1,93 +1,125 @@
 import os
-import time
 import unittest
-import uuid
-from unittest.mock import Mock
+from dataclasses import dataclass
+from unittest import mock
 
-import boto3
+# noinspection PyPackageRequirements
+import pytest
 
 import orca_recovery_adapter
 
 
-# todo: Copied from copy_to_glacier adapter. Refine in ORCA-666
-class TestCopyToArchiveAdapter(unittest.TestCase):
-    def test_orca_recovery_adapter_happy_path(self):
+class TestOrcaRecoveryAdapter(unittest.TestCase):
 
+    def test_orca_recovery_adapter_happy_path(
+        self,
+    ):
+        """
+        Runs against AWS to request recovery of a file.
+        """
+        def lambda_context():
+            @dataclass
+            class LambdaContext:
+                function_name: str = "test"
+                memory_limit_in_mb: int = 128
+                invoked_function_arn: str = "arn:aws:lambda:eu-west-1:809313241:function:test"
+                aws_request_id: str = "52fdfc07-2182-154f-163f-5f0f9a621d72"
+
+            return LambdaContext()
+
+        # PREFIX-orca-primary
         orca_recovery_bucket = os.environ["ORCA_RECOVERY_BUCKET"]
+        # PREFIX-public
         cumulus_bucket_name = os.environ["CUMULUS_BUCKET_NAME"]
+        # PREFIX-internal
+        system_bucket_name = os.environ["CUMULUS_SYSTEM_BUCKET_NAME"]
+        # MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf
         key_name = os.environ["OBJECT_KEY_NAME"]
-        granule_id = uuid.uuid4().__str__()
-        provider_id = uuid.uuid4().__str__()
-        createdAt_time = int((time.time() + 5) * 1000)
-        collection_shortname = uuid.uuid4().__str__()
-        collection_version = uuid.uuid4().__str__()
-        execution_id = uuid.uuid4().__str__()
+        file_name = os.path.basename(key_name)
+        _, file_extension = os.path.splitext(file_name)
+        granule_id = os.environ["GRANULE_ID"]
 
         orca_recovery_adapter_input_event = {
-          "payload": {
-            "granules": [
-              {
-                "granuleId": granule_id,
-                "createdAt": createdAt_time,
-                "files": [
-                  {
-                    "bucket": cumulus_bucket_name,
-                    "key": key_name
-                  }
+            "payload": {
+                "granules": [
+                    {
+                        "granuleId": granule_id,
+                        "files": [
+                            {
+                                "fileName": file_name,
+                                "key": key_name,
+                                "bucket": orca_recovery_bucket
+                            }
+                        ]
+                    }
                 ]
-              }
-            ]
-          },
-          "task_config": {
-            "providerId": provider_id,
-            "executionId": execution_id,
-            "collectionShortname": collection_shortname,
-            "collectionVersion": collection_version,
-            "defaultBucketOverride": orca_recovery_bucket
-          }
+            },
+            "task_config": {
+                "buckets": "{$.meta.buckets}",
+                "fileBucketMaps": "{$.meta.collection.files}",
+                "excludedFileExtensions": "{$.meta.collection.meta.orca.excludedFileExtensions}",
+                "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
+                "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
+                "defaultBucketOverride": "{$.meta.collection.meta.orca.defaultBucketOverride}",
+                "defaultRecoveryTypeOverride":
+                    "{$.meta.collection.meta.orca.defaultRecoveryTypeOverride}"
+            },
+            "meta": {
+                "buckets": {
+                    "public": {"name": cumulus_bucket_name, "type": "public"},
+                    "orca_default": {"name": orca_recovery_bucket, "type": "orca"}
+                },
+                "collection": {
+                    "meta": {
+                        "orca": {
+                            "excludedFileExtensions": [".blah"]
+                        }
+                    },
+                    "files": [
+                        {
+                            "regex": ".*" + file_extension,
+                            "sampleFileName": "blah" + file_extension,
+                            "bucket": "public"
+                        }
+                    ]
+                }
+            },
+            "cumulus_meta": {
+                "system_bucket": system_bucket_name
+            }
         }
 
         expected_output = {
-          "payload": {
-            "granules": [
-              {
-                "granuleId": granule_id,
-                "createdAt": createdAt_time,
-                "files": [
-                  {
-                    "bucket": cumulus_bucket_name,
-                    "key": key_name
-                  }
-                ]
-              }
-            ],
-            "copied_to_orca": [
-              "s3://" + cumulus_bucket_name + "/" + key_name,
-            ]
-          },
-          "task_config": {
-            "providerId": provider_id,
-            "executionId": execution_id,
-            "collectionShortname": collection_shortname,
-            "collectionVersion": collection_version,
-            "defaultBucketOverride": orca_recovery_bucket
-          },
-          "exception": "None"
-        }
-        context = Mock()
-        result = orca_recovery_adapter.handler(orca_recovery_adapter_input_event, context)
-        self.assertEqual(result, expected_output)
-        # verify that the object exists in recovery bucket
-        try:
-            head_object_output = boto3.client("s3").head_object(
-                Bucket=orca_recovery_bucket, Key=key_name)
-            self.assertEqual(
-                200,
-                head_object_output["ResponseMetadata"]["HTTPStatusCode"],
-                f"Error searching for object {key_name} in the {orca_recovery_bucket}",
-            )
-        except Exception as ex:
-            raise ex
+            'payload': {
+                'granules': [{
+                    'granuleId': granule_id,
+                    'keys': [{
+                        'key': key_name, 'destBucket': cumulus_bucket_name
+                    }],
+                    'recoverFiles': [{
+                        'success': True,
+                        'filename': file_name,
+                        'keyPath': key_name,
+                        'restoreDestination': cumulus_bucket_name,
+                        's3MultipartChunksizeMb': None,
+                        'statusId': 1,
+                        'requestTime': mock.ANY,
+                        'lastUpdate': mock.ANY
+                    }]
+                }],
+                'asyncOperationId': mock.ANY
+            },
+            'task_config': orca_recovery_adapter_input_event["task_config"],
+            'meta': orca_recovery_adapter_input_event["meta"],
+            'cumulus_meta': orca_recovery_adapter_input_event["cumulus_meta"],
+            'exception': 'None'}
+
+        # noinspection PyTypeChecker
+        result = orca_recovery_adapter.handler(
+            orca_recovery_adapter_input_event,
+            lambda_context(),
+        )
+        self.assertEqual(expected_output, result)
 
 
 if __name__ == '__main__':

--- a/tasks/orca_recovery_adapter/test/unit_tests/test_orca_recovery_adapter.py
+++ b/tasks/orca_recovery_adapter/test/unit_tests/test_orca_recovery_adapter.py
@@ -78,7 +78,7 @@ class TestOrcaRecoveryAdapter(TestCase):
             result = orca_recovery_adapter.task(event, None)
 
         mock_boto3_config.assert_called_once_with(
-            read_timeout=600, retries={'total_max_attempts': 1}
+            read_timeout=18000, retries={'total_max_attempts': 1}
         )
         mock_boto3_client.assert_called_once_with(
             "stepfunctions",
@@ -150,7 +150,7 @@ class TestOrcaRecoveryAdapter(TestCase):
                 orca_recovery_adapter.task(event, None)
 
         mock_boto3_config.assert_called_once_with(
-            read_timeout=600, retries={'total_max_attempts': 1}
+            read_timeout=18000, retries={'total_max_attempts': 1}
         )
         mock_boto3_client.assert_called_once_with(
             "stepfunctions",


### PR DESCRIPTION
## Summary of Changes

Create integration tests for recovery adapter lambda

Addresses [ORCA-666: Create integration tests for recovery adapter lambda](https://bugs.earthdata.nasa.gov/browse/ORCA-666)

## Changes

* Added integration test for recovery adapter.
* Added docs on deploying recovery adapter as lambda. Optional step function.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Run against AWS deployment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [ ] CHANGELOG.md
    - [x] Testing documentation
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
    - [x] Integration tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets