### PR TITLE
ORCA-795: Update ORCA graphql internal reconciliation to remove s3 access keys and use IAM logic for DB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,14 @@ Remove the `s3_access_key` and `s3_secret_key` variables from your `orca.tf` fil
 ### Changed
 
 - *ORCA-832* - Modified pyscopg2 installation to allow for SSL connections to database.
+- *ORCA-795* - Modified Graphql task policy to allow for S3 imports.
 
 ### Deprecated
 
 ### Removed
 
 - *ORCA-793* - Removed `s3_access_key` and `s3_secret_key` variables from terraform.
+- *ORCA-795* - Removed `s3_access_key` and `s3_secret_key` variables from Graphql code and from get_current_archive_list task.
 
 ### Fixed
 

--- a/graphql/src/adapters/storage/internal_reconciliation_postgres.py
+++ b/graphql/src/adapters/storage/internal_reconciliation_postgres.py
@@ -12,14 +12,10 @@ class InternalReconciliationStorageAdapterPostgres(InternalReconciliationStorage
         self,
         user_connection_uri: str,
         admin_connection_uri: str,
-        s3_access_key: str,
-        s3_secret_key: str,
     ):
         super(InternalReconciliationStorageAdapterPostgres, self).__init__(
             user_connection_uri,
             admin_connection_uri,
-            s3_access_key,
-            s3_secret_key
         )
 
     @staticmethod
@@ -78,8 +74,6 @@ class InternalReconciliationStorageAdapterPostgres(InternalReconciliationStorage
                 :report_bucket_name,
                 :csv_key_path,
                 :report_bucket_region,
-                :s3_access_key,
-                :s3_secret_key,
                 ''
             )
             """

--- a/graphql/src/adapters/storage/internal_reconciliation_rdbms.py
+++ b/graphql/src/adapters/storage/internal_reconciliation_rdbms.py
@@ -29,13 +29,9 @@ class InternalReconciliationStorageAdapterRDBMS(
         self,
         user_connection_uri: str,
         admin_connection_uri: str,
-        s3_access_key: str,
-        s3_secret_key: str,
     ):
         self.user_connection_uri = user_connection_uri
         self.admin_connection_uri = admin_connection_uri
-        self.s3_access_key = s3_access_key
-        self.s3_secret_key = s3_secret_key
 
     @shared_db.retry_operational_error()
     def create_job(
@@ -194,8 +190,6 @@ class InternalReconciliationStorageAdapterRDBMS(
                             "report_bucket_name": csv_file_location.bucket_name,
                             "csv_key_path": csv_file_location.key,
                             "report_bucket_region": report_bucket_region,
-                            "s3_access_key": self.s3_access_key,
-                            "s3_secret_key": self.s3_secret_key,
                         }
                     ],
                 )

--- a/graphql/src/adapters/webserver/application.py
+++ b/graphql/src/adapters/webserver/application.py
@@ -14,10 +14,6 @@ from src.adapters.storage.postgres import StorageAdapterPostgres
 from src.adapters.webserver.uvicorn_settings import UvicornSettings
 from src.adapters.word_generation.word_generation import UUIDWordGeneration
 
-S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY = "s3_access_key"
-S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY = "s3_secret_key"  # nosec
-
-
 def get_application(uvicorn_settings: UvicornSettings):
     """
     Sets up an application for use with uvicorn.
@@ -54,20 +50,12 @@ def get_application(uvicorn_settings: UvicornSettings):
         db_connect_info, logger, db_connect_info.user_database_name,
     )
 
-    s3_credentials = json.loads(
-        uvicorn_settings.S3_ACCESS_CREDENTIALS
-    )
-    s3_access_key = s3_credentials[S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY]
-    s3_secret_key = s3_credentials[S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY]
-
     adapters_storage = AdaptersStorage(
         UUIDWordGeneration(),
         StorageAdapterPostgres(user_connection_uri),
         InternalReconciliationStorageAdapterPostgres(
             user_connection_uri,
             admin_connection_uri,
-            s3_access_key,
-            s3_secret_key
         ),
         initialized_logger_provider
     )

