### PR TITLE
ORCA-896: Delete old unused Cumulus ORCA docker image from nexus repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-873* - Modified build task script to copy schemas into a schema folder to resolve errors.
 - *ORCA-872* - Updated grapql version, modified policy in `modules/iam/main.tf` to resolve errors, and added DB role attachment to `modules/graphql_0/main.tf`
 - *ORCA-774* - Updated Lambdas and GraphQL to Python 3.10
+- *ORCA-896* - Updated Bamboo files to use `latest` tag on `cumulus_orca` Docker image to resolve Bamboo jobs using old images.
 
 ### Deprecated
 

--- a/bamboo-specs/specs/deploy-cumulus-orca-buckets.yaml
+++ b/bamboo-specs/specs/deploy-cumulus-orca-buckets.yaml
@@ -28,7 +28,7 @@ Deploy DR ORCA buckets:
   other:
     clean-working-dir: true
   docker:
-    image: maven.earthdata.nasa.gov/cumulus_orca
+    image: maven.earthdata.nasa.gov/cumulus_orca:latest
     volumes:
       ${bamboo.working.directory}: ${bamboo.working.directory}
       ${bamboo.tmp.directory}: ${bamboo.tmp.directory}
@@ -51,7 +51,7 @@ Deploy Cumulus buckets and Cumulus and Orca modules:
   other:
     clean-working-dir: true
   docker:
-    image: maven.earthdata.nasa.gov/cumulus_orca
+    image: maven.earthdata.nasa.gov/cumulus_orca:latest
     volumes:
       ${bamboo.working.directory}: ${bamboo.working.directory}
       ${bamboo.tmp.directory}: ${bamboo.tmp.directory}
@@ -78,7 +78,7 @@ Run Ingest Integration tests:
   other:
     clean-working-dir: true
   docker:
-    image: maven.earthdata.nasa.gov/cumulus_orca
+    image: maven.earthdata.nasa.gov/cumulus_orca:latest
     volumes:
       ${bamboo.working.directory}: ${bamboo.working.directory}
       ${bamboo.tmp.directory}: ${bamboo.tmp.directory}

--- a/bamboo-specs/specs/orca-cleanup.yaml
+++ b/bamboo-specs/specs/orca-cleanup.yaml
@@ -22,7 +22,7 @@ Clean up ORCA buckets and modules:
   other:
     clean-working-dir: true
   docker:
-    image: maven.earthdata.nasa.gov/cumulus_orca
+    image: maven.earthdata.nasa.gov/cumulus_orca:latest
     volumes:
       ${bamboo.working.directory}: ${bamboo.working.directory}
       ${bamboo.tmp.directory}: ${bamboo.tmp.directory}
@@ -43,7 +43,7 @@ Clean up DR ORCA buckets:
   other:
     clean-working-dir: true
   docker:
-    image: maven.earthdata.nasa.gov/cumulus_orca
+    image: maven.earthdata.nasa.gov/cumulus_orca:latest
     volumes:
       ${bamboo.working.directory}: ${bamboo.working.directory}
       ${bamboo.tmp.directory}: ${bamboo.tmp.directory}

--- a/bamboo-specs/specs/orca-code-release.yaml
+++ b/bamboo-specs/specs/orca-code-release.yaml
@@ -54,7 +54,7 @@ Build and Test:
   other:
     clean-working-dir: true
   docker:
-    image: maven.earthdata.nasa.gov/cumulus_orca
+    image: maven.earthdata.nasa.gov/cumulus_orca:latest
     volumes:
       ${bamboo.working.directory}: ${bamboo.working.directory}
       ${bamboo.tmp.directory}: ${bamboo.tmp.directory}
@@ -170,7 +170,7 @@ Release ORCA Code:
   key: RO
   description: Cleans, creates a GitHub Release and uploads artifacts for release
   docker:
-    image: maven.earthdata.nasa.gov/cumulus_orca
+    image: maven.earthdata.nasa.gov/cumulus_orca:latest
     volumes:
       ${bamboo.working.directory}: ${bamboo.working.directory}
       ${bamboo.tmp.directory}: ${bamboo.tmp.directory}


### PR DESCRIPTION
## Summary of Changes

Updated Bamboo files to use `latest` tag on `cumulus_orca` Docker image to resolve Bamboo jobs using old images.

Addresses [ORCA-896: Delete old unused Cumulus ORCA docker image from nexus repo](https://bugs.earthdata.nasa.gov/browse/ORCA-896)

## Changes

* Updated Bamboo files to use `latest` tag on `cumulus_orca` Docker image to resolve Bamboo jobs using old images.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Bamboo jobs pass successfully. https://ci.earthdata.nasa.gov/browse/ORCA-OI475

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] User documentation
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
