### PR TITLE
Feature/orca 513 Improve logging in integration tests

### DIFF
--- a/integration_test/workflow_tests/custom_logger.py
+++ b/integration_test/workflow_tests/custom_logger.py
@@ -6,7 +6,7 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
     # https://stackoverflow.com/questions/39467271/cant-get-this-custom-logging-adapter-example-to-work
     def process(self, msg, kwargs):
         my_context = kwargs.pop('my_context', self.extra['my_context'])
-        return '[%s] %s' % (my_context, msg), kwargs
+        return f"[{my_context}] {msg}", kwargs
 
     def set_logger(group_name):
         logger = logging.getLogger(__name__)

--- a/integration_test/workflow_tests/custom_logger.py
+++ b/integration_test/workflow_tests/custom_logger.py
@@ -1,0 +1,16 @@
+import logging
+
+
+class CustomLoggerAdapter(logging.LoggerAdapter):
+    # example taken from
+    # https://stackoverflow.com/questions/39467271/cant-get-this-custom-logging-adapter-example-to-work
+    def process(self, msg, kwargs):
+        my_context = kwargs.pop('my_context', self.extra['my_context'])
+        return '[%s] %s' % (my_context, msg), kwargs
+
+    def set_logger(group_name):
+        logger = logging.getLogger(__name__)
+        syslog = logging.StreamHandler()
+        logger.addHandler(syslog)
+        logger_adapter = CustomLoggerAdapter(logger, {'my_context': group_name})
+        return logger_adapter

