### PR TITLE
ORCA-724: Update Operator documentation for recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and includes an additional section for migration notes.
 - *ORCA-361* Removed hardcoded test values from `extract_file_paths_for_granule` unit tests.
 - *ORCA-710* Removing duplicate logging messages in `integration_test/workflow_tests/custom_logger.py`
 - *ORCA-784* Changed documentation to replace restore with copy based on task's naming as well as changed file name from `website/docs/operator/restore-to-orca.mdx` to `website/docs/operator/reingest-to-orca.mdx`.
-- *ORCA-724* Updated documentation to update inputs and outputs in  `website/docs/operator/data-recovery.md`.
+- *ORCA-724* Updated ORCA recovery documentation to include recovery workflow process and relevant inputs and outputs in `website/docs/operator/data-recovery.md`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and includes an additional section for migration notes.
 - *ORCA-361* Removed hardcoded test values from `extract_file_paths_for_granule` unit tests.
 - *ORCA-710* Removing duplicate logging messages in `integration_test/workflow_tests/custom_logger.py`
 - *ORCA-784* Changed documentation to replace restore with copy based on task's naming as well as changed file name from `website/docs/operator/restore-to-orca.mdx` to `website/docs/operator/reingest-to-orca.mdx`.
+- *ORCA-724* Updated documentation to update inputs and outputs in  `website/docs/operator/data-recovery.md`.
 
 ### Deprecated
 

--- a/website/docs/operator/data-recovery.md
+++ b/website/docs/operator/data-recovery.md
@@ -7,6 +7,10 @@ description: Provides documentation for Operators to recover missing data.
 import MyImage from '@site/docs/templates/pan-zoom-image.mdx';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+:::important
+As of ORCA v8.1 the Cumulus Message Adapter is no longer used. Users will need to deploy the recovery adapter before the recovery can be ran. Reference [Deployment with Cumulus](https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-with-cumulus#modify-the-recovery-workflow)
+:::
+
 ## Recovery via Cumulus Dashboard
 
 Recovery processes are kicked off manually by an operator through the Cumulus Dashboard. 
@@ -58,10 +62,12 @@ The following is an input event example that an operator might set up while runn
       {
         "collectionId": "1234",
         "granuleId": "integrationGranuleId",
+        "version": "integrationGranuleVersion",
         "files": [
           {
             "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
             "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+            "bucket": "test-orca-primary"
           }
         ]
       }
@@ -110,6 +116,10 @@ The following is an input event example that an operator might set up while runn
       ]
     }
   },
+  "cumulus_meta": {
+    "system_bucket": "test-internal",
+    "asyncOperationId": "1234"
+  }
 }
 ```
 
@@ -127,6 +137,7 @@ The following is the corresponding output that the workflow will return if succe
         {
           "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+          "bucket": "test-orca-primary"
         }
       ],
       "keys": [

--- a/website/docs/operator/data-recovery.md
+++ b/website/docs/operator/data-recovery.md
@@ -56,13 +56,12 @@ The following is an input event example that an operator might set up while runn
   "payload": {
     "granules": [
       {
+        "collectionId": "1234",
         "granuleId": "integrationGranuleId",
-        "version": "integrationGranuleVersion",
         "files": [
           {
             "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
             "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-            "bucket": "test-orca-primary"
           }
         ]
       }
@@ -111,10 +110,6 @@ The following is an input event example that an operator might set up while runn
       ]
     }
   },
-  "cumulus_meta": {
-    "system_bucket": "test-internal",
-    "asyncOperationId": "1234"
-  }
 }
 ```
 
@@ -125,13 +120,13 @@ The following is the corresponding output that the workflow will return if succe
 {
   "granules": [
     {
+      "collectionId": "integrationCollectionId",
       "granuleId": "integrationGranuleId",
       "version": "integrationGranuleVersion",
       "files": [
         {
           "fileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "key": "MOD09GQ/006/MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-          "bucket": "test-orca-primary"
         }
       ],
       "keys": [


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-724: Update Operator documentation for recovery](https://bugs.earthdata.nasa.gov/browse/ORCA-724)

## Changes

* Updated documentation to update inputs and outputs in  `website/docs/operator/data-recovery.md`.

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update

## How Has This Been Tested?
Deployed website locally and verified that changes worked successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] Operator Documentation 
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
