### PR TITLE
ORCA-888: Enable cloudwatch logs in Aurora v2 DB for better troubleshooting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and includes an additional section for migration notes.
 ### Migration Notes
  
 ### Added
+- *ORCA-888* - Enabled CloudWatch logs for Aurora Serverless v2 for troubleshooting. 
 
 ### Changed
 

--- a/modules/aurora-serverless-v2/main.tf
+++ b/modules/aurora-serverless-v2/main.tf
@@ -58,7 +58,7 @@ resource "aws_rds_cluster" "example" {
   final_snapshot_identifier       = "${var.prefix}-v2-cluster-final-snapshot-${local.timestamp_sanitized}"
   snapshot_identifier             = var.snapshot_identifier
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_cluster_group_v13.id
-
+  enabled_cloudwatch_logs_exports = var.aurora_cloudwatch_logs
   serverlessv2_scaling_configuration {
     max_capacity = var.max_capacity
     min_capacity = var.min_capacity

--- a/modules/aurora-serverless-v2/variables.tf
+++ b/modules/aurora-serverless-v2/variables.tf
@@ -126,3 +126,10 @@ variable "db_parameters" {
     }
   ]
 }
+
+variable "aurora_cloudwatch_logs" {
+  description = "Type of logs to export to CloudWatch"
+  type = list(string)
+  default = [ "postgresql" ]
+  
+}


### PR DESCRIPTION
## Summary of Changes

 Enabled CloudWatch logs for Aurora Serverless v2 for troubleshooting. 

Addresses [ORCA-888: Enable cloudwatch logs in Aurora v2 DB for better troubleshooting.](https://bugs.earthdata.nasa.gov/browse/ORCA-888)

## Changes

* Updated Aurora Serverless v2 module in `modules/aurora-serverless-v2/main.tf` to enable CloudWatch logs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Deployed database successfully, verified logs were being sent to CloudWatch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] User documentation
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
