### PR TITLE
ORCA-823: Fix Security Group Errors in Security Group Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and includes an additional section for migration notes.
 
 ### Fixed
 
+- *ORCA-823* Fixed security group errors of incorrect referenced resources in `modules/security-groups/main.tf` and `modules/security-groups/outputs.tf`
+
 ### Security
 
 ## [9.0.2] 2024-01-26

--- a/modules/security_groups/main.tf
+++ b/modules/security_groups/main.tf
@@ -38,6 +38,6 @@ resource "aws_security_group_rule" "rds_allow_lambda_access" {
   to_port                  = 5432
   protocol                 = "TCP"
   description              = "Allows ${var.prefix} Orca lambda access."
-  source_security_group_id = aws_security_group.vpc-postgres-ingress-all-egress.id
+  source_security_group_id = aws_security_group.vpc_postgres_ingress_all_egress.id
   security_group_id        = var.rds_security_group_id
 }

--- a/modules/security_groups/output.tf
+++ b/modules/security_groups/output.tf
@@ -1,4 +1,4 @@
 output "vpc_postgres_ingress_all_egress_id" {
-  value       = aws_security_group.vpc-postgres-ingress-all-egress.id
+  value       = aws_security_group.vpc_postgres_ingress_all_egress.id
   description = "PostgreSQL security group id"
 }


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-823: Fix Security Group Errors in Security Group Modules](https://bugs.earthdata.nasa.gov/browse/ORCA-823)

## Changes

* Fixed security group errors of incorrect referenced resources in `modules/security-groups/main.tf` and `modules/security-groups/outputs.tf`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Deployed security groups successfully without errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] My code has passed security scanning
    - [x] git-secrets
    - [x] Snyk

