### PR TITLE
ORCA-752: Review use of security groups and actual needs for ORCA Lambdas and other objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-849* - Added optional `fileDestinationOverride` property in copyToArchive workflow that can be used to override the file destination key if desired.
 - *ORCA-880* - Modified terraform to add an optional variable `lambda_runtime` for lambda runtime.
 - *ORCA-128* - Added Scheduler module at `cumulus-orca/modules/scheduler` to shutdown specifically tagged resources such as EC2, RDS, ECS, Autoscaling Groups, Redshift, and DocumentDB.
-- *ORCA-752* - Created Security Group for ORCA Lambdas that only need outbound access at `modules/security_groups/main.tf
+- *ORCA-752* - Created Security Group for ORCA Lambdas that only need outbound access at `modules/security_groups/main.tf`
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-849* - Added optional `fileDestinationOverride` property in copyToArchive workflow that can be used to override the file destination key if desired.
 - *ORCA-880* - Modified terraform to add an optional variable `lambda_runtime` for lambda runtime.
 - *ORCA-128* - Added Scheduler module at `cumulus-orca/modules/scheduler` to shutdown specifically tagged resources such as EC2, RDS, ECS, Autoscaling Groups, Redshift, and DocumentDB.
+- *ORCA-752* - Created Security Group for ORCA Lambdas that only need outbound access at `modules/security_groups/main.tf
 
 
 ### Changed

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -331,7 +331,7 @@ resource "aws_lambda_function" "extract_filepaths_for_granule" {
 
   vpc_config {
     subnet_ids         = var.lambda_subnet_ids
-    security_group_ids = [module.lambda_security_group.vpc_postgres_ingress_all_egress_id]
+    security_group_ids = [module.lambda_security_group.vpc_all_egress_id]
   }
   environment {
     variables = {

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_function" "copy_to_archive" {
 
   vpc_config {
     subnet_ids         = var.lambda_subnet_ids
-    security_group_ids = [module.lambda_security_group.vpc_postgres_ingress_all_egress_id]
+    security_group_ids = [module.lambda_security_group.vpc_all_egress_id]
   }
 
   environment {
@@ -420,7 +420,7 @@ resource "aws_lambda_function" "request_from_archive" {
 
   vpc_config {
     subnet_ids         = var.lambda_subnet_ids
-    security_group_ids = [module.lambda_security_group.vpc_postgres_ingress_all_egress_id]
+    security_group_ids = [module.lambda_security_group.vpc_all_egress_id]
   }
 
   environment {
@@ -458,7 +458,7 @@ resource "aws_lambda_function" "copy_from_archive" {
 
   vpc_config {
     subnet_ids         = var.lambda_subnet_ids
-    security_group_ids = [module.lambda_security_group.vpc_postgres_ingress_all_egress_id]
+    security_group_ids = [module.lambda_security_group.vpc_all_egress_id]
   }
 
   environment {

--- a/modules/security_groups/main.tf
+++ b/modules/security_groups/main.tf
@@ -41,3 +41,24 @@ resource "aws_security_group_rule" "rds_allow_lambda_access" {
   source_security_group_id = aws_security_group.vpc_postgres_ingress_all_egress.id
   security_group_id        = var.rds_security_group_id
 }
+
+
+
+resource "aws_security_group" "vpc_all_egress" {
+  name        = "${var.prefix}-vpc-all-egress"
+  description = "Allow all outbound traffic"
+  tags        = var.tags
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
+  security_group_id = aws_security_group.vpc_all_egress.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1" 
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv6" {
+  security_group_id = aws_security_group.vpc_all_egress.id
+  cidr_ipv6         = "::/0"
+  ip_protocol       = "-1" 
+}

--- a/modules/security_groups/output.tf
+++ b/modules/security_groups/output.tf
@@ -2,3 +2,8 @@ output "vpc_postgres_ingress_all_egress_id" {
   value       = aws_security_group.vpc_postgres_ingress_all_egress.id
   description = "PostgreSQL security group id"
 }
+
+output "vpc_all_egress_id" {
+  value       = aws_security_group.vpc_all_egress.id
+  description = "Egress security group id"
+}


### PR DESCRIPTION
## Summary of Changes

Four Lambdas do not need Postgres access so created a security group that only gives them the outbound traffic needed for them to function.

Addresses [ORCA-752: Review use of security groups and actual needs for ORCA Lambdas and other objects](https://bugs.earthdata.nasa.gov/browse/ORCA-752)

## Changes

* Created Security Group for ORCA Lambdas that only need outbound access at `modules/security_groups/main.tf`
* Applied to the four Lambdas that don't need Postgres Access
   * copy_from_archive
   * copy_to_archive
   * request_from_archive
   * extract_filepaths_for_granule

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployed successfully, and affected Lambdas/Step Functions run successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets