### PR TITLE
ORCA-710: Fix duplicate messages in workflow_tests/custom_logger.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,17 @@ and includes an additional section for migration notes.
 - *Security* - Vulnerabilities fixes and changes.
 
 ## [Unreleased]
-- *ORCA-366* Adding unit test for request_method
 
 ### Migration Notes
 
 ### Added
 
+- *ORCA-366* Adding unit test for request_method
+
 ### Changed
 
 - *ORCA-361* Removed hardcoded test values from `extract_file_paths_for_granule` unit tests.
+- *ORCA-710* Removing duplicate logging messages in `integration_test/workflow_tests/custom_logger.py`
 
 ### Deprecated
 

--- a/integration_test/workflow_tests/custom_logger.py
+++ b/integration_test/workflow_tests/custom_logger.py
@@ -11,8 +11,8 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
     @staticmethod
     def set_logger(group_name):
         logger = logging.getLogger(__name__)
-        syslog = logging.StreamHandler()
-        logger.addHandler(syslog)
-        logger_adapter = CustomLoggerAdapter(logger, {'my_context': group_name})
-        logger.propagate = False
+        logger_adapter = CustomLoggerAdapter(logger, {"my_context": group_name})
+        if not logger.handlers:
+            syslog = logging.StreamHandler()
+            logger.addHandler(syslog)
         return logger_adapter

--- a/integration_test/workflow_tests/custom_logger.py
+++ b/integration_test/workflow_tests/custom_logger.py
@@ -14,4 +14,5 @@ class CustomLoggerAdapter(logging.LoggerAdapter):
         syslog = logging.StreamHandler()
         logger.addHandler(syslog)
         logger_adapter = CustomLoggerAdapter(logger, {'my_context': group_name})
+        logger.propagate = False
         return logger_adapter


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-366: Improve/Add additional unit tests needed in shared_recovery.py.](https://bugs.earthdata.nasa.gov/browse/ORCA-710)

## Changes

* Removed duplicate logging messages produced by `integration_test/workflow_tests/custom_logger.py`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran scripts locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] My code has passed security scanning
    - [x] git-secrets
    - [x] Snyk

