### PR TITLE
ORCA-128: As a developer, I would like to minimize costs in AWS by shutting down resources when not in use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-868* - Added EC2 instance for DB comparison after migration under `modules/db_compare_instance/main.tf`
 - *ORCA-849* - Added optional `fileDestinationOverride` property in copyToArchive workflow that can be used to override the file destination key if desired.
 - *ORCA-880* - Modified terraform to add an optional variable `lambda_runtime` for lambda runtime.
+- *ORCA-128* - Added Scheduler module at `cumulus-orca/modules/scheduler`.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-868* - Added EC2 instance for DB comparison after migration under `modules/db_compare_instance/main.tf`
 - *ORCA-849* - Added optional `fileDestinationOverride` property in copyToArchive workflow that can be used to override the file destination key if desired.
 - *ORCA-880* - Modified terraform to add an optional variable `lambda_runtime` for lambda runtime.
-- *ORCA-128* - Added Scheduler module at `cumulus-orca/modules/scheduler`.
+- *ORCA-128* - Added Scheduler module at `cumulus-orca/modules/scheduler` to shutdown specifically tagged resources such as EC2, RDS, ECS, Autoscaling Groups, Redshift, and DocumentDB.
 
 
 ### Changed

--- a/modules/scheduler/README.md
+++ b/modules/scheduler/README.md
@@ -1,0 +1,65 @@
+# Instance Scheduler
+This module creates Lambda functions that turn on or off EC2 Instances, Auto Scaling Groups, RDS Instances, ECS Clusters, RedShift Clusters, and DocumentDB Instances based on the instance tags. The code is sourced from the [diodonfrost terraform-aws-lambda-scheduler-stop-start github](https://github.com/diodonfrost/terraform-aws-lambda-scheduler-stop-start), with parameters entered to configure the function, including a cron expression for the schedule.
+
+## Example Scheduler Block for EC2
+```terraform
+# Schedule = office-hours-8-6
+module "start_ec2_instance_8am" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours_8_6 ? 1 : 0
+    name = "start_ec2_instance_8am"
+    cloudwatch_schedule_expression = "cron(0 14 ? * MON-FRI *)"
+    schedule_action = "start"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    ec2_schedule = "true"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "office-hours-8-6"
+    }
+}
+
+module "stop_ec2_instance_6pm" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours_8_6 ? 1 : 0
+    name = "stop_ec2_instance_6pm"
+    cloudwatch_schedule_expression = "cron(59 23 ? * MON-FRI *)"
+    schedule_action = "stop"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    ec2_schedule = "true"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "office-hours-8-6"
+    }
+}
+
+
+```
+
+## Usage
+1. Ensure the instance you want scheduled for start/stop has the tags specified, e.g. Key = **Schedule** Value = **office-hours-8-6**
+2. Run a deployment with all lambda functions set to false in the **variables.tf** file or the deployment will fail.
+
+**Example:**
+```terraform
+variable "create_office_hours" {
+    default = false
+}
+
+variable "create_stop_only_8pm_autoscaling" {
+    default = false
+}
+
+variable "create_office_hours_8_6_autoscaling" {
+    default = false
+}
+
+variable "create_office_hours_autoscaling" {
+    default = false
+}
+```

--- a/modules/scheduler/module/main.tf
+++ b/modules/scheduler/module/main.tf
@@ -1,0 +1,162 @@
+module "start_ec2_instance" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours ? 1 : 0
+    name = "start_ec2_instance"
+    cloudwatch_schedule_expression = "cron(0 12 ? * MON-FRI *)"
+    schedule_action = "start"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "false"
+    ec2_schedule = "true"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "office-hours"
+    }
+}
+
+module "stop_ec2_instance" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours ? 1 : 0
+    name = "stop_ec2_instance"
+    cloudwatch_schedule_expression = "cron(59 23 ? * MON-FRI *)"
+    schedule_action = "stop"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "false"
+    ec2_schedule = "true"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "office-hours"
+    }
+}
+
+# Schedule = office-hours-8-6
+module "start_ec2_instance_8am" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours_8_6 ? 1 : 0
+    name = "start_ec2_instance_8am"
+    cloudwatch_schedule_expression = "cron(0 13 ? * MON-FRI *)"
+    schedule_action = "start"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "false"
+    ec2_schedule = "true"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "office-hours-8-6"
+    }
+}
+
+module "stop_ec2_instance_6pm" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours_8_6 ? 1 : 0
+    name = "stop_ec2_instance_6pm"
+    cloudwatch_schedule_expression = "cron(59 22 ? * MON-FRI *)"
+    schedule_action = "stop"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "false"
+    ec2_schedule = "true"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "office-hours-8-6"
+    }
+}
+
+module "start_autoscaling_instance" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours ? 1 : 0
+    name = "start_autoscaling_instance"
+    cloudwatch_schedule_expression = "cron(0 12 ? * MON-FRI *)"
+    schedule_action = "start"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "true"
+    ec2_schedule = "false"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "autoscaling-office-hours"
+    }
+}
+
+module "stop_autoscaling_instance" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours ? 1 : 0
+    name = "stop_autoscaling_instance"
+    cloudwatch_schedule_expression = "cron(59 23 ? * MON-FRI *)"
+    schedule_action = "stop"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "true"
+    ec2_schedule = "false"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "autoscaling-office-hours"
+    }
+}
+
+# Schedule = office-hours-8-6
+module "start_autoscaling_instance_8am" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours_8_6 ? 1 : 0
+    name = "start_autoscaling_instance_8am"
+    cloudwatch_schedule_expression = "cron(0 13 ? * MON-FRI *)"
+    schedule_action = "start"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "true"
+    ec2_schedule = "false"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "autoscaling-office-hours-8-6"
+    }
+}
+
+module "stop_autoscaling_instance_6pm" {
+    source = "diodonfrost/lambda-scheduler-stop-start/aws"
+    version = "3.5.0"
+    count = var.create_office_hours_8_6 ? 1 : 0
+    name = "stop_autoscaling_instance_6pm"
+    cloudwatch_schedule_expression = "cron(59 22 ? * MON-FRI *)"
+    schedule_action = "stop"
+    aws_regions = ["us-west-2"]
+    tags = var.tags
+    autoscaling_schedule = "true"
+    ec2_schedule = "false"
+    rds_schedule = "false"
+    cloudwatch_alarm_schedule = "false"
+    custom_iam_role_arn = aws_iam_role.aws_instance_scheduler_role.arn
+    resources_tag = {
+        key = "Schedule"
+        value = "autoscaling-office-hours-8-6"
+    }
+}
+

