### PR TITLE
ORCA-805: Investigate and fix terraform dependency chain in ORCA terraform modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and includes an additional section for migration notes.
 - *ORCA-724* Updated ORCA recovery documentation to include recovery workflow process and relevant inputs and outputs in `website/docs/operator/data-recovery.md`.
 - *ORCA-789* Updated `extract_filepaths_for_granule` to more flexibly match file-regex values to keys.
 - *ORCA-787* Modified `modules/api-gateway/main.tf` api gateway stage name to remove the extra orca from the data management URL path
+- *ORCA-805* Changed `modules/security_groups/main.tf` security group resource name from `vpc_postgres_ingress_all_egress` to `vpc-postgres-ingress-all-egress` to resolve errors when upgrading from ORCA v8 to v9. Also removed graphql_1 dependency `module.orca_lambdas` since this module does not depend on the lambda module in `modules/orca/main.tf`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ and includes an additional section for migration notes.
 ### Migration Notes
 
 - Update terraform to the latest 1.5 version
+- For users upgrading from ORCA v8.x.x to v9.x.x follow the below steps before deploying:
+    1. Run the Lambda deletion script found in `python3 bin/delete_lambda.py` this will delete all of the ORCA Lambdas with a provided prefix. Or delete them manually in the AWS console.
+    2. Navigate to the AWS console and search for the Cumulus RDS security group.
+    3. Remove the inbound rule with the source of `PREFIX-vpc-ingress-all-egress` in Cumulus RDS security group.
+    4. Search for `PREFIX-vpc-ingress-all-egress` and delete the security group **NOTE:** Due to the Lambdas using ENIs, when deleting the securty groups it may say they are still associated with a Lambda that was deleted by the script. AWS may need a few minutes to refresh to fully disassociate the ENIs completely, if this error appears wait a few minutes and then try again.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and includes an additional section for migration notes.
 
 ### Migration Notes
 
+- For users upgrading from ORCA v8.x.x to v9.x.x follow the below steps before deploying:
+    1. Run the Lambda deletion script found in `python3 bin/delete_lambda.py` this will delete all of the ORCA Lambdas with a provided prefix. Or delete them manually in the AWS console.
+    2. Navigate to the AWS console and search for the Cumulus RDS security group.
+    3. Remove the inbound rule with the source of `PREFIX-vpc-ingress-all-egress` in Cumulus RDS security group.
+    4. Search for `PREFIX-vpc-ingress-all-egress` and delete the security group **NOTE:** Due to the Lambdas using ENIs, when deleting the securty groups it may say they are still associated with a Lambda that was deleted by the script. AWS may need a few minutes to refresh to fully disassociate the ENIs completely, if this error appears wait a few minutes and then try again.
+
 ### Added
 
 - *ORCA-366* Added unit test for shared libraries.

