### PR TITLE
ORCA-366 - Improve/Add additional unit tests needed in shared_recovery.py

### DIFF
--- a/shared_libraries/orca_shared/recovery/test/unit_tests/test_shared_recovery.py
+++ b/shared_libraries/orca_shared/recovery/test/unit_tests/test_shared_recovery.py
@@ -94,6 +94,7 @@ class TestSharedRecoveryLibraries(unittest.TestCase):
                         }
                     ]
                 )
+                print(request_method.value)
 
     @patch.dict(
         os.environ,

--- a/shared_libraries/orca_shared/recovery/test/unit_tests/test_shared_recovery.py
+++ b/shared_libraries/orca_shared/recovery/test/unit_tests/test_shared_recovery.py
@@ -94,7 +94,12 @@ class TestSharedRecoveryLibraries(unittest.TestCase):
                         }
                     ]
                 )
-                print(request_method.value)
+                # Verifies that request_method is set properly (new_job or update_file)
+                self.assertTrue(
+                    request_method.value == "new_job"
+                    or request_method.value == "update_file",
+                    f"Incorrect Request Method: {request_method.value}",
+                )
 
     @patch.dict(
         os.environ,


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-366: Improve/Add additional unit tests needed in shared_recovery.py.](https://bugs.earthdata.nasa.gov/browse/ORCA-366)

## Changes

* Added unit test to verify request_method has the correct value associated

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran using Bamboo and locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] My code has passed security scanning
    - [x] git-secrets
    - [x] Snyk