--- a/modules/scheduler/module/main.tf
+++ b/modules/scheduler/module/main.tf
@@ -5,7 +5,7 @@ module "start_ec2_instance" {
     name = "start_ec2_instance"
     cloudwatch_schedule_expression = "cron(0 12 ? * MON-FRI *)"
     schedule_action = "start"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "false"
     ec2_schedule = "true"
@@ -25,7 +25,7 @@ module "stop_ec2_instance" {
     name = "stop_ec2_instance"
     cloudwatch_schedule_expression = "cron(59 23 ? * MON-FRI *)"
     schedule_action = "stop"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "false"
     ec2_schedule = "true"
@@ -46,7 +46,7 @@ module "start_ec2_instance_8am" {
     name = "start_ec2_instance_8am"
     cloudwatch_schedule_expression = "cron(0 13 ? * MON-FRI *)"
     schedule_action = "start"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "false"
     ec2_schedule = "true"
@@ -66,7 +66,7 @@ module "stop_ec2_instance_6pm" {
     name = "stop_ec2_instance_6pm"
     cloudwatch_schedule_expression = "cron(59 22 ? * MON-FRI *)"
     schedule_action = "stop"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "false"
     ec2_schedule = "true"
@@ -86,7 +86,7 @@ module "start_autoscaling_instance" {
     name = "start_autoscaling_instance"
     cloudwatch_schedule_expression = "cron(0 12 ? * MON-FRI *)"
     schedule_action = "start"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "true"
     ec2_schedule = "false"
@@ -106,7 +106,7 @@ module "stop_autoscaling_instance" {
     name = "stop_autoscaling_instance"
     cloudwatch_schedule_expression = "cron(59 23 ? * MON-FRI *)"
     schedule_action = "stop"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "true"
     ec2_schedule = "false"
@@ -127,7 +127,7 @@ module "start_autoscaling_instance_8am" {
     name = "start_autoscaling_instance_8am"
     cloudwatch_schedule_expression = "cron(0 13 ? * MON-FRI *)"
     schedule_action = "start"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "true"
     ec2_schedule = "false"
@@ -147,7 +147,7 @@ module "stop_autoscaling_instance_6pm" {
     name = "stop_autoscaling_instance_6pm"
     cloudwatch_schedule_expression = "cron(59 22 ? * MON-FRI *)"
     schedule_action = "stop"
-    aws_regions = ["us-west-2"]
+    aws_regions = [var.aws_region]
     tags = var.tags
     autoscaling_schedule = "true"
     ec2_schedule = "false"

--- a/modules/scheduler/module/main.tf
+++ b/modules/scheduler/module/main.tf
@@ -82,7 +82,7 @@ module "stop_ec2_instance_6pm" {
 module "start_autoscaling_instance" {
     source = "diodonfrost/lambda-scheduler-stop-start/aws"
     version = "3.5.0"
-    count = var.create_office_hours ? 1 : 0
+    count = var.create_office_hours_autoscaling ? 1 : 0
     name = "start_autoscaling_instance"
     cloudwatch_schedule_expression = "cron(0 12 ? * MON-FRI *)"
     schedule_action = "start"
@@ -102,7 +102,7 @@ module "start_autoscaling_instance" {
 module "stop_autoscaling_instance" {
     source = "diodonfrost/lambda-scheduler-stop-start/aws"
     version = "3.5.0"
-    count = var.create_office_hours ? 1 : 0
+    count = var.create_office_hours_autoscaling ? 1 : 0
     name = "stop_autoscaling_instance"
     cloudwatch_schedule_expression = "cron(59 23 ? * MON-FRI *)"
     schedule_action = "stop"
@@ -123,7 +123,7 @@ module "stop_autoscaling_instance" {
 module "start_autoscaling_instance_8am" {
     source = "diodonfrost/lambda-scheduler-stop-start/aws"
     version = "3.5.0"
-    count = var.create_office_hours_8_6 ? 1 : 0
+    count = var.create_office_hours_8_6_autoscaling ? 1 : 0
     name = "start_autoscaling_instance_8am"
     cloudwatch_schedule_expression = "cron(0 13 ? * MON-FRI *)"
     schedule_action = "start"
@@ -143,7 +143,7 @@ module "start_autoscaling_instance_8am" {
 module "stop_autoscaling_instance_6pm" {
     source = "diodonfrost/lambda-scheduler-stop-start/aws"
     version = "3.5.0"
-    count = var.create_office_hours_8_6 ? 1 : 0
+    count = var.create_office_hours_8_6_autoscaling ? 1 : 0
     name = "stop_autoscaling_instance_6pm"
     cloudwatch_schedule_expression = "cron(59 22 ? * MON-FRI *)"
     schedule_action = "stop"

--- a/modules/scheduler/module/outputs.tf
+++ b/modules/scheduler/module/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_instance_scheduler_role_arn" {
+  value = aws_iam_role.aws_instance_scheduler_role.arn
+}

--- a/modules/scheduler/module/scheduler-policy-role.tf
+++ b/modules/scheduler/module/scheduler-policy-role.tf
@@ -1,0 +1,100 @@
+data "aws_iam_policy_document" "aws_instance_scheduler_policydata" {
+  statement {
+    sid = 1
+    actions = [
+      "rds:StartDBCluster",
+      "rds:StopDBCluster",
+      "kms:Decrypt",
+      "ec2:TerminateInstances",
+      "autoscaling:ResumeProcesses",
+      "lambda:InvokeFunction",
+      "autoscaling:SuspendProcesses",
+      "rds:StopDBInstance",
+      "ec2:StopInstances",
+      "rds:StartDBInstance",
+      "logs:CreateLogStream",
+      "cloudwatch:EnableAlarmActions",
+      "ec2:StartInstances",
+      "cloudwatch:DisableAlarmActions",
+      "kms:Encrypt",
+      "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "kms:CreateGrant",
+      "rds:DescribeDBClusters"
+    ]
+    resources = [
+      "arn:aws:autoscaling:*:${var.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/*",
+      "arn:aws:rds:*:${var.aws_account_id}:db:*",
+      "arn:aws:rds:*:${var.aws_account_id}:cluster:*",
+      "arn:aws:lambda:*:${var.aws_account_id}:function:*",
+      "arn:aws:cloudwatch:*:${var.aws_account_id}:alarm:*",
+      "arn:aws:logs:*:${var.aws_account_id}:log-group:*",
+      "arn:aws:kms:*:${var.aws_account_id}:key/*",
+      "arn:aws:ec2:*:${var.aws_account_id}:instance/*"
+    ]
+  }
+
+  statement {
+    sid = 2
+    actions = [
+      "autoscaling:DescribeAutoScalingInstances",
+      "ec2:DescribeInstances",
+      "tag:GetResources",
+      "autoscaling:DescribeScalingProcessTypes",
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeTags"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid = 3
+    actions = [
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      "arn:aws:logs:*:${var.aws_account_id}:log-group:*:log-stream:*"
+    ]
+  }
+
+  statement {
+    sid = 4
+    actions = [
+      "redshift:PauseCluster"
+    ]
+    resources = [
+      "arn:aws:redshift:*:${var.aws_account_id}:cluster:*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "aws_instance_scheduler_rolepolicy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "aws_instance_scheduler_policy" {
+  name = "aws-instance-scheduler-policy"
+  path = "/"
+  tags = var.tags
+  description = "Terraforms InstanceScheduler actions to start and stop resources"
+  policy = data.aws_iam_policy_document.aws_instance_scheduler_policydata.json
+}
+
+resource "aws_iam_role" "aws_instance_scheduler_role" {
+  name                = "aws-instance-scheduler-role"
+  assume_role_policy  = data.aws_iam_policy_document.aws_instance_scheduler_rolepolicy.json
+  managed_policy_arns = [
+      aws_iam_policy.aws_instance_scheduler_policy.arn,
+  ]
+  permissions_boundary = var.role_permissions_boundary_arn
+}
+

--- a/modules/scheduler/module/scheduler-policy-role.tf
+++ b/modules/scheduler/module/scheduler-policy-role.tf
@@ -5,7 +5,6 @@ data "aws_iam_policy_document" "aws_instance_scheduler_policydata" {
       "rds:StartDBCluster",
       "rds:StopDBCluster",
       "kms:Decrypt",
-      "ec2:TerminateInstances",
       "autoscaling:ResumeProcesses",
       "lambda:InvokeFunction",
       "autoscaling:SuspendProcesses",

--- a/modules/scheduler/module/variables.tf
+++ b/modules/scheduler/module/variables.tf
@@ -2,6 +2,11 @@ variable "aws_account_id" {
     type = string
 }
 
+variable "aws_region" {
+    type = string
+    default = "us-west-2"
+}
+
 variable "create_office_hours" {
     default = false
 }

--- a/modules/scheduler/module/variables.tf
+++ b/modules/scheduler/module/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_account_id" {
+    type = string
+}
+
+variable "create_office_hours" {
+    default = false
+}
+
+variable "create_office_hours_8_6" {
+    default = false
+}
+
+variable "create_office_hours_autoscaling" {
+    default = false
+}
+
+variable "create_office_hours_8_6_autoscaling" {
+    default = false
+}
+
+variable "role_permissions_boundary_arn" {
+  description = "CSR developer permissions boundary"
+  type = string
+}
+
+variable "tags" {
+  description = "Default tags to be applied."
+  type = map(string)
+}


### PR DESCRIPTION
## Summary of Changes

Added scheduler lambda to start/stop resources on a schedule if tagged with specified tags in `cumulus-orca/modules/scheduler`

Addresses [ORCA-128: As a developer, I would like to minimize costs in AWS by shutting down resources when not in use.](https://bugs.earthdata.nasa.gov/browse/ORCA-128)

## Changes

* Added scheduler lambda to start/stop resources on a schedule if tagged with specified tags in `cumulus-orca/modules/scheduler`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployed module with various schedules and tested on resources such as EC2, Auto Scaling Groups, RDS, and ECS cluster.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
    - [x] User documentation
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