--- a/integration_test/workflow_tests/helpers.py
+++ b/integration_test/workflow_tests/helpers.py
@@ -113,7 +113,7 @@ def get_state_machine_execution_results(
     start = datetime.datetime.utcnow()
     while True:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/stepfunctions.html#SFN.Client.describe_execution
-        logging.debug("Getting execution description...")
+        logging.debug(f"Getting execution description from {execution_arn}")
         execution_state = boto3.client("stepfunctions").describe_execution(
             executionArn=execution_arn
         )

--- a/integration_test/workflow_tests/test_packages/catalog/test_provider_does_not_exist.py
+++ b/integration_test/workflow_tests/test_packages/catalog/test_provider_does_not_exist.py
@@ -1,11 +1,13 @@
 import json
-import logging
 import time
 import uuid
 from unittest import TestCase
 
 import helpers
+from custom_logger import CustomLoggerAdapter
 
+#Set the logger
+logging = CustomLoggerAdapter.set_logger("Ingest TestProviderDoesNotExist")
 
 class TestProviderDoesNotExist(TestCase):
     def test_provider_does_not_exist_returns_empty_granules_list(self):

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_files_excluded.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_files_excluded.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 import uuid
 from unittest import TestCase, mock
@@ -10,7 +9,10 @@ import boto3
 from botocore.exceptions import ClientError
 
 import helpers
+from custom_logger import CustomLoggerAdapter
 
+#Set the logger
+logging = CustomLoggerAdapter.set_logger("Ingest TestMultipleGranulesFilesExcluded")
 
 class TestMultipleGranules(TestCase):
     def test_multiple_granules_files_excluded_passes(self):
@@ -38,7 +40,6 @@ class TestMultipleGranules(TestCase):
             # Upload the randomized file to source bucket
             boto3.client('s3').upload_file("file1.hdf",
                                             bucket_name, key_name)
-
             copy_to_archive_input = {
                 "payload": {
                     "granules": [

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 import uuid
 from unittest import TestCase, mock
@@ -7,7 +6,10 @@ from unittest import TestCase, mock
 import boto3
 
 import helpers
+from custom_logger import CustomLoggerAdapter
 
+#Set the logger
+logging = CustomLoggerAdapter.set_logger("Ingest TestMultipleGranulesHappyPath")
 
 class TestMultipleGranulesHappyPath(TestCase):
 
@@ -263,3 +265,26 @@ class TestMultipleGranulesHappyPath(TestCase):
         except Exception as ex:
             logging.error(ex)
             raise
+
+
+# import logging
+
+# class CustomAdapter(logging.LoggerAdapter):
+#     def process(self, msg, kwargs):
+#         my_context = kwargs.pop('my_context', self.extra['my_context'])
+#         return '[%s] %s' % (my_context, msg), kwargs
+
+#     def set_logger(group_name):
+
+#         logger = logging.getLogger(__name__)
+#         syslog = logging.StreamHandler()
+#         logger.addHandler(syslog)
+#         adapter = CustomAdapter(logger,{'my_context': group_name})
+#         return adapter
+
+# logger = CustomAdapter.set_logger("Ingest test logger")
+# logger.setLevel(logging.INFO)
+
+# logger.info('The sky is so blue')
+# logger.error("test")
+# logger.critical("test critical")

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_happy_path.py
@@ -265,26 +265,3 @@ class TestMultipleGranulesHappyPath(TestCase):
         except Exception as ex:
             logging.error(ex)
             raise
-
-
-# import logging
-
-# class CustomAdapter(logging.LoggerAdapter):
-#     def process(self, msg, kwargs):
-#         my_context = kwargs.pop('my_context', self.extra['my_context'])
-#         return '[%s] %s' % (my_context, msg), kwargs
-
-#     def set_logger(group_name):
-
-#         logger = logging.getLogger(__name__)
-#         syslog = logging.StreamHandler()
-#         logger.addHandler(syslog)
-#         adapter = CustomAdapter(logger,{'my_context': group_name})
-#         return adapter
-
-# logger = CustomAdapter.set_logger("Ingest test logger")
-# logger.setLevel(logging.INFO)
-
-# logger.info('The sky is so blue')
-# logger.error("test")
-# logger.critical("test critical")

--- a/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_same_id_different_collections.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_multiple_granules_same_id_different_collections.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 import uuid
 from unittest import TestCase, mock
@@ -7,7 +6,10 @@ from unittest import TestCase, mock
 import boto3
 
 import helpers
+from custom_logger import CustomLoggerAdapter
 
+#Set the logger
+logging = CustomLoggerAdapter.set_logger("Ingest TestMultipleGranulesSameIdDifferentCollections")
 
 class TestMultipleGranulesSameIdDifferentCollections(TestCase):
 

--- a/integration_test/workflow_tests/test_packages/ingest/test_no_granules.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_no_granules.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 import uuid
 from unittest import TestCase
@@ -7,7 +6,10 @@ from unittest import TestCase
 import boto3
 
 import helpers
+from custom_logger import CustomLoggerAdapter
 
+#Set the logger
+logging = CustomLoggerAdapter.set_logger("Ingest TestNoGranules")
 
 class TestNoGranules(TestCase):
     def test_no_granules_passes(self):

--- a/integration_test/workflow_tests/test_packages/ingest/test_override_storage_class.py
+++ b/integration_test/workflow_tests/test_packages/ingest/test_override_storage_class.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 import uuid
 from unittest import TestCase, mock
@@ -7,7 +6,10 @@ from unittest import TestCase, mock
 import boto3
 
 import helpers
+from custom_logger import CustomLoggerAdapter
 
+#Set the logger
+logging = CustomLoggerAdapter.set_logger("Ingest TestOverrideStorageClassHappyPath")
 
 class TestOverrideStorageClassHappyPath(TestCase):
 

--- a/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
+++ b/tasks/orca_catalog_reporting/test/unit_tests/test_orca_catalog_reporting.py
@@ -424,6 +424,7 @@ class TestOrcaCatalogReportingUnit(
                 }
             ],
         )
+        mock_execute_result.mappings.assert_called_once_with()
         mock_exit.assert_called_once_with(None, None, None)
         mock_get_catalog_sql.assert_called_once_with()
         self.assertEqual(


### PR DESCRIPTION
## Summary of Changes

Please write a sentence or two summarizing the proposed change.

Addresses [ORCA-513: Improve logging in integration tests
](https://bugs.earthdata.nasa.gov/browse/ORCA-513)

## Changes

* added custom logger to categorize integration tests

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran the integration tests and verified tests are categorized.

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas

- [x ] My changes generate no new warnings
- [ x] My code has passed security scanning
    - [x ] Snyk
    - [x ] git-secrets



## What is the expected correct/added behavior?

Tests are logged as 
`[Ingest TestMultipleGranulesFilesExcluded]`, 
`[Ingest TestOverrideStorageClassHappyPath]`, 
`[Ingest TestProviderDoesNotExist]`, 
`[Ingest TestMultipleGranulesSameIdDifferentCollections]`, 
`[Ingest TestMultipleGranulesHappyPath]`
`[Ingest TestNoGranules"]`
