### PR TITLE
ORCA-826: Modify Delete Lambda Scripts to Delete on Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and includes an additional section for migration notes.
 
 ### Changed
 
-- *ORCA-826* - Changed bin/delete_lambda.py to delete ORCA lambdas based on their tags
+- *ORCA-826* - Changed bin/delete_lambda.py to delete ORCA lambdas based on their tags.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and includes an additional section for migration notes.
 
 ### Changed
 
+- *ORCA-826* - Changed bin/delete_lambda.py to delete ORCA lambdas based on their tags
+
 ### Deprecated
 
 ### Removed

--- a/bin/delete_lambda.py
+++ b/bin/delete_lambda.py
@@ -1,7 +1,7 @@
 import subprocess
 import json
 
-# Gets user input for the prefix of ORCA lambdas to delete
+# Gets user input for the prefix of lambdas to delete
 prefix = input("Enter Prefix: ")
 
 # Gets ORCA lambda functions with given prefix
@@ -19,11 +19,13 @@ for sub in convert:
     try:
         # Finds lambdas with the tag application set to ORCA and deletes the ORCA Lambdas
         for tag in tag_convert:
-            if tag_convert[tag]['application'] == 'ORCA':
-                print("Deleting " + sub['FunctionName'])
-                del_lambda = sub['FunctionName']
-                delete_function = f"aws lambda delete-function --function-name {del_lambda}"
-                subprocess.run(delete_function, shell=True, capture_output=True)
-    # If the lambda with the provided prefix does not match the tag for deletion it is skipped and is not deleted
-    except KeyError:
-        pass
+            for attr in tag_convert[tag]:
+                if attr == 'application':
+                    if tag_convert[tag]['application'] == 'ORCA':
+                        print("Deleting " + sub['FunctionName'])
+                        del_lambda = sub['FunctionName']
+                        delete_function = f"aws lambda delete-function --function-name {del_lambda}"
+                        subprocess.run(delete_function, shell=True, capture_output=True)
+    # Throws an error if deletion is interrupted
+    except KeyError as ke:
+        raise ke

