### PR TITLE
Updated CHANGELOG with version 6.0.4 information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,12 @@ and includes an additional section for migration notes.
   }
   ```
 
+## [6.0.4] 2023-09-26
+
+### Fixed
+
+- *ORCA-738* Update cumulus-process to v1.2.0 and cumulus-message-adapter-python to v2.1.0. To alleviate potential issues related to timeouts when using CMA calls.
+
 ## [6.0.3] 2023-02-28
 
 ### Changed


### PR DESCRIPTION
## Summary of Changes

Updated CHANGELOG to include release 6.0.4

Addresses [ORCA-738: Upgrade Cumulus Message Adapter libraries](https://bugs.earthdata.nasa.gov/browse/ORCA-738)

## Changes

All changes for the release have already occured in later versions. This backwards compatible patch was made for teams that were not ready to go to Cumulus versions 17 or 18.