### PR TITLE
changed parallel configuration in run and build scripts

### DIFF
--- a/bin/build_tasks.sh
+++ b/bin/build_tasks.sh
@@ -40,7 +40,8 @@ export -f build_task
 task_dirs=$(ls -d tasks/* | egrep -v "package")
 
 echo "Building in parallel..."
-parallel --jobs 0 -n 1 -X --halt now,fail=1 build_task ::: $task_dirs
+# todo: ORCA-681: Repair parallelism and switch back to `--jobs 0`
+parallel --jobs 1 -n 1 -X --halt now,fail=1 build_task ::: $task_dirs
 
 process_return_code=$?
 echo

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -41,7 +41,8 @@ task_dirs=$(ls -d tasks/* | egrep -v "package")
 ## Call each task's testing suite
 ## TODO: Add more logging output
 echo "Running unit tests in parallel..."
-parallel --jobs 0 -n 1 -X --halt now,fail=1 run_unit_tests ::: $task_dirs
+# todo: ORCA-681: Repair parallelism and switch back to `--jobs 0`
+parallel --jobs 1 -n 1 -X --halt now,fail=1 run_unit_tests ::: $task_dirs
 
 process_return_code=$?
 echo


### PR DESCRIPTION
## Summary of Changes

Addresses error during bin/build_task.sh and bin/run_tests.sh. 
      ERROR: Failed building wheel for orca-shared
      ERROR: Could not build wheels for orca-shared, which is required to install pyproject.toml-based projects

## Changes

* Changed parallel configuration in bin/build_tasks.sh and bin/run_tests.sh. See https://bugs.earthdata.nasa.gov/browse/ORCA-681

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran bin/build_task.sh and bin/run_tests.sh successfully locally.
