### PR TITLE
[ORCA-716] bug: fix graphql service deployment failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and includes an additional section for migration notes.
 ### Changed
 - *ORCA-700* Removed Cumulus Workflow wrapper from step-functions. No anticipated customer impact.
 - *ORCA-709* Updated terraform AWS provider to version 5. This is to support Cumulus and CIRRUS changes.
-- *ORCA-712* Fixed new deployment errors with API Gateway by adding an IAM policy and tying it to the GW.
+- *ORCA-714* Fixed new deployment errors with API Gateway by adding an IAM policy and tying it to the GW.
+- *ORCA-716* Fixed Deployment issues with GraphQL tasks by adding permission and health check.
 
 ### Migration Notes
 - Changes have been made to SQS message processing that are not backwards compatible. Halt ingest and wait for the `PREFIX-orca-status-update-queue.fifo` queue to empty before applying update.

--- a/modules/graphql_1/main.tf
+++ b/modules/graphql_1/main.tf
@@ -46,7 +46,10 @@ data "aws_iam_policy_document" "gql_task_execution_policy_document" {
     actions = [
       "secretsmanager:GetSecretValue"
     ]
-    resources = [var.db_connect_info_secret_arn]
+    resources = [
+      var.db_connect_info_secret_arn,
+      var.s3_access_credentials_secret_arn
+    ]
   }
 }
 
@@ -235,6 +238,16 @@ resource "aws_ecs_task_definition" "gql_task" {
         "awslogs-group": "${var.prefix}_orca_graph_ql",
         "awslogs-stream-prefix": "ecs"
       }
+    },
+    "HealthCheck": {
+      "Command": [
+        "CMD-SHELL",
+	      "curl --fail http://localhost:5000/healthz || exit 1"
+      ],
+      "StartPeriod": 30,
+      "Interval": 60,
+      "Timeout": 5,
+      "Retries": 3
     }
   }
 ]


### PR DESCRIPTION
## Summary of Changes

This fix updates the terraform files for deploying the GraphQL service by fixing a missing permission and adding a healthcheck.

Addresses [ORCA-716: Fix issues with GraphQL deployment](https://bugs.earthdata.nasa.gov/browse/ORCA-716)

## Changes

* Updated file `modules/graphql_1/main.tf` with additional permissions to access S3 credentials and a healthcheck

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually by visually inspecting ECS cluster through AWS cluster and verifying tasks started and ran without error.

In addition, the service was redeployed in `development` mode and tunneling was tested to verify access and functionality to the service by using the browser. The setup for this test is below.

### In terminal 1
Create a aws ssm session with a tunnel to the load balancer. Replace with the DNS of your internal load balancer and EC2 instance (I used the Cumulus ECS cluster in the account) as seen below.

`aws ssm start-session --target <EC2 Instance> --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["<Load Balancer DNS>"],"portNumber":["5000"], "localPortNumber":["8000"]}'`

### In terminal 2
Open your web browser like firefox to the address `http://localhost:8000/graphql`.

You should have the development plaground website available to query the GraphQL server. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [X] CHANGELOG.md
    - [ ] Testing documentation
    - [ ] Development documentation
    - [ ] User documentation
    - [ ] (Additional here)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
    - [ ] Unit tests
    - [ ] Integration tests
    - [X] Manual tests (outlined above)
- [X] New and existing unit tests pass locally with my changes
    - [X] Automated tests passing (if not fork)
    - [X] Manual testing/integration testing passes (if forked)
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My code has passed security scanning
    - [X] Snyk
    - [X] git-secrets

## What is the current behavior?

Tasks fail to start for the GraphQL service

## What is the expected correct/added behavior?

Tasks should start on deployment without error.

## Relevant logs and/or screenshots

See card

## Possible fixes

See Card