### PR TITLE
ORCA-787: Update ORCA API pathing by removing the extra `orca` to avoid confusion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and includes an additional section for migration notes.
 - *ORCA-784* Changed documentation to replace restore with copy based on task's naming as well as changed file name from `website/docs/operator/restore-to-orca.mdx` to `website/docs/operator/reingest-to-orca.mdx`.
 - *ORCA-724* Updated ORCA recovery documentation to include recovery workflow process and relevant inputs and outputs in `website/docs/operator/data-recovery.md`.
 - *ORCA-789* Updated `extract_filepaths_for_granule` to more flexibly match file-regex values to keys.
+- *ORCA-787* Updated `modules/api-gateway/main.tf` to remove extra `orca` in path to avoid confusion.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and includes an additional section for migration notes.
 - *ORCA-784* Changed documentation to replace restore with copy based on task's naming as well as changed file name from `website/docs/operator/restore-to-orca.mdx` to `website/docs/operator/reingest-to-orca.mdx`.
 - *ORCA-724* Updated ORCA recovery documentation to include recovery workflow process and relevant inputs and outputs in `website/docs/operator/data-recovery.md`.
 - *ORCA-789* Updated `extract_filepaths_for_granule` to more flexibly match file-regex values to keys.
-- *ORCA-787* Updated `modules/api-gateway/main.tf` to remove extra `orca` in path to avoid confusion.
+- *ORCA-787* Modified `modules/api-gateway/main.tf` api gateway stage name to remove the extra orca from the data management URL path
 
 ### Deprecated
 

--- a/modules/api-gateway/main.tf
+++ b/modules/api-gateway/main.tf
@@ -233,10 +233,17 @@ resource "aws_lambda_permission" "request_status_for_job_api_permission" {
   source_arn    = "${aws_api_gateway_rest_api.orca_api.execution_arn}/*/${aws_api_gateway_method.request_status_for_job_api_method.http_method}${aws_api_gateway_resource.request_status_for_job_api_resource_recovery_jobs.path}"
 }
 
+## API resource for pathing orca/
+resource "aws_api_gateway_resource" "orca_api_resource" {
+  path_part   = "orca"
+  parent_id   = aws_api_gateway_rest_api.orca_api.root_resource_id
+  rest_api_id = aws_api_gateway_rest_api.orca_api.id
+}
+
 ## API resource for pathing orca/datamanagement
 resource "aws_api_gateway_resource" "orca_datamanagement_api_resource" {
   path_part   = "datamanagement"
-  parent_id   = aws_api_gateway_rest_api.orca_api.root_resource_id
+  parent_id   = aws_api_gateway_resource.orca_api_resource.id
   rest_api_id = aws_api_gateway_rest_api.orca_api.id
 }
 

--- a/modules/api-gateway/main.tf
+++ b/modules/api-gateway/main.tf
@@ -233,17 +233,10 @@ resource "aws_lambda_permission" "request_status_for_job_api_permission" {
   source_arn    = "${aws_api_gateway_rest_api.orca_api.execution_arn}/*/${aws_api_gateway_method.request_status_for_job_api_method.http_method}${aws_api_gateway_resource.request_status_for_job_api_resource_recovery_jobs.path}"
 }
 
-## API resource for pathing orca/
-resource "aws_api_gateway_resource" "orca_api_resource" {
-  path_part   = "orca"
-  parent_id   = aws_api_gateway_rest_api.orca_api.root_resource_id
-  rest_api_id = aws_api_gateway_rest_api.orca_api.id
-}
-
 ## API resource for pathing orca/datamanagement
 resource "aws_api_gateway_resource" "orca_datamanagement_api_resource" {
   path_part   = "datamanagement"
-  parent_id   = aws_api_gateway_resource.orca_api_resource.id
+  parent_id   = aws_api_gateway_rest_api.orca_api.root_resource_id
   rest_api_id = aws_api_gateway_rest_api.orca_api.id
 }
 

--- a/modules/api-gateway/main.tf
+++ b/modules/api-gateway/main.tf
@@ -537,4 +537,7 @@ resource "aws_api_gateway_deployment" "orca_api_deployment" {
     aws_api_gateway_integration.internal_reconcile_report_phantom_api_integration,
     aws_api_gateway_integration.internal_reconcile_report_mismatch_api_integration
   ]
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/modules/api-gateway/variables.tf
+++ b/modules/api-gateway/variables.tf
@@ -54,7 +54,7 @@ variable "orca_catalog_reporting_invoke_arn" {
 variable "api_gateway_stage_name" {
   type        = string
   description = "stage name for the ORCA cumulus reconciliation api gateway"
-  default     = "orca"
+  default     = "api"
 }
 
 variable "vpc_endpoint_id" {


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-787: Update ORCA API pathing by removing the extra `orca` to avoid confusion.](https://bugs.earthdata.nasa.gov/browse/ORCA-787)

## Changes

* Updated ORCA API pathing by removing the extra `orca` to avoid confusion.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested API path in AWS console

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] My code has passed security scanning
    - [x] git-secrets
    - [x] Snyk

