### PR TITLE
Feature/orca 789 Update extract_filepaths_for_granule to more flexibly match file-regex values to keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and includes an additional section for migration notes.
 - *ORCA-361* Removed hardcoded test values from `extract_file_paths_for_granule` unit tests.
 - *ORCA-710* Removing duplicate logging messages in `integration_test/workflow_tests/custom_logger.py`
 - *ORCA-784* Changed documentation to replace restore with copy based on task's naming as well as changed file name from `website/docs/operator/restore-to-orca.mdx` to `website/docs/operator/reingest-to-orca.mdx`.
+- *ORCA-789* Updated `extract_filepaths_for_granule` to more flexibly match file-regex values to keys.
 
 ### Deprecated
 

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -8,9 +8,10 @@ import json
 import re
 from typing import Any, Dict, List
 
-import fastjsonschema as fastjsonschema
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
+
+import fastjsonschema as fastjsonschema
 from fastjsonschema import JsonSchemaException
 
 # Set AWS powertools logger
@@ -110,7 +111,7 @@ def task(task_input: Dict[str, Any], config: Dict[str, Any]):
                 else:
                     matching_regex = next(
                         filter(
-                            lambda key: re.compile(key).match(file_name), regex_buckets
+                            lambda key: re.compile(key).search(file_name), regex_buckets
                         ),
                         None,
                     )

--- a/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/test/unit_tests/test_extract_file_paths_for_granule.py
@@ -9,10 +9,10 @@ import uuid
 from test.helpers import create_handler_event, create_task_event
 from unittest.mock import MagicMock, Mock, patch
 
+import extract_filepaths_for_granule
+
 # noinspection PyPackageRequirements
 import fastjsonschema as fastjsonschema
-
-import extract_filepaths_for_granule
 
 # Generating schema validators can take time, so do it once and reuse.
 with open("schemas/input.json", "r") as raw_schema:


### PR DESCRIPTION
## Summary of Changes


Addresses [ORCA-789: Update extract_filepaths_for_granule to more flexibly match file-regex values to keys(https://bugs.earthdata.nasa.gov/browse/ORCA-789)

## Changes

* Used python's .search function instead of .match as requested by NSIDC.

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Deployed in AWS and ran recovery workflows.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x ] CHANGELOG.md
- [x ] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
    - [ x] Manual tests (outlined above)
- [ x] My code has passed security scanning
    - [x ] Snyk
    - [ x] git-secrets