--- a/bin/delete_lambda.py
+++ b/bin/delete_lambda.py
@@ -1,0 +1,18 @@
+import subprocess
+import json
+
+# Gets user input for the prefix of lambdas to delete
+prefix = input("Enter Prefix: ")
+
+# Gets ORCA lambda functions with given prefix
+get_functions = f"aws lambda list-functions --query 'Functions[] | [?contains(FunctionName, `{prefix}`) == `true`]'"
+completed_process = subprocess.run(get_functions, shell=True, capture_output=True)
+output = completed_process.stdout
+convert = json.loads(output.decode("utf-8").replace("'","'"))
+
+# Deletes ORCA lambda functions with the given prefix
+for sub in convert:
+    print("Deleting " + sub['FunctionName'])
+    lambda_output = sub['FunctionName']
+    delete_function = f"aws lambda delete-function --function-name {lambda_output}"
+    subprocess.run(delete_function, shell=True, capture_output=True)

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -242,7 +242,7 @@ module "orca_ecs" {
 ## =============================
 module "orca_graphql_1" {
   source     = "../graphql_1"
-  depends_on = [module.orca_lambdas, module.orca_ecs, module.orca_graphql_0, module.orca_secretsmanager] ## secretsmanager sets up db connection secrets.
+  depends_on = [module.orca_ecs, module.orca_graphql_0, module.orca_secretsmanager] ## secretsmanager sets up db connection secrets.
   ## --------------------------
   ## Cumulus Variables
   ## --------------------------

--- a/modules/security_groups/main.tf
+++ b/modules/security_groups/main.tf
@@ -2,7 +2,7 @@
 
 ## vpc_postgres_ingress_all_egress - PostgreSQL Security Group
 ## ==============================================================================
-resource "aws_security_group" "vpc_postgres_ingress_all_egress" {
+resource "aws_security_group" "vpc-postgres-ingress-all-egress" {
   ## OPTIONAL
   description = "ORCA security group to allow PostgreSQL access."
   name        = "${var.prefix}-vpc-ingress-all-egress"
@@ -38,6 +38,6 @@ resource "aws_security_group_rule" "rds_allow_lambda_access" {
   to_port                  = 5432
   protocol                 = "TCP"
   description              = "Allows ${var.prefix} Orca lambda access."
-  source_security_group_id = aws_security_group.vpc_postgres_ingress_all_egress.id
+  source_security_group_id = aws_security_group.vpc-postgres-ingress-all-egress.id
   security_group_id        = var.rds_security_group_id
 }

--- a/modules/security_groups/main.tf
+++ b/modules/security_groups/main.tf
@@ -2,7 +2,7 @@
 
 ## vpc_postgres_ingress_all_egress - PostgreSQL Security Group
 ## ==============================================================================
-resource "aws_security_group" "vpc-postgres-ingress-all-egress" {
+resource "aws_security_group" "vpc_postgres_ingress_all_egress" {
   ## OPTIONAL
   description = "ORCA security group to allow PostgreSQL access."
   name        = "${var.prefix}-vpc-ingress-all-egress"

--- a/modules/security_groups/output.tf
+++ b/modules/security_groups/output.tf
@@ -1,4 +1,4 @@
 output "vpc_postgres_ingress_all_egress_id" {
-  value       = aws_security_group.vpc_postgres_ingress_all_egress.id
+  value       = aws_security_group.vpc-postgres-ingress-all-egress.id
   description = "PostgreSQL security group id"
 }

--- a/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
+++ b/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
@@ -75,7 +75,11 @@ To update your ORCA version:
 1.	Find the desired release on the [ORCA Releases page](https://github.com/nasa/cumulus-orca/releases).
 
 2.	Update the `source` in your Terraform deployment files for ORCA by
-replacing `vx.x.x` with the desired version of ORCA.
+replacing `vx.x.x` with the desired version of ORCA. If upgrading from `v8.x.x` to `v9.x.x` follow the below steps:
+    1. Run the Lambda deletion script found in `bin/delete_lambda.py` this will delete all of the ORCA Lambdas with a provided prefix. Or delete them manually in the AWS console.
+    2. Navigate to the AWS console and search for the Cumulus RDS security group.
+    3. Remove the inbound rule with the source of `PREFIX-vpc-ingress-all-egress` in Cumulus RDS security group.
+    4. Search for `PREFIX-vpc-ingress-all-egress` and delete the security group **NOTE:** Due to the Lambdas using ENIs, when deleting the securty groups it may say they are still associated with a Lambda that was deleted by the script. AWS may need a few minutes to refresh to fully disassociate the ENIs completely, if this error appears wait a few minuts and then try again.
 
 3.	Run `terraform init` to get the latest copies of your updated modules.
 

--- a/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
+++ b/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
@@ -76,7 +76,7 @@ To update your ORCA version:
 
 2.	Update the `source` in your Terraform deployment files for ORCA by
 replacing `vx.x.x` with the desired version of ORCA. If upgrading from `v8.x.x` to `v9.x.x` follow the below steps:
-    1. Run the Lambda deletion script found in `bin/delete_lambda.py` this will delete all of the ORCA Lambdas with a provided prefix. Or delete them manually in the AWS console.
+    1. Run the Lambda deletion script found in `python3 bin/delete_lambda.py` this will delete all of the ORCA Lambdas with a provided prefix. Or delete them manually in the AWS console.
     2. Navigate to the AWS console and search for the Cumulus RDS security group.
     3. Remove the inbound rule with the source of `PREFIX-vpc-ingress-all-egress` in Cumulus RDS security group.
     4. Search for `PREFIX-vpc-ingress-all-egress` and delete the security group **NOTE:** Due to the Lambdas using ENIs, when deleting the securty groups it may say they are still associated with a Lambda that was deleted by the script. AWS may need a few minutes to refresh to fully disassociate the ENIs completely, if this error appears wait a few minutes and then try again.

--- a/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
+++ b/website/docs/developer/deployment-guide/deployment-upgrading-orca.md
@@ -79,7 +79,7 @@ replacing `vx.x.x` with the desired version of ORCA. If upgrading from `v8.x.x` 
     1. Run the Lambda deletion script found in `bin/delete_lambda.py` this will delete all of the ORCA Lambdas with a provided prefix. Or delete them manually in the AWS console.
     2. Navigate to the AWS console and search for the Cumulus RDS security group.
     3. Remove the inbound rule with the source of `PREFIX-vpc-ingress-all-egress` in Cumulus RDS security group.
-    4. Search for `PREFIX-vpc-ingress-all-egress` and delete the security group **NOTE:** Due to the Lambdas using ENIs, when deleting the securty groups it may say they are still associated with a Lambda that was deleted by the script. AWS may need a few minutes to refresh to fully disassociate the ENIs completely, if this error appears wait a few minuts and then try again.
+    4. Search for `PREFIX-vpc-ingress-all-egress` and delete the security group **NOTE:** Due to the Lambdas using ENIs, when deleting the securty groups it may say they are still associated with a Lambda that was deleted by the script. AWS may need a few minutes to refresh to fully disassociate the ENIs completely, if this error appears wait a few minutes and then try again.
 
 3.	Run `terraform init` to get the latest copies of your updated modules.
 


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-805: Investigate and fix terraform dependency chain in ORCA terraform modules.](https://bugs.earthdata.nasa.gov/browse/ORCA-805)

## Changes

* Changed `modules/security_groups/main.tf` security group resource name from `vpc_postgres_ingress_all_egress` to `vpc-postgres-ingress-all-egress` to resolve errors when upgrading from ORCA v8 to v9. Also removed graphql_1 dependency `module.orca_lambdas` since this module does not depend on the lambda module in `modules/orca/main.tf`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Upgraded from ORCA v6 to v8 then to v9 without errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] My code has passed security scanning
    - [x] git-secrets
    - [x] Snyk

