### PR TITLE
Added collectionId to recovery status reporting lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and includes an additional section for migration notes.
 - *ORCA-614*, *ORCA-428* Moved some Internal Reconciliation functionality to GraphQL
 - *ORCA-679* Updated area in recovery where granule ID was treated as a globally unique key. Per Cumulus updates, uniqueness is now granule ID plus collection ID.
   - *ORCA-678* `collection_id` column added to recovery status tables.
+  - ORCA-683* `collectionId` added to [Recovery Job status](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-jobs-api-output) output.
 
 ### Changed
 - *ORCA-573* Updated ORCA DB user password to now have a stronger password requirement. See migration notes for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and includes an additional section for migration notes.
 - *ORCA-614*, *ORCA-428* Moved some Internal Reconciliation functionality to GraphQL
 - *ORCA-679* Updated area in recovery where granule ID was treated as a globally unique key. Per Cumulus updates, uniqueness is now granule ID plus collection ID.
   - *ORCA-678* `collection_id` column added to recovery status tables.
-  - ORCA-683* `collectionId` added to [Recovery Job status](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-jobs-api-output) output.
+  - *ORCA-683* `collectionId` added to [Recovery Job status](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-jobs-api-output) output.
+  - *ORCA-684* `collectionId` added to [Recovery Granule status](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-granules-api) input and output.
 
 ### Changed
 - *ORCA-573* Updated ORCA DB user password to now have a stronger password requirement. See migration notes for details.
@@ -35,6 +36,9 @@ and includes an additional section for migration notes.
 - *ORCA-647* Upgraded sqlalchemy from v1.4.11 to v2.0.5.
 
 ### Migration Notes