--- a/graphql/src/adapters/webserver/uvicorn_settings.py
+++ b/graphql/src/adapters/webserver/uvicorn_settings.py
@@ -9,7 +9,6 @@ class UvicornSettings(BaseSettings):
     PORT: int = 5000  # Used for local testing. Overwritten in Dockerfile.
     ORCA_ENV = "production"
     DB_CONNECT_INFO: str
-    S3_ACCESS_CREDENTIALS: str
 
     # noinspection PyPep8Naming
     def get_DEV(self) -> bool:

--- a/graphql/test/unit_tests/adapters/storage/test_internal_reconciliation_rdbms.py
+++ b/graphql/test/unit_tests/adapters/storage/test_internal_reconciliation_rdbms.py
@@ -33,8 +33,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
 
         mock_user_connection_uri = Mock()
         mock_admin_connection_uri = Mock()
-        mock_s3_access_key = Mock()
-        mock_s3_secret_key = Mock()
 
         mock_orca_archive_location = Mock()
         mock_inventory_creation_time = Mock()
@@ -56,8 +54,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
         adapter = InternalReconciliationStorageAdapterRDBMS(
             mock_user_connection_uri,
             mock_admin_connection_uri,
-            mock_s3_access_key,
-            mock_s3_secret_key,
         )
 
         result = adapter.create_job(
@@ -101,14 +97,10 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
         """
         mock_user_connection_uri = Mock()
         mock_admin_connection_uri = Mock()
-        mock_s3_access_key = Mock()
-        mock_s3_secret_key = Mock()
 
         adapter = InternalReconciliationStorageAdapterRDBMS(
             mock_user_connection_uri,
             mock_admin_connection_uri,
-            mock_s3_access_key,
-            mock_s3_secret_key,
         )
 
         mock_report_source = Mock()
@@ -154,8 +146,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
 
         mock_user_connection_uri = Mock()
         mock_admin_connection_uri = Mock()
-        mock_s3_access_key = Mock()
-        mock_s3_secret_key = Mock()
 
         mock_orca_archive_location = Mock()
         mock_execute = Mock()
@@ -172,8 +162,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
         adapter = InternalReconciliationStorageAdapterRDBMS(
             mock_user_connection_uri,
             mock_admin_connection_uri,
-            mock_s3_access_key,
-            mock_s3_secret_key,
         )
 
         adapter.truncate_s3_partition(
@@ -207,14 +195,10 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
     ):
         mock_user_connection_uri = Mock()
         mock_admin_connection_uri = Mock()
-        mock_s3_access_key = Mock()
-        mock_s3_secret_key = Mock()
 
         adapter = InternalReconciliationStorageAdapterRDBMS(
             mock_user_connection_uri,
             mock_admin_connection_uri,
-            mock_s3_access_key,
-            mock_s3_secret_key,
         )
 
         job_id = random.randint(0, 9999999999)  # nosec
@@ -263,8 +247,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
 
         mock_user_connection_uri = Mock()
         mock_admin_connection_uri = Mock()
-        mock_s3_access_key = Mock()
-        mock_s3_secret_key = Mock()
 
         mock_report_bucket_name = uuid.uuid4().__str__()
         mock_report_bucket_region = Mock()
@@ -295,8 +277,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
         adapter = InternalReconciliationStorageAdapterRDBMS(
             mock_user_connection_uri,
             mock_admin_connection_uri,
-            mock_s3_access_key,
-            mock_s3_secret_key,
         )
 
         adapter.update_job_with_s3_inventory(
@@ -335,8 +315,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
                             "report_bucket_name": csv_file_location.bucket_name,
                             "csv_key_path": csv_file_location.key,
                             "report_bucket_region": mock_report_bucket_region,
-                            "s3_access_key": mock_s3_access_key,
-                            "s3_secret_key": mock_s3_secret_key,
                         }
                     ],
                 )
@@ -391,8 +369,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
 
         mock_user_connection_uri = Mock()
         mock_admin_connection_uri = Mock()
-        mock_s3_access_key = Mock()
-        mock_s3_secret_key = Mock()
 
         mock_job_id = random.randint(0, 99999999)  # nosec
         mock_orca_archive_location = Mock()
@@ -410,8 +386,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
         adapter = InternalReconciliationStorageAdapterRDBMS(
             mock_user_connection_uri,
             mock_admin_connection_uri,
-            mock_s3_access_key,
-            mock_s3_secret_key,
         )
         adapter.perform_orca_reconcile(
             mock_orca_archive_location,
@@ -476,8 +450,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
             with self.subTest(direction=direction):
                 mock_user_connection_uri = Mock()
                 mock_admin_connection_uri = Mock()
-                mock_s3_access_key = Mock()
-                mock_s3_secret_key = Mock()
 
                 mock_job_id = Mock()
                 mock_cursor_collection_id = Mock()
@@ -532,8 +504,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
                 adapter = InternalReconciliationStorageAdapterRDBMS(
                     mock_user_connection_uri,
                     mock_admin_connection_uri,
-                    mock_s3_access_key,
-                    mock_s3_secret_key,
                 )
 
                 result = adapter.get_phantom_page(
@@ -577,8 +547,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
             with self.subTest(direction=direction):
                 mock_user_connection_uri = Mock()
                 mock_admin_connection_uri = Mock()
-                mock_s3_access_key = Mock()
-                mock_s3_secret_key = Mock()
 
                 mock_job_id = Mock()
                 mock_cursor_collection_id = Mock()
@@ -647,8 +615,6 @@ class TestInternalReconciliationStorageAdapterRDBMS(unittest.TestCase):
                 adapter = InternalReconciliationStorageAdapterRDBMS(
                     mock_user_connection_uri,
                     mock_admin_connection_uri,
-                    mock_s3_access_key,
-                    mock_s3_secret_key,
                 )
 
                 result = adapter.get_mismatch_page(

--- a/graphql/test/unit_tests/adapters/webserver/test_application.py
+++ b/graphql/test/unit_tests/adapters/webserver/test_application.py
@@ -40,8 +40,6 @@ class TestApplication(unittest.TestCase):
         mock_user_password = uuid.uuid4().__str__()
         mock_host = uuid.uuid4().__str__()
         mock_port = uuid.uuid4().__str__()
-        mock_s3_access_key = uuid.uuid4().__str__()
-        mock_s3_secret_key = uuid.uuid4().__str__()
 
         mock_uvicorn_settings = Mock()
         mock_uvicorn_settings.DB_CONNECT_INFO = json.dumps({
@@ -53,10 +51,6 @@ class TestApplication(unittest.TestCase):
             "user_password": mock_user_password,
             "host": mock_host,
             "port": mock_port,
-        })
-        mock_uvicorn_settings.S3_ACCESS_CREDENTIALS = json.dumps({
-            "s3_access_key": mock_s3_access_key,
-            "s3_secret_key": mock_s3_secret_key,
         })
 
         result = get_application(mock_uvicorn_settings)
@@ -94,8 +88,6 @@ class TestApplication(unittest.TestCase):
         mock_internal_reconciliation_storage_adapter_postgres.assert_called_once_with(
             mock_create_postgres_connection_uri.create_user_uri.return_value,
             mock_create_postgres_connection_uri.create_admin_uri.return_value,
-            mock_s3_access_key,
-            mock_s3_secret_key,
         )
         mock_adapters_storage.assert_called_once_with(
             mock_uuid_word_generation.return_value,

--- a/graphql/test/unit_tests/adapters/webserver/test_uvicorn_settings.py
+++ b/graphql/test/unit_tests/adapters/webserver/test_uvicorn_settings.py
@@ -16,7 +16,6 @@ class TestUvicornSettings(unittest.TestCase):
         mock_host = uuid.uuid4().__str__()
         mock_port = random.randint(0, 99999)  # nosec
         mock_db_connect_info = uuid.uuid4().__str__()
-        mock_s3_credentials = uuid.uuid4().__str__()
 
         for orca_env in ["production", "development", None, "apples"]:
             with self.subTest(orca_env=orca_env):
@@ -25,12 +24,10 @@ class TestUvicornSettings(unittest.TestCase):
                                     "HOST": mock_host, "PORT": mock_port.__str__(),
                                     "ORCA_ENV": orca_env,
                                     "DB_CONNECT_INFO": mock_db_connect_info,
-                                    "S3_ACCESS_CREDENTIALS": mock_s3_credentials,
                                 } if orca_env is not None else
                                 {
                                     "HOST": mock_host, "PORT": mock_port.__str__(),
                                     "DB_CONNECT_INFO": mock_db_connect_info,
-                                    "S3_ACCESS_CREDENTIALS": mock_s3_credentials,
                                 },
                                 clear=True):
                     result = UvicornSettings()
@@ -39,4 +36,3 @@ class TestUvicornSettings(unittest.TestCase):
                 self.assertEqual(mock_port, result.PORT)
                 self.assertEqual(True if orca_env == "development" else False, result.DEV)
                 self.assertEqual(mock_db_connect_info, result.DB_CONNECT_INFO)
-                self.assertEqual(mock_s3_credentials, result.S3_ACCESS_CREDENTIALS)

--- a/modules/graphql_0/main.tf
+++ b/modules/graphql_0/main.tf
@@ -13,6 +13,20 @@ data "aws_iam_policy_document" "assume_gql_tasks_role_policy_document" {
     }
     actions = ["sts:AssumeRole"]
   }
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["rds.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [
+        "${data.aws_caller_identity.current.account_id}"
+      ]
+    }
+  }
 }
 
 resource "aws_iam_role" "gql_tasks_role" {
@@ -53,25 +67,6 @@ resource "aws_iam_role" "orca_ecs_task_execution_role" {
   tags                 = var.tags
 }
 
-## IAM role for internal reconciliation S3 import role
-
-data "aws_iam_policy_document" "assume_rds_role" {
-  statement {
-    principals {
-      type        = "Service"
-      identifiers = ["rds.amazonaws.com"]
-    }
-    actions = ["sts:AssumeRole"]
-    condition {
-      test = "StringEquals"
-      variable = "aws:SourceAccount"
-      values = [
-        "${data.aws_caller_identity.current.account_id}"
-      ]
-    }
-  }
-}
-
 # Policy document for S3 import
 data "aws_iam_policy_document" "rds_s3_import_role_policy_document" {
   statement {
@@ -85,18 +80,8 @@ data "aws_iam_policy_document" "rds_s3_import_role_policy_document" {
     ]
   }
 }
-
-# Role to be associated with the Serverless Cluster for S3 Import
-resource "aws_iam_role" "rds_s3_import_role" {
-  name                 = "${var.prefix}_rds_s3_import_role"
-  assume_role_policy   = data.aws_iam_policy_document.assume_rds_role.json
-  permissions_boundary = var.permissions_boundary_arn
-  tags                 = var.tags
-}
-
-# Policy for the RDS S3 Import Role
 resource "aws_iam_role_policy" "rds_s3_import_role_policy" {
   name   = "${var.prefix}_rds_s3_import_role_policy"
-  role   = aws_iam_role.rds_s3_import_role.id
+  role   = aws_iam_role.gql_tasks_role.id
   policy = data.aws_iam_policy_document.rds_s3_import_role_policy_document.json
 }

--- a/modules/graphql_0/main.tf
+++ b/modules/graphql_0/main.tf
@@ -75,8 +75,8 @@ data "aws_iam_policy_document" "rds_s3_import_role_policy_document" {
       "s3:ListBucket"
     ]
     resources = [
-        "arn:aws:s3:::${var.prefix}_orca-reports",
-        "arn:aws:s3:::${var.prefix}_orca-reports/*"
+        "arn:aws:s3:::${var.prefix}-orca-reports",
+        "arn:aws:s3:::${var.prefix}-orca-reports/*"
     ]
   }
 }

--- a/tasks/get_current_archive_list/get_current_archive_list.py
+++ b/tasks/get_current_archive_list/get_current_archive_list.py
@@ -27,11 +27,7 @@ from sqlalchemy import text
 from sqlalchemy.future import Engine
 
 OS_ENVIRON_INTERNAL_REPORT_QUEUE_URL_KEY = "INTERNAL_REPORT_QUEUE_URL"
-OS_ENVIRON_S3_CREDENTIALS_SECRET_ARN_KEY = "S3_CREDENTIALS_SECRET_ARN"  # nosec
 OS_ENVIRON_DB_CONNECT_INFO_SECRET_ARN_KEY = "DB_CONNECT_INFO_SECRET_ARN"  # nosec
-
-S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY = "s3_access_key"
-S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY = "s3_secret_key"  # nosec
 
 MESSAGES_KEY = "Messages"
 RECORD_REPORT_BUCKET_REGION_KEY = "reportBucketRegion"
@@ -66,8 +62,6 @@ def task(
     report_bucket_region: str,
     report_bucket_name: str,
     manifest_key: str,
-    s3_access_key: str,
-    s3_secret_key: str,
     db_connect_info: Dict,
 ) -> Dict[str, Any]:
     """
@@ -121,8 +115,6 @@ def task(
         truncate_s3_partition(manifest[MANIFEST_SOURCE_BUCKET_KEY], admin_engine)
         # noinspection PyArgumentList
         update_job_with_s3_inventory_in_postgres(
-            s3_access_key,
-            s3_secret_key,
             report_bucket_name,
             report_bucket_region,
             # There will probably only be one file, but AWS leaves the option open.
@@ -262,8 +254,6 @@ def truncate_s3_partition_sql(partition_name: str) -> text:
 
 @shared_db.retry_operational_error()
 def update_job_with_s3_inventory_in_postgres(
-    s3_access_key: str,
-    s3_secret_key: str,
     report_bucket_name: str,
     report_bucket_region: str,
     csv_key_paths: List[str],
@@ -312,8 +302,6 @@ def update_job_with_s3_inventory_in_postgres(
                             "report_bucket_name": report_bucket_name,
                             "csv_key_path": csv_key_path,
                             "report_bucket_region": report_bucket_region,
-                            "s3_access_key": s3_access_key,
-                            "s3_secret_key": s3_secret_key,
                         }
                     ],
                 )
@@ -438,8 +426,6 @@ def trigger_csv_load_from_s3_sql() -> text:  # pragma: no cover
             :report_bucket_name,
             :csv_key_path,
             :report_bucket_region,
-            :s3_access_key,
-            :s3_secret_key,
             ''
         )
         """
@@ -478,36 +464,36 @@ def translate_s3_import_to_partitioned_data_sql() -> text:  # pragma: no cover
     )
 
 
-def get_s3_credentials_from_secrets_manager(s3_credentials_secret_arn: str) -> tuple:
-    """
-    Gets the s3 secret from the given arn and decompiles into two strings.
-    Args:
-        s3_credentials_secret_arn: The arn of the secret containing s3 credentials.
+# def get_s3_credentials_from_secrets_manager(s3_credentials_secret_arn: str) -> tuple:
+#     """
+#     Gets the s3 secret from the given arn and decompiles into two strings.
+#     Args:
+#         s3_credentials_secret_arn: The arn of the secret containing s3 credentials.
 
-    Returns:
-        A tuple consisting of
-            (str) An access key
-            (str) A secret key
-    """
-    secretsmanager = boto3.client(
-        "secretsmanager", region_name=os.environ["AWS_REGION"]
-    )
-    LOGGER.debug(f"Getting secret '{s3_credentials_secret_arn}'")
-    s3_credentials = json.loads(
-        secretsmanager.get_secret_value(SecretId=s3_credentials_secret_arn)[
-            "SecretString"
-        ]
-    )
-    s3_access_key = s3_credentials.get(S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY, None)
-    if s3_access_key is None or len(s3_access_key) == 0:
-        LOGGER.error(f"{S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY} secret is not set.")
-        raise ValueError(f"{S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY} secret is not set.")
-    s3_secret_key = s3_credentials.get(S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY, None)
-    if s3_secret_key is None or len(s3_secret_key) == 0:
-        LOGGER.error(f"{S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY} secret is not set.")
-        raise ValueError(f"{S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY} secret is not set.")
+#     Returns:
+#         A tuple consisting of
+#             (str) An access key
+#             (str) A secret key
+#     """
+#     secretsmanager = boto3.client(
+#         "secretsmanager", region_name=os.environ["AWS_REGION"]
+#     )
+#     LOGGER.debug(f"Getting secret '{s3_credentials_secret_arn}'")
+#     s3_credentials = json.loads(
+#         secretsmanager.get_secret_value(SecretId=s3_credentials_secret_arn)[
+#             "SecretString"
+#         ]
+#     )
+#     s3_access_key = s3_credentials.get(S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY, None)
+#     if s3_access_key is None or len(s3_access_key) == 0:
+#         LOGGER.error(f"{S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY} secret is not set.")
+#         raise ValueError(f"{S3_ACCESS_CREDENTIALS_ACCESS_KEY_KEY} secret is not set.")
+#     s3_secret_key = s3_credentials.get(S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY, None)
+#     if s3_secret_key is None or len(s3_secret_key) == 0:
+#         LOGGER.error(f"{S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY} secret is not set.")
+#         raise ValueError(f"{S3_ACCESS_CREDENTIALS_SECRET_KEY_KEY} secret is not set.")
 
-    return s3_access_key, s3_secret_key
+#     return s3_access_key, s3_secret_key
 
 
 @dataclass(frozen=True)
@@ -590,8 +576,6 @@ def handler(event: Dict[str, List], context: LambdaContext) -> Dict[str, Any]:
     Environment Vars:
         INTERNAL_REPORT_QUEUE_URL (string):
             The URL of the SQS queue the job came from.
-        S3_CREDENTIALS_SECRET_ARN (string):
-            The ARN of the secret containing s3 credentials.
         DB_CONNECT_INFO_SECRET_ARN (string):
             Secret ARN of the AWS secretsmanager secret for connecting to the database.
             See shared_db.py's get_configuration for further details.
@@ -600,9 +584,6 @@ def handler(event: Dict[str, List], context: LambdaContext) -> Dict[str, Any]:
     """
 
     # getting the env variables
-    s3_access_key, s3_secret_key = get_s3_credentials_from_secrets_manager(
-        check_env_variable(OS_ENVIRON_S3_CREDENTIALS_SECRET_ARN_KEY)
-    )
     db_connect_info = shared_db.get_configuration(
         check_env_variable(OS_ENVIRON_DB_CONNECT_INFO_SECRET_ARN_KEY)
     )
@@ -614,8 +595,6 @@ def handler(event: Dict[str, List], context: LambdaContext) -> Dict[str, Any]:
         message_data.report_bucket_region,
         message_data.report_bucket_name,
         message_data.manifest_key,
-        s3_access_key,
-        s3_secret_key,
         db_connect_info,
     )
     result[OUTPUT_RECEIPT_HANDLE_KEY] = message_data.message_receipt_handle


### PR DESCRIPTION
## Summary of Changes

Removed S3 access keys from graphql code as well as modified graphql task role to allow S3 imports to the V2 Serverless database

Addresses [ORCA-795: Update ORCA graphql internal reconciliation to remove s3 access keys and use IAM logic for DB.](https://bugs.earthdata.nasa.gov/browse/ORCA-795)

## Changes

* Removed `s3_access_key` and `s3_secret_key` from graphql code. Updated policy for graphql task role to allow for S3 imports into the V2 database

## Type of change

Please delete options that are not relevant.

- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Ran in AWS to verify tables from graphql populated and ran unit tests.

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x ] CHANGELOG.md
    - [x ] User documentation
- [ x] My code has passed security scanning
    - [ x] Snyk
    - [ x] git-secrets
