### PR TITLE
Feature/orca 845 Create IAM role to allow S3 Import for Aurora v2 database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and includes an additional section for migration notes.
  
 ### Added
 
+- *ORCA-845* - Created IAM role for RDS S3 import needed for Aurora v2 upgrade.
+
 ### Changed
 
 - *ORCA-832* - Modified pyscopg2 installation to allow for SSL connections to database.

--- a/modules/graphql_0/main.tf
+++ b/modules/graphql_0/main.tf
@@ -2,6 +2,8 @@ data "aws_vpc" "primary" {
   id = var.vpc_id
 }
 
+data "aws_caller_identity" "current" {}
+
 # IAM role that tasks can use to make API requests to authorized AWS services. If you make a boto3 call, this is what carries it out.
 data "aws_iam_policy_document" "assume_gql_tasks_role_policy_document" {
   statement {
@@ -49,4 +51,52 @@ resource "aws_iam_role" "orca_ecs_task_execution_role" {
   assume_role_policy   = data.aws_iam_policy_document.assume_ecs_task_execution_role_policy_document.json
   permissions_boundary = var.permissions_boundary_arn
   tags                 = var.tags
+}
+
+## IAM role for internal reconciliation S3 import role
+
+data "aws_iam_policy_document" "assume_rds_role" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["rds.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [
+        "${data.aws_caller_identity.current.account_id}"
+      ]
+    }
+  }
+}
+
+# Policy document for S3 import
+data "aws_iam_policy_document" "rds_s3_import_role_policy_document" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+        "arn:aws:s3:::${var.prefix}_orca-reports",
+        "arn:aws:s3:::${var.prefix}_orca-reports/*"
+    ]
+  }
+}
+
+# Role to be associated with the Serverless Cluster for S3 Import
+resource "aws_iam_role" "rds_s3_import_role" {
+  name                 = "${var.prefix}_rds_s3_import_role"
+  assume_role_policy   = data.aws_iam_policy_document.assume_rds_role.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
+}
+
+# Policy for the RDS S3 Import Role
+resource "aws_iam_role_policy" "rds_s3_import_role_policy" {
+  name   = "${var.prefix}_rds_s3_import_role_policy"
+  role   = aws_iam_role.rds_s3_import_role.id
+  policy = data.aws_iam_policy_document.rds_s3_import_role_policy_document.json
 }


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-845: Create IAM role to allow S3 Import for Aurora v2 database.](https://bugs.earthdata.nasa.gov/browse/ORCA-845)

## Changes

* Created IAM role in modules/graphql_0/main.tf

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployed to AWS

## Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [ x] CHANGELOG.md
- [x ] My code has passed security scanning
    - [x ] Snyk
    - [ x] git-secrets
