### PR TITLE
ORCA-774: Update python to 3.10 for all orca lambdas and dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-797* - Removed s3 credential variables from `deployment-with-cumulus.md` and `s3-credentials.md` documentations since they are no longer used in Aurora v2 DB.
 - *ORCA-873* - Modified build task script to copy schemas into a schema folder to resolve errors.
 - *ORCA-872* - Updated grapql version, modified policy in `modules/iam/main.tf` to resolve errors, and added DB role attachment to `modules/graphql_0/main.tf`
+- *ORCA-774* - Updated Lambdas and GraphQL to Python 3.10
 
 ### Deprecated
 

--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 # =============================================================================
-FROM python:3.9-slim as builder
+FROM python:3.10-slim as builder
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ RUN pip wheel --no-cache-dir --wheel-dir /app/wheels -r requirements.txt --trust
 
 # Final Stage
 # =============================================================================
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 # Set variables
 ARG VERSION_NUMBER="test"

--- a/modules/graphql_1/main.tf
+++ b/modules/graphql_1/main.tf
@@ -215,7 +215,7 @@ resource "aws_ecs_task_definition" "gql_task" {
 [
   {
     "name": "orca-gql",
-    "image": "ghcr.io/nasa/orca/graphql:0.33",
+    "image": "ghcr.io/nasa/orca/graphql:0.34",
     "cpu": 512,
     "memory": 256,
     "networkMode": "awsvpc",

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "internal_report_queue_message_retention_time_seconds" {
 variable "lambda_runtime" {
   type        = string
   description = "Runtime for lambdas."
-  default     = "python3.9"
+  default     = "python3.10"
 }
 
 variable "metadata_queue_message_retention_time_seconds" {


### PR DESCRIPTION
## Summary of Changes

Updated Lambda runtime and GraphQL Docker image to use Python 3.10 and pushed new image of GraphQL.

Addresses [ORCA-774: Update python to 3.10 for all orca lambdas and dockerfiles](https://bugs.earthdata.nasa.gov/browse/ORCA-774)

## Changes

* Updated Lambda runtime and GraphQL Docker image to use Python 3.10.
* Pushed new image of GraphQL.
* Modified GraphQL ECS task definition to use the new image.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests passed. Deployed and tested workflows and lambdas in AWS.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] User documentation
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