+- `collectionId` properties have been added to [Recovery Jobs](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-jobs-api) and [Recovery Granules](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-granules-api).
+  - For Recovery Jobs, it is only added to [output](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-jobs-api-output).
+  - For Recovery Granules, it is now required on [input](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-granules-api-input) and will be returned on [output](https://nasa.github.io/cumulus-orca/docs/developer/api/orca-api#recovery-granules-api-output).
 - Changes have been made to SQS message processing that are not backwards compatible. Halt ingest and wait for the `PREFIX-orca-status-update-queue.fifo` queue to empty before applying update.
   - If the queue is or becomes stuck, it may be necessary to flush the queue and its associated Dead Letter Queue.
 - The output format of `copy_to_archive` lambda and step-function has been simplified. If accessing these resources outside of a Cumulus perspective, instead of accessing `output["payload"]["granules"]` you now use `output["granules"]`.

--- a/tasks/request_status_for_granule/README.md
+++ b/tasks/request_status_for_granule/README.md
@@ -12,9 +12,10 @@ Visit the [Developer Guide](https://nasa.github.io/cumulus-orca/docs/developer/d
 Fully defined json schemas written in the schema of https://json-schema.org/ can be found in the [schemas folder](schemas).
 
 ### Example Input
-Input with granule_id and asyncOperationId.
+Input with granule info and asyncOperationId.
 ```json
 {
+  "collectionId": "collectionName___001",
   "granuleId": "6c8d0c8b-4f9a-4d87-ab7c-480b185a0250",
   "asyncOperationId": "43c9751b-9498-4733-90d8-56b1458e0f85"
 }
@@ -22,6 +23,7 @@ Input with granule_id and asyncOperationId.
 Input with no asyncOperationId. Only the most recent operation for the granule will be queried.
 ```json
 {
+  "collectionId": "collectionName___001",
   "granuleId": "6c8d0c8b-4f9a-4d87-ab7c-480b185a0250"
 }
 ```
@@ -29,6 +31,7 @@ Input with no asyncOperationId. Only the most recent operation for the granule w
 ### Example Output
 ```json
 {
+  "collectionId": "collectionName___001",
   "granuleId": "6c8d0c8b-4f9a-4d87-ab7c-480b185a0250",
   "asyncOperationId": "43c9751b-9498-4733-90d8-56b1458e0f85",
   "files": [

--- a/tasks/request_status_for_granule/schemas/input.json
+++ b/tasks/request_status_for_granule/schemas/input.json
@@ -5,8 +5,11 @@
 	"description": "The input for the request_status Lambda when retrieving status for a particular granule.",
 	"type": "object",
 	"properties": {
+		"collectionId": {
+			"description": "The ID of the collection containing the granule."
+		},
 		"granuleId": {
-			"description": "The unique ID of the granule to retrieve status for.",
+			"description": "The ID of the granule to retrieve status for.",
 			"type": "string"
 		},
 		"asyncOperationId": {
@@ -14,5 +17,5 @@
 			"type": "string"
 		}
 	},
-	"required": [ "granuleId" ]
+	"required": [ "collectionId", "granuleId" ]
 }

--- a/tasks/request_status_for_granule/schemas/output.json
+++ b/tasks/request_status_for_granule/schemas/output.json
@@ -5,8 +5,12 @@
 	"description": "The output from the request_status Lambda when retrieving status for a particular granule. If multiple jobs match the information given, only the most recent will be returned.",
 	"type": "object",
 	"properties": {
+		"collectionId": {
+			"description": "The ID of the collection containing the granule retrieved.",
+			"type": "string"
+		},
 		"granuleId": {
-			"description": "The unique ID of the granule to retrieve status for.",
+			"description": "The ID of the granule retrieved.",
 			"type": "string"
 		},
 		"asyncOperationId": {

--- a/tasks/request_status_for_job/README.md
+++ b/tasks/request_status_for_job/README.md
@@ -29,14 +29,17 @@ Fully defined json schemas written in the schema of https://json-schema.org/ can
   },
   "granules": [
     {
+      "collectionId": "collectionName___001",
       "granuleId": "6c8d0c8b-4f9a-4d87-ab7c-480b185a0250",
       "status": "failed"
     },
     {
+      "collectionId": "collectionName___001",
       "granuleId": "b5681dc1-48ba-4dc3-877d-1b5ad97e8276",
       "status": "pending"
     },
     {
+      "collectionId": "collectionName___001",
       "granuleId": "7a75767d-abe3-4c1d-b55f-9009de1838f8",
       "status": "success"
     }

--- a/tasks/request_status_for_job/request_status_for_job.py
+++ b/tasks/request_status_for_job/request_status_for_job.py
@@ -17,6 +17,7 @@ OUTPUT_JOB_ID_KEY = "asyncOperationId"
 OUTPUT_JOB_STATUS_TOTALS_KEY = "jobStatusTotals"
 OUTPUT_GRANULES_KEY = "granules"
 OUTPUT_STATUS_KEY = "status"
+OUTPUT_COLLECTION_ID_KEY = "collectionId"
 OUTPUT_GRANULE_ID_KEY = "granuleId"
 
 
@@ -100,6 +101,7 @@ def get_granule_status_entries_for_job(
     for row in results.mappings():
         rows.append(
             {
+                OUTPUT_COLLECTION_ID_KEY: row[OUTPUT_COLLECTION_ID_KEY],
                 OUTPUT_GRANULE_ID_KEY: row[OUTPUT_GRANULE_ID_KEY],
                 OUTPUT_STATUS_KEY: row[OUTPUT_STATUS_KEY],
             }
@@ -111,6 +113,7 @@ def get_granule_status_entries_for_job_sql() -> text:  # pragma: no cover
     return text(  # nosec
         f"""
                 SELECT
+                    collection_id as "{OUTPUT_COLLECTION_ID_KEY}
                     granule_id as "{OUTPUT_GRANULE_ID_KEY}",
                     recovery_status.value AS "{OUTPUT_STATUS_KEY}"
                 FROM

--- a/tasks/request_status_for_job/schemas/output.json
+++ b/tasks/request_status_for_job/schemas/output.json
@@ -44,11 +44,11 @@
 				"type": "object",
 				"properties": {
 					"collectionId": {
-						"description": "The id of the collection containing the granule.",
+						"description": "The ID of the collection containing the granule.",
 						"type": "string"
 					},
 					"granuleId": {
-						"description": "The id of the granule.",
+						"description": "The ID of the granule.",
 						"type": "string"
 					},
 					"status": {

--- a/tasks/request_status_for_job/schemas/output.json
+++ b/tasks/request_status_for_job/schemas/output.json
@@ -43,8 +43,12 @@
 				"description": "A granule being copied as part of the job.",
 				"type": "object",
 				"properties": {
+					"collectionId": {
+						"description": "The id of the collection containing the granule.",
+						"type": "string"
+					},
 					"granuleId": {
-						"description": "The unique ID of the granule.",
+						"description": "The id of the granule.",
 						"type": "string"
 					},
 					"status": {
@@ -53,7 +57,7 @@
 						"pattern": "^(pending|success|error|staged)$"
 					}
 				},
-				"required": [ "granuleId", "status" ]
+				"required": [ "collectionId", "granuleId", "status" ]
 			},
 			"uniqueItems": true
 		}

--- a/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
+++ b/tasks/request_status_for_job/test/unit_tests/test_request_status_for_job.py
@@ -45,6 +45,7 @@ class TestRequestStatusForJobUnit(
             request_status_for_job.OUTPUT_JOB_ID_KEY: job_id,
             request_status_for_job.OUTPUT_GRANULES_KEY: [
                 {
+                    request_status_for_job.OUTPUT_COLLECTION_ID_KEY: uuid.uuid4().__str__(),
                     request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
                     request_status_for_job.OUTPUT_STATUS_KEY: "staged"
                 }
@@ -182,6 +183,7 @@ class TestRequestStatusForJobUnit(
             request_status_for_job.OUTPUT_JOB_ID_KEY: job_id,
             request_status_for_job.OUTPUT_GRANULES_KEY: [
                 {
+                    request_status_for_job.OUTPUT_COLLECTION_ID_KEY: uuid.uuid4().__str__(),
                     request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
                     request_status_for_job.OUTPUT_STATUS_KEY: "staged"
                 }
@@ -280,10 +282,12 @@ class TestRequestStatusForJobUnit(
 
         expected_result = [
             {
+                request_status_for_job.OUTPUT_COLLECTION_ID_KEY: uuid.uuid4().__str__(),
                 request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
                 request_status_for_job.OUTPUT_STATUS_KEY: uuid.uuid4().__str__(),
             },
             {
+                request_status_for_job.OUTPUT_COLLECTION_ID_KEY: uuid.uuid4().__str__(),
                 request_status_for_job.OUTPUT_GRANULE_ID_KEY: uuid.uuid4().__str__(),
                 request_status_for_job.OUTPUT_STATUS_KEY: uuid.uuid4().__str__(),
             },
@@ -389,6 +393,10 @@ class TestRequestStatusForJobUnit(
         job_id = uuid.uuid4().__str__()
 
         db_connect_info = Mock()
+
+        collection_id_0 = uuid.uuid4().__str__()
+        collection_id_1 = uuid.uuid4().__str__()
+
         granule_id_0 = uuid.uuid4().__str__()
         granule_id_1 = uuid.uuid4().__str__()
 
@@ -397,10 +405,12 @@ class TestRequestStatusForJobUnit(
         mock_execute_result0.mappings = Mock(
             return_value=[
                 {
+                    request_status_for_job.OUTPUT_COLLECTION_ID_KEY: collection_id_0,
                     request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_0,
                     request_status_for_job.OUTPUT_STATUS_KEY: "success",
                 },
                 {
+                    request_status_for_job.OUTPUT_COLLECTION_ID_KEY: collection_id_1,
                     request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_1,
                     request_status_for_job.OUTPUT_STATUS_KEY: "pending",
                 },
@@ -431,10 +441,12 @@ class TestRequestStatusForJobUnit(
             request_status_for_job.OUTPUT_JOB_ID_KEY: job_id,
             request_status_for_job.OUTPUT_GRANULES_KEY: [
                 {
+                    request_status_for_job.OUTPUT_COLLECTION_ID_KEY: collection_id_0,
                     request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_0,
                     request_status_for_job.OUTPUT_STATUS_KEY: "success",
                 },
                 {
+                    request_status_for_job.OUTPUT_COLLECTION_ID_KEY: collection_id_1,
                     request_status_for_job.OUTPUT_GRANULE_ID_KEY: granule_id_1,
                     request_status_for_job.OUTPUT_STATUS_KEY: "pending",
                 }

--- a/website/docs/developer/api/api.md
+++ b/website/docs/developer/api/api.md
@@ -124,7 +124,7 @@ Recovery granules API input invoke URL example: `https://example.execute-api.us-
 An example of the API input body is shown below:
 ```json
 {
-  "granule_id": "MOD14A1.061.H5V12.2020312.141531789",
+  "granuleId": "MOD14A1.061.H5V12.2020312.141531789",
   "asyncOperationId": "43c9751b-9498-4733-90d8-56b1458e0f85"
 }
 ```
@@ -212,10 +212,12 @@ An example of the API output is shown below:
   },
   "granules": [
     {
+      "collectionId": "collectionName___001",
       "granuleId": "6c8d0c8b-4f9a-4d87-ab7c-480b185a0250",
       "status": "error"
     },
     {
+      "collectionId": "collectionName___001",
       "granuleId": "b5681dc1-48ba-4dc3-877d-1b5ad97e8276",
       "status": "pending"
     }
@@ -229,8 +231,9 @@ The following table lists the fields in the output:
 | asyncOperationId    | `str`       | The unique ID of the asyncOperation.                                                                |
 | jobStatusTotals     | `Object`    | Sum of how many granules are in each particular restoration status ('pending', 'staged', 'success', or 'error'). |
 | granules            | `Array[Object]` | An array representing each granule being copied as part of the job.                             |
-| granuleId           | `str`       | The unique ID of the granule retrieved.                                                             |
-| status              | `str`       | The status of the restoration of the file. May be 'pending', 'staged', 'success', or 'error'.       |
+| collectionId        | `str`       | The id of the collection containing the granule.                                                    |
+| granuleId           | `str`       | The id of the granule.                                                                              |
+| status              | `str`       | The status of the restoration of the granule. May be 'pending', 'staged', 'success', or 'error'.    |
 
 The API returns status code 200 on success, 400 if input is in incorrect format, 500 if an error occurs when querying the database, and 404 if not found.
 

--- a/website/docs/developer/api/api.md
+++ b/website/docs/developer/api/api.md
@@ -124,6 +124,7 @@ Recovery granules API input invoke URL example: `https://example.execute-api.us-
 An example of the API input body is shown below:
 ```json
 {
+  "collectionId": "collectionName___001",
   "granuleId": "MOD14A1.061.H5V12.2020312.141531789",
   "asyncOperationId": "43c9751b-9498-4733-90d8-56b1458e0f85"
 }
@@ -132,7 +133,8 @@ The following table lists the fields in the input:
 
 | Name              | Data Type   | Description                                                                              | Required |
 | ------------------|-------------|------------------------------------------------------------------------------------------|----------|
-| granuleId         | `str`       | The unique ID of the granule to retrieve status for.                                     | Yes |
+| collectionId      | `str`       | The ID of the collection containing the granule.                                         | Yes |
+| granuleId         | `str`       | The ID of the granule to retrieve status for.                                            | Yes |
 | asyncOperationId  | `str`       | The unique ID of the asyncOperation. May apply to a request that covers multiple granules. | No |
 
 
@@ -140,6 +142,7 @@ The following table lists the fields in the input:
 An example of the API output is shown below:
 ```json
 {
+  "collectionId": "collectionName___001",
   "granuleId": "MOD14A1.061.H5V12.2020312.141531789",
   "asyncOperationId": "43c9751b-9498-4733-90d8-56b1458e0f85",
   "files": [
@@ -168,7 +171,8 @@ The following table lists the fields in the output:
 
 | Name               | Data Type   |                           Description                                                               |
 | -------------------| ----------- | ----------------------------------------------------------------------------------------------------|
-| granuleId          | `str`       | The unique ID of the granule retrieved.                                                             |
+| collectionId       | `str`       | The ID of the collection containing the granule retrieved.                                          |
+| granuleId          | `str`       | The ID of the granule retrieved.                                                                    |
 | asyncOperationId   | `str`       | The unique ID of the asyncOperation.                                                                |
 | files              | `Array[Object]`| Description and status of the files within the given granule.                                    |
 | fileName           | `str`       | The name and extension of the file.                                                                 |


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-675: catalog reporting: Remove incorrect assertions of "unique" in schema.](https://bugs.earthdata.nasa.gov/browse/ORCA-675)
Addresses [ORCA-683: request_status_for_job: Add collection_id](https://bugs.earthdata.nasa.gov/browse/ORCA-683)
Addresses [ORCA-684: request_status_for_granule: Add collection_id](https://bugs.earthdata.nasa.gov/browse/ORCA-684)

## Changes

* Added collectionId to request_status_for_job output.
* Added collectionId to request_status_for_granule input and output.
* Updated developer and user docs for new API.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Path not yet ready for deployment. Tested locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Testing documentation
    - [x] Development documentation
    - [x] User documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] New and existing unit tests pass locally with my changes
    - [x] Automated tests passing (if not fork)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets