### PR TITLE
ORCA-450: Research and implement replacement for ACL rules in buckets & ORCA-441: Restrict policies/roles for s3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@ and includes an additional section for migration notes.
 
 ### Added
 
+- *ORCA-450* - Removed ACL requirement and added BucketOwnerEnforced to ORCA bucket objects.
+
 ### Changed
+
+- *ORCA-441* - Updated policies for ORCA buckets and copy_to_archive to give them only the permissions needed to restrict unwanted/unintended actions.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and includes an additional section for migration notes.
 
 ### Added
 
-- *ORCA-450* - Removed ACL requirement and added BucketOwnerEnforced to ORCA bucket objects.
+- *ORCA-450* - Removed Access Control List (ACL) requirement and added BucketOwnerEnforced to ORCA bucket objects.
 
 ### Changed
 

--- a/modules/dr_buckets/dr_buckets.tf
+++ b/modules/dr_buckets/dr_buckets.tf
@@ -34,6 +34,14 @@ resource "aws_s3_bucket" "orca_archive_bucket" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "orca_archive_bucket_ownership" {
+  bucket = aws_s3_bucket.orca_archive_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 # ORCA Archive Bucket Versioning
 resource "aws_s3_bucket_versioning" "orca_archive_versioning" {
   bucket = aws_s3_bucket.orca_archive_bucket.id
@@ -57,9 +65,11 @@ data "aws_iam_policy_document" "orca_archive_cross_account_access_policy" {
     }
 
     actions = [
-      "s3:GetObject*",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
       "s3:RestoreObject",
-      "s3:GetBucket*",
+      "s3:GetBucketVersioning",
+      "s3:GetBucketNotification",
       "s3:ListBucket",
       "s3:PutBucketNotification",
       "s3:GetInventoryConfiguration",
@@ -80,7 +90,7 @@ data "aws_iam_policy_document" "orca_archive_cross_account_access_policy" {
     }
 
     actions = [
-      "s3:PutObject*"
+      "s3:PutObject"
     ]
 
     resources = [
@@ -88,18 +98,11 @@ data "aws_iam_policy_document" "orca_archive_cross_account_access_policy" {
     ]
 
     condition {
-      test = "StringNotEquals"
+      test = "StringEquals"
       variable = "s3:x-amz-storage-class"
       values = [
         "GLACIER",
         "DEEP_ARCHIVE"
-      ]
-    }
-    condition {
-      test = "StringNotEquals"
-      variable = "s3:x-amz-acl"
-      values = [
-        "bucket-owner-full-control"
       ]
     }
   }
@@ -109,6 +112,14 @@ data "aws_iam_policy_document" "orca_archive_cross_account_access_policy" {
 resource "aws_s3_bucket" "orca_archive_worm_bucket" {
   bucket = "${var.prefix}-orca-archive-worm"
   tags = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "orca_archive_worm_bucket_ownership" {
+  bucket = aws_s3_bucket.orca_archive_worm_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 # ORCA Archive Worm Bucket Versioning
@@ -190,6 +201,14 @@ resource "aws_s3_bucket_policy" "orca_reports_cross_account_access" {
   policy = data.aws_iam_policy_document.orca_reports_cross_account_access_policy.json
 }
 
+resource "aws_s3_bucket_ownership_controls" "orca_reports_bucket_ownership" {
+  bucket = aws_s3_bucket.orca_reports_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 data "aws_iam_policy_document" "orca_reports_cross_account_access_policy" {
   statement {
     sid = "Reports Cross Account Access"
@@ -199,11 +218,10 @@ data "aws_iam_policy_document" "orca_reports_cross_account_access_policy" {
     }
 
     actions = [
-      "s3:GetObject*",
-      "s3:GetBucket*",
+      "s3:GetObject",
+      "s3:GetBucketNotification",
       "s3:ListBucket",
       "s3:PutObject",
-      "s3:PutObjectAcl",
       "s3:PutBucketNotification"
     ]
 
@@ -220,20 +238,12 @@ data "aws_iam_policy_document" "orca_reports_cross_account_access_policy" {
     }
 
     actions = [
-      "s3:PutObject*"
+      "s3:PutObject"
     ]
 
     resources = [
       "${aws_s3_bucket.orca_reports_bucket.arn}/*"
     ]
-
-    condition {
-      test = "StringEquals"
-      variable = "s3:x-amz-acl"
-      values = [
-        "bucket-owner-full-control"
-      ]
-    }
     condition {
       test = "StringEquals"
       variable = "aws:SourceAccount"

--- a/modules/dr_buckets_cloudformation/dr-buckets.yaml
+++ b/modules/dr_buckets_cloudformation/dr-buckets.yaml
@@ -14,6 +14,9 @@ Resources:
     Type: 'AWS::S3::Bucket'
     Properties:
       BucketName: !Sub '${PREFIX}-orca-archive'
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
   S3ARCHBUCKETPOL:
     Type: 'AWS::S3::BucketPolicy'
     Properties:
@@ -24,9 +27,11 @@ Resources:
         Statement:
           - Sid: CrossAccPolicyDoc
             Action: [
-              "s3:GetObject*",
+              "s3:GetObject",
+              "s3:GetObjectVersion",
               "s3:RestoreObject",
-              "s3:GetBucket*",
+              "s3:GetBucketVersioning",
+              "s3:GetBucketNotification",
               "s3:ListBucket",
               "s3:PutBucketNotification",
               "s3:GetInventoryConfiguration",
@@ -41,15 +46,14 @@ Resources:
             Principal:
               AWS: !Join ['', ["arn:aws:iam::", !Ref CumulusAccountID, ":root"]]
           - Sid: "Cross Account Write Access"
-            Action: "s3:PutObject*"
+            Action: "s3:PutObject"
             Effect: Allow
             Resource: !Sub 'arn:aws:s3:::${S3ARCHBUCKET}/*'
             Condition:
-              StringNotEquals:
+              StringEquals:
                 's3:x-amz-storage-class':
                   - 'GLACIER'
                   - 'DEEP_ARCHIVE'
-                's3:x-amz-acl': 'bucket-owner-full-control'
             Principal:
               AWS: !Join ['', ["arn:aws:iam::", !Ref CumulusAccountID, ":root"]]
     DependsOn: S3ARCHBUCKET
@@ -57,6 +61,9 @@ Resources:
     Type: 'AWS::S3::Bucket'
     Properties:
       BucketName: !Sub '${PREFIX}-orca-reports'
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
   S3REPBUCKETPOL:
     Type: 'AWS::S3::BucketPolicy'
     Properties:
@@ -67,11 +74,10 @@ Resources:
         Statement:
           - Sid: CrossAccPolicyDoc
             Action: [
-              "s3:GetObject*",
-              "s3:GetBucket*",
+              "s3:GetObject",
+              "s3:GetBucketNotification",
               "s3:ListBucket",
               "s3:PutObject",
-              "s3:PutObjectAcl",
               "s3:PutBucketNotification"
             ]
             Effect: Allow

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -76,8 +76,9 @@ data "aws_iam_policy_document" "restore_object_role_policy_document" {
   statement {
     actions = [
       "s3:AbortMultipartUpload",
-      "s3:GetObject*",
-      "s3:PutObject*",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:PutObject",
       "s3:ListMultipartUploadParts",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion"
@@ -87,7 +88,8 @@ data "aws_iam_policy_document" "restore_object_role_policy_document" {
   statement {
     actions = [
       "s3:RestoreObject",
-      "s3:GetObject"
+      "s3:GetObject",
+      "s3:GetObjectVersion"
     ]
     resources = concat(local.orca_bucket_arns, local.orca_bucket_paths)
   }
@@ -123,9 +125,8 @@ data "aws_iam_policy_document" "restore_object_role_policy_document" {
   }
   statement {
     actions = [
-      "s3:GetObject*",  # Get the manifest
-      "s3:PutObject",  # Copy the gzip to add missing metadata
-      "s3:PutObjectAcl"  # Copy the gzip to add missing metadata
+      "s3:GetObject",  # Get the manifest
+      "s3:PutObject"  # Copy the gzip to add missing metadata
     ]
     resources = ["arn:aws:s3:::${var.orca_reports_bucket_name}/*"]
   }

--- a/tasks/copy_from_archive/copy_from_archive.py
+++ b/tasks/copy_from_archive/copy_from_archive.py
@@ -224,8 +224,6 @@ def copy_object(
                 # 'MetadataDirective': 'COPY',
                 # 'ContentType': s3_cli.head_object(Bucket=src_bucket_name,
                 #  Key=src_object_name)['ContentType'],
-                # 'ACL': 'bucket-owner-full-control'
-                # Sets the x-amz-acl URI Request Parameter. Needed for cross-OU copies.
             },
             Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB),
         )

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -127,7 +127,6 @@ def copy_granule_between_buckets(
             "ContentType": s3.head_object(Bucket=source_bucket_name, Key=source_key)[
                 "ContentType"
             ],
-            "ACL": "bucket-owner-full-control",  # Sets the x-amz-acl URI Request Parameter.
             # Needed for cross-OU copies.
         },
         Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB),

--- a/tasks/copy_to_archive/test/unit_tests/test_copy_to_archive.py
+++ b/tasks/copy_to_archive/test/unit_tests/test_copy_to_archive.py
@@ -322,7 +322,6 @@ class TestCopyToArchive(TestCase):
                         "StorageClass": mock_get_storage_class.return_value,
                         "MetadataDirective": "COPY",
                         "ContentType": content_type,
-                        "ACL": "bucket-owner-full-control",
                     },
                     Config=unittest.mock.ANY,  # Checked by ConfigCheck.
                     # Equality checkers do not work.
@@ -592,7 +591,6 @@ class TestCopyToArchive(TestCase):
                         "StorageClass": mock_get_storage_class.return_value,
                         "MetadataDirective": "COPY",
                         "ContentType": content_type,
-                        "ACL": "bucket-owner-full-control",
                     },
                     Config=unittest.mock.ANY,  # Checked by ConfigCheck.
                     # Equality checkers do not work.
@@ -695,7 +693,6 @@ class TestCopyToArchive(TestCase):
                         "StorageClass": mock_get_storage_class.return_value,
                         "MetadataDirective": "COPY",
                         "ContentType": content_type,
-                        "ACL": "bucket-owner-full-control",
                     },
                     Config=unittest.mock.ANY,  # Checked by ConfigCheck.
                     # Equality checkers do not work.

--- a/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
@@ -133,11 +133,11 @@ modifications, which will be detailed below.
             "AWS": "arn:aws:iam::012345678912:root"
          },
          "Action":[
-            "s3:GetObject*",
-            "S3:GetObjectTagging",
-            "S3:PutObjectTagging",
+            "s3:GetObject",
+            "s3:GetObjectVersion",
             "s3:RestoreObject",
-            "s3:GetBucket*",
+            "s3:GetBucketVersioning",
+            "s3:GetBucketNotification",
             "s3:ListBucket",
             "s3:PutBucketNotification",
             "s3:GetInventoryConfiguration",
@@ -155,7 +155,7 @@ modifications, which will be detailed below.
          "Principal": {
             "AWS": "arn:aws:iam::012345678912:root"
          },
-         "Action": "s3:PutObject*",
+         "Action": "s3:PutObject",
          "Resource": [
             "arn:aws:s3:::PREFIX-orca-archive/*"
          ],
@@ -211,8 +211,8 @@ modifications, which will be detailed below.
         "AWS": "arn:aws:iam::012345678912:root"
       },
       "Action": [
-        "s3:GetObject*",
-        "s3:GetBucket*",
+        "s3:GetObject",
+        "s3:GetBucketNotification",
         "s3:ListBucket",
         "s3:PutObject",
         "s3:PutBucketNotification"

--- a/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
@@ -161,7 +161,6 @@ modifications, which will be detailed below.
          ],
          "Condition": {
             "StringEquals": {
-               "s3:x-amz-acl": "bucket-owner-full-control",
                "s3:x-amz-storage-class": [
                   "GLACIER",
                   "DEEP_ARCHIVE"
@@ -216,7 +215,6 @@ modifications, which will be detailed below.
         "s3:GetBucket*",
         "s3:ListBucket",
         "s3:PutObject",
-        "s3:PutObjectAcl",
         "s3:PutBucketNotification"
       ],
       "Resource": [
@@ -234,7 +232,6 @@ modifications, which will be detailed below.
       "Resource": "arn:aws:s3:::PREFIX-orca-reports/*",
       "Condition": {
         "StringEquals": {
-      	  "s3:x-amz-acl": "bucket-owner-full-control",
       	  "aws:SourceAccount": "000000000000"
         },
       	"ArnLike": {

--- a/website/docs/developer/research/research-multipart-chunksize.md
+++ b/website/docs/developer/research/research-multipart-chunksize.md
@@ -22,7 +22,6 @@ We currently are using the default value of 8mb, which will cause problems when 
         'StorageClass': 'GLACIER',
         'MetadataDirective': 'COPY',
         'ContentType': s3.head_object(Bucket=source_bucket_name, Key=source_key)['ContentType'],
-        'ACL': 'bucket-owner-full-control'  # Sets the x-amz-acl URI Request Parameter. Needed for cross-OU copies.
     },
     Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB)
   )

--- a/website/docs/developer/research/research-s3-bucket-policies.md
+++ b/website/docs/developer/research/research-s3-bucket-policies.md
@@ -116,12 +116,16 @@ Versioning is not used, and in general no changes are required beyond updating t
         "AWS": "arn:aws:iam::012345678912:root"
       },
       "Action": [
-        "s3:GetObject*",
-        "s3:GetBucket*",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:RestoreObject",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketNotification",
         "s3:ListBucket",
-        "s3:PutObject",
-        "s3:PutObjectAcl",
-        "s3:PutBucketNotification"
+        "s3:PutBucketNotification",
+        "s3:GetInventoryConfiguration",
+        "s3:PutInventoryConfiguration",
+        "s3:ListBucketVersions"
       ],
       "Resource": [
         "arn:aws:s3:::PREFIX-orca-archive-versioned",
@@ -138,7 +142,6 @@ Versioning is not used, and in general no changes are required beyond updating t
       "Resource": "arn:aws:s3:::PREFIX-orca-archive-versioned/*",
       "Condition": {
         "StringEquals": {
-      	  "s3:x-amz-acl": "bucket-owner-full-control",
       	  "aws:SourceAccount": "0000000000000"
         },
       	"ArnLike": {
@@ -156,7 +159,6 @@ Versioning is not used, and in general no changes are required beyond updating t
       "Resource": "arn:aws:s3:::PREFIX-orca-archive-worm/*",
       "Condition": {
         "StringEquals": {
-      	  "s3:x-amz-acl": "bucket-owner-full-control",
       	  "aws:SourceAccount": "000000000000"
         },
       	"ArnLike": {


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-450: Research and implement replacement for ACL rules in buckets](https://bugs.earthdata.nasa.gov/browse/ORCA-450) & [ORCA-441: Restrict policies/roles for s3 buckets](https://bugs.earthdata.nasa.gov/browse/ORCA-441)

## Changes

* Removed ACL requirement and added BucketOwnerEnforced to ORCA bucket objects.
* Updated policies for ORCA buckets and copy_to_archive to give them only the permissions needed to restrict unwanted/unintended actions.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Deployed ORCA and ORCA DR buckets successfully, ran Step Function workflows and succeeded, as well as ran unit tests which were successful.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] My code has passed security scanning
    - [x] git-secrets
    - [x] Snyk

