### PR TITLE
ORCA-873: Fix copy_to_archive lambda schema validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-832* - Modified pyscopg2 installation to allow for SSL connections to database.
 - *ORCA-795* - Modified Graphql task policy to allow for S3 imports.
 - *ORCA-797* - Removed s3 credential variables from `deployment-with-cumulus.md` and `s3-credentials.md` documentations since they are no longer used in Aurora v2 DB.
+- *ORCA-873* - Modified build task script to copy schemas into a schema folder to resolve errors.
 
 ### Deprecated
 

--- a/lambda scripts/build.sh
+++ b/lambda scripts/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/copy_from_archive/bin/build.sh
+++ b/tasks/copy_from_archive/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/copy_to_archive/bin/build.sh
+++ b/tasks/copy_to_archive/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/copy_to_archive_adapter/bin/build.sh
+++ b/tasks/copy_to_archive_adapter/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/extract_filepaths_for_granule/bin/build.sh
+++ b/tasks/extract_filepaths_for_granule/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO:  Copying the input, output and config schemas..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 ## Create the zip archive
 cd build

--- a/tasks/get_current_archive_list/bin/build.sh
+++ b/tasks/get_current_archive_list/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/internal_reconcile_report_job/bin/build.sh
+++ b/tasks/internal_reconcile_report_job/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/internal_reconcile_report_mismatch/bin/build.sh
+++ b/tasks/internal_reconcile_report_mismatch/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/internal_reconcile_report_orphan/bin/build.sh
+++ b/tasks/internal_reconcile_report_orphan/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy src files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/internal_reconcile_report_phantom/bin/build.sh
+++ b/tasks/internal_reconcile_report_phantom/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/orca_catalog_reporting/bin/build.sh
+++ b/tasks/orca_catalog_reporting/bin/build.sh
@@ -54,7 +54,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/orca_recovery_adapter/bin/build.sh
+++ b/tasks/orca_recovery_adapter/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/perform_orca_reconcile/bin/build.sh
+++ b/tasks/perform_orca_reconcile/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/post_copy_request_to_queue/bin/build.sh
+++ b/tasks/post_copy_request_to_queue/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/post_to_catalog/bin/build.sh
+++ b/tasks/post_to_catalog/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/post_to_database/bin/build.sh
+++ b/tasks/post_to_database/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/post_to_queue_and_trigger_step_function/bin/build.sh
+++ b/tasks/post_to_queue_and_trigger_step_function/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/request_from_archive/bin/build.sh
+++ b/tasks/request_from_archive/bin/build.sh
@@ -55,7 +55,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/request_status_for_granule/bin/build.sh
+++ b/tasks/request_status_for_granule/bin/build.sh
@@ -56,7 +56,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive

--- a/tasks/request_status_for_job/bin/build.sh
+++ b/tasks/request_status_for_job/bin/build.sh
@@ -56,7 +56,7 @@ check_returncode $? "ERROR: Failed to copy lambda files to build directory."
 
 ## Copy the schema files to build
 echo "INFO: Copying schema files ..."
-cp -r schemas/ build/
+cp -r schemas/ build/schemas/
 check_returncode $? "ERROR: Failed to copy schema files to build directory."
 
 ## Create the zip archive


### PR DESCRIPTION
## Summary of Changes

Modified build task script to copy schemas into a schema folder to resolve schema validation errors.

Addresses [ORCA-873: Fix copy_to_archive lambda schema validation errors](https://bugs.earthdata.nasa.gov/browse/ORCA-873)

## Changes

* Modified build task script to copy schemas into a schema folder to resolve schema validation errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Deployed and tested workflows and lambdas in AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] User documentation
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
