### PR TITLE
ORCA-714 Fix AWS GW Deployment error on fresh install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and includes an additional section for migration notes.
 
 ### Changed
 - *ORCA-700* Removed Cumulus Workflow wrapper from step-functions. No anticipated customer impact.
+- *ORCA-709* Updated terraform AWS provider to version 5. This is to support Cumulus and CIRRUS changes.
 
 ### Migration Notes
 - Changes have been made to SQS message processing that are not backwards compatible. Halt ingest and wait for the `PREFIX-orca-status-update-queue.fifo` queue to empty before applying update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and includes an additional section for migration notes.
 ### Changed
 - *ORCA-700* Removed Cumulus Workflow wrapper from step-functions. No anticipated customer impact.
 - *ORCA-709* Updated terraform AWS provider to version 5. This is to support Cumulus and CIRRUS changes.
+- *ORCA-712* Fixed new deployment errors with API Gateway by adding an IAM policy and tying it to the GW.
 
 ### Migration Notes
 - Changes have been made to SQS message processing that are not backwards compatible. Halt ingest and wait for the `PREFIX-orca-status-update-queue.fifo` queue to empty before applying update.

--- a/modules/api-gateway/main.tf
+++ b/modules/api-gateway/main.tf
@@ -21,6 +21,28 @@ resource "aws_api_gateway_rest_api" "orca_api" {
   }
 }
 
+# TODO: This policy should be tightened up to only allow traffic from the Cumulus and DR VPC users
+#       for now, this has been left open to prevent any breakage and resolve a deployment issue.
+# .     See ORCA-721
+data "aws_iam_policy_document" "orca_api_policy" {
+  statement {
+    resources = ["*"]
+    actions   = ["execute-api:Invoke"]
+    effect = "Allow"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+  }
+}
+
+resource "aws_api_gateway_rest_api_policy" "orca_api_policy" {
+  rest_api_id = aws_api_gateway_rest_api.orca_api.id
+  policy      = data.aws_iam_policy_document.orca_api_policy.json
+}
+
 #API details for orca_catalog_reporting lambda
 resource "aws_api_gateway_resource" "orca_catalog_reporting_api_resource_catalog" {
   path_part   = "catalog"
@@ -505,5 +527,6 @@ resource "aws_api_gateway_deployment" "orca_api_deployment" {
     aws_api_gateway_integration.internal_reconcile_report_job_api_integration,
     aws_api_gateway_integration.internal_reconcile_report_orphan_api_integration,
     aws_api_gateway_integration.internal_reconcile_report_phantom_api_integration,
-  aws_api_gateway_integration.internal_reconcile_report_mismatch_api_integration]
+    aws_api_gateway_integration.internal_reconcile_report_mismatch_api_integration
+  ]
 }

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,9 +1,4 @@
 resource "aws_ecs_cluster" "orca_ecs_cluster" {
   name = "${var.prefix}_orca_ecs_cluster"
-  capacity_providers = ["FARGATE"]
-  default_capacity_provider_strategy {
-    capacity_provider = "FARGATE"
-    weight            = 100
-  }
   tags                = var.tags
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.63.0, < 4.0.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes

Update API GW deployment to remove deployment issues requiring you to run terraform apply twice on initial installs into an environment.

Addresses [ORCA-714: Fix issues with API GW requiring 2 terraform apply to deploy](https://bugs.earthdata.nasa.gov/browse/ORCA-714)

## Changes

* Created a permissive IAM policy for the API GW
* Tied the IAM policy to the gateway

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual tests were performed for deployment to verify no error occured on fresh deployments.
- Manually tested access to the API by using an aws ssm tunnel to the API GW and running a basic curl command to the resource path using the setup below.

### Setup

#### Needed items
- EC2 instance to tunnel through (Cumulus ECS Cluster EC2 was used for this)
- API Gateway ID from deployment (retrieved via aws cli or the AWS GUI)

#### Environment setup
Two terminal windows are needed to perform the test

##### Terminal 1
 In the first terminal run the following command substituting you EC2 instance ID and your API Gateway ID

`aws ssm start-session --target <EC2 Instance ID> --document-name AWS-StartPortForwardingSessionToRemot
eHost --parameters '{"host":["<API GW ID>.execute-api.us-west-2.amazonaws
.com"],"portNumber":["443"], "localPortNumber":["8000"]}'`

##### Terminal 2
In the second window run a curl command for one of the paths providing the proper input as seen below. Replace with your API Gateway ID

`curl -X POST -d '{"pageIndex": 0, "endTimestamp": 10000000000000}' -H 'x-apigw-api-id:<API GW ID>' -k https://127.0.0.1:8000/orca/catalog/reconcile/ | jq .`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [X] CHANGELOG.md
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
    - [X] Manual tests (outlined above)
- [X] New and existing unit tests pass locally with my changes
    - [X] Automated tests passing (if not fork)
    - [X] Manual testing/integration testing passes (if forked)
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] My code has passed security scanning
    - [X] Snyk
    - [X] git-secrets

## What is the current behavior?

When running terraform apply on new installations the deploy fails with an API GW error message. If the deploy is ran again no, error occurs and no updates are made.

## What is the expected correct/added behavior?

when running terraform apply on a fresh install, no errors should occur.