--- a/bin/delete_lambda.py
+++ b/bin/delete_lambda.py
@@ -10,9 +10,20 @@ completed_process = subprocess.run(get_functions, shell=True, capture_output=Tru
 output = completed_process.stdout
 convert = json.loads(output.decode("utf-8").replace("'","'"))
 
-# Deletes ORCA lambda functions with the given prefix
 for sub in convert:
-    print("Deleting " + sub['FunctionName'])
-    lambda_output = sub['FunctionName']
-    delete_function = f"aws lambda delete-function --function-name {lambda_output}"
-    subprocess.run(delete_function, shell=True, capture_output=True)
+    lambda_output = sub['FunctionArn']
+    get_tags = f"aws lambda list-tags --resource {lambda_output}"
+    tags_process = subprocess.run(get_tags, shell=True, capture_output=True)
+    tag_output = tags_process.stdout
+    tag_convert = json.loads(tag_output.decode("utf-8").replace("'","'"))
+    try:
+        # Finds lambdas with the tag application set to ORCA and deletes the ORCA Lambdas
+        for tag in tag_convert:
+            if tag_convert[tag]['application'] == 'ORCA':
+                print("Deleting " + sub['FunctionName'])
+                del_lambda = sub['FunctionName']
+                delete_function = f"aws lambda delete-function --function-name {del_lambda}"
+                subprocess.run(delete_function, shell=True, capture_output=True)
+    # If the lambda with the provided prefix does not match the tag for deletion it is skipped and is not deleted
+    except KeyError:
+        pass

--- a/bin/delete_lambda.py
+++ b/bin/delete_lambda.py
@@ -4,18 +4,15 @@ import json
 # Gets user input for the prefix of ORCA lambdas to delete
 prefix = input("Enter Prefix: ")
 
-# Gets AWS Profile to use for ORCA lambda deletion
-profile = input("Enter AWS Profile: ")
-
 # Gets ORCA lambda functions with given prefix
-get_functions = f"aws lambda list-functions --profile {profile} --query 'Functions[] | [?contains(FunctionName, `{prefix}`) == `true`]'"
+get_functions = f"aws lambda list-functions --query 'Functions[] | [?contains(FunctionName, `{prefix}`) == `true`]'"
 completed_process = subprocess.run(get_functions, shell=True, capture_output=True)
 output = completed_process.stdout
 convert = json.loads(output.decode("utf-8").replace("'","'"))
 
 for sub in convert:
     lambda_output = sub['FunctionArn']
-    get_tags = f"aws lambda list-tags --profile {profile} --resource {lambda_output}"
+    get_tags = f"aws lambda list-tags --resource {lambda_output}"
     tags_process = subprocess.run(get_tags, shell=True, capture_output=True)
     tag_output = tags_process.stdout
     tag_convert = json.loads(tag_output.decode("utf-8").replace("'","'"))
@@ -25,7 +22,7 @@ for sub in convert:
             if tag_convert[tag]['application'] == 'ORCA':
                 print("Deleting " + sub['FunctionName'])
                 del_lambda = sub['FunctionName']
-                delete_function = f"aws lambda delete-function --profile {profile} --function-name {del_lambda}"
+                delete_function = f"aws lambda delete-function --function-name {del_lambda}"
                 subprocess.run(delete_function, shell=True, capture_output=True)
     # If the lambda with the provided prefix does not match the tag for deletion it is skipped and is not deleted
     except KeyError:

--- a/bin/delete_lambda.py
+++ b/bin/delete_lambda.py
@@ -1,18 +1,21 @@
 import subprocess
 import json
 
-# Gets user input for the prefix of lambdas to delete
+# Gets user input for the prefix of ORCA lambdas to delete
 prefix = input("Enter Prefix: ")
 
+# Gets AWS Profile to use for ORCA lambda deletion
+profile = input("Enter AWS Profile: ")
+
 # Gets ORCA lambda functions with given prefix
-get_functions = f"aws lambda list-functions --query 'Functions[] | [?contains(FunctionName, `{prefix}`) == `true`]'"
+get_functions = f"aws lambda list-functions --profile {profile} --query 'Functions[] | [?contains(FunctionName, `{prefix}`) == `true`]'"
 completed_process = subprocess.run(get_functions, shell=True, capture_output=True)
 output = completed_process.stdout
 convert = json.loads(output.decode("utf-8").replace("'","'"))
 
 for sub in convert:
     lambda_output = sub['FunctionArn']
-    get_tags = f"aws lambda list-tags --resource {lambda_output}"
+    get_tags = f"aws lambda list-tags --profile {profile} --resource {lambda_output}"
     tags_process = subprocess.run(get_tags, shell=True, capture_output=True)
     tag_output = tags_process.stdout
     tag_convert = json.loads(tag_output.decode("utf-8").replace("'","'"))
@@ -22,7 +25,7 @@ for sub in convert:
             if tag_convert[tag]['application'] == 'ORCA':
                 print("Deleting " + sub['FunctionName'])
                 del_lambda = sub['FunctionName']
-                delete_function = f"aws lambda delete-function --function-name {del_lambda}"
+                delete_function = f"aws lambda delete-function --profile {profile} --function-name {del_lambda}"
                 subprocess.run(delete_function, shell=True, capture_output=True)
     # If the lambda with the provided prefix does not match the tag for deletion it is skipped and is not deleted
     except KeyError:


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-826: Modify Delete Lambda Scripts to Delete on Tags](https://bugs.earthdata.nasa.gov/browse/ORCA-826)

## Changes

* Modified `bin/delete_lambda.py` to delete ORCA lambdas based on their tags

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran script and deleted only ORCA lambdas with the matching tag and not any other lambdas with the same prefix.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] My code has passed security scanning
    - [x] git-secrets
    - [x] Snyk

