### PR TITLE
ORCA-889: Create Network Load balancer for VPC Link in DR account with proper configuration/target groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Once the Aurora V1 database has been migrated/upgrade to Aurora V2 you can verif
 - *ORCA-849* - Added optional `fileDestinationOverride` property in copyToArchive workflow that can be used to override the file destination key if desired.
 - *ORCA-844* - Created initial VPC link to interact with DR ORCA API gateway endpoint with the cumulus account.
 - *ORCA-839* - Created AWS common resources in DR account for decoupling efforts.
+- *ORCA-889* - Added Network Load Balancer and target groups in `modules/graphql_1/main.tf`. As well as updated bucket permission for Network Load Balancer logs to S3 in `website/docs/developer/deployment-guide/creating-orca-archive-bucket.md`.
 
 
 ### Changed

--- a/modules/graphql_1/main.tf
+++ b/modules/graphql_1/main.tf
@@ -152,8 +152,8 @@ resource "aws_lb_listener" "gql_app_lb_listener" {
 }
 
 # Network Load Balacner
-resource "aws_lb_target_group" "network_lb_tg" {
-  name        = "${random_id.lb_name.hex}-gql-n"
+resource "aws_lb_target_group" "decoupling_network_lb_target_group" {
+  name        = "${random_id.lb_name.hex}-decoupling-network-tg"
   target_type = "alb"
   port        = local.graphql_port
   protocol    = "TCP"
@@ -163,17 +163,17 @@ resource "aws_lb_target_group" "network_lb_tg" {
   }
 }
 
-data "aws_lb" "gql_net_lb_data" {
-  arn = aws_lb.gql_net_lb.arn
+data "aws_lb" "decoupling_orca_nlb_data" {
+  arn = aws_lb.decoupling_orca_nlb.arn
 }
 
-resource "aws_lb" "gql_net_lb" {
-  name               = "${var.prefix}-gql-n"
+resource "aws_lb" "decoupling_orca_nlb" {
+  name               = "${var.prefix}-decoupling-orca-nlb"
   internal           = true
   load_balancer_type = "network"
   access_logs {
     bucket  = var.system_bucket
-    prefix  = "${var.prefix}-lb-gql-n-logs"
+    prefix  = "${var.prefix}-decoupling-orca-nlb-logs"
     enabled = true
   }
   drop_invalid_header_fields = true
@@ -183,21 +183,21 @@ resource "aws_lb" "gql_net_lb" {
   tags = var.tags
 }
 
-resource "aws_lb_listener" "gql_net_lb_listener" {
-  load_balancer_arn = aws_lb.gql_net_lb.arn
+resource "aws_lb_listener" "decoupling_orca_nlb_listener" {
+  load_balancer_arn = aws_lb.decoupling_orca_nlb.arn
   port              = local.graphql_port
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.network_lb_tg.arn
+    target_group_arn = aws_lb_target_group.decoupling_network_lb_target_group.arn
   }
 
   tags               = var.tags
 }
 
-resource "aws_lb_target_group_attachment" "network-tg-attachment" {
-  target_group_arn = aws_lb_target_group.network_lb_tg.arn
+resource "aws_lb_target_group_attachment" "network_tg_attachment" {
+  target_group_arn = aws_lb_target_group.decoupling_network_lb_target_group.arn
   target_id        = aws_lb.gql_app_lb.arn
   port             = local.graphql_port
 }

--- a/modules/graphql_1/output.tf
+++ b/modules/graphql_1/output.tf
@@ -4,5 +4,5 @@ output "graphql_load_balancer_dns_name" {
 }
 
 output "network_load_balancer_dns_name" {
-  value       = data.aws_lb.gql_net_lb_data.dns_name
+  value       = data.aws_lb.decoupling_orca_nlb_data.dns_name
 }

--- a/modules/graphql_1/output.tf
+++ b/modules/graphql_1/output.tf
@@ -2,3 +2,7 @@ output "graphql_load_balancer_dns_name" {
   value       = data.aws_lb.gql_app_lb_data.dns_name
   description = "The DNS Name of the Application Load Balancer that handles access to ORCA GraphQL."
 }
+
+output "network_load_balancer_dns_name" {
+  value       = data.aws_lb.gql_net_lb_data.dns_name
+}

--- a/modules/orca/output.tf
+++ b/modules/orca/output.tf
@@ -129,5 +129,5 @@ output "orca_graphql_load_balancer_dns_name" {
 
 output "orca_network_load_balancer_dns_name" {
   value       = module.orca_graphql_1.network_load_balancer_dns_name
-  description = "The DNS Name of the Application Load Balancer that handles access to ORCA GraphQL."
+  description = "The DNS Name of the Network Load Balancer."
 }

--- a/modules/orca/output.tf
+++ b/modules/orca/output.tf
@@ -126,3 +126,8 @@ output "orca_graphql_load_balancer_dns_name" {
   value       = module.orca_graphql_1.graphql_load_balancer_dns_name
   description = "The DNS Name of the Application Load Balancer that handles access to ORCA GraphQL."
 }
+
+output "orca_network_load_balancer_dns_name" {
+  value       = module.orca_graphql_1.network_load_balancer_dns_name
+  description = "The DNS Name of the Application Load Balancer that handles access to ORCA GraphQL."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -111,3 +111,8 @@ output "orca_graphql_load_balancer_dns_name" {
   value       = module.orca.orca_graphql_load_balancer_dns_name
   description = "The DNS Name of the Application Load Balancer that handles access to ORCA GraphQL."
 }
+
+output "orca_network_load_balancer_dns_name" {
+  value       = module.orca.orca_network_load_balancer_dns_name
+  description = "The DNS Name of the Network Load Balancer."
+}

--- a/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
+++ b/website/docs/developer/deployment-guide/creating-orca-archive-bucket.md
@@ -331,3 +331,30 @@ Replace `<BUCKET_NAME>` with your `system-bucket` name.
 Replace `<PREFIX>` with your prefix.
 
 Replace `<AWS_ACCOUNT_ID>` with your Cumulus OU account number.
+
+
+For Network Load Balancers you must add the following S3 bucket policy to your `system_bucket`, which will likely be named `<PREFIX>-internal`, to give the load balancer access to write logs to the S3 bucket. Otherwise, the deployment will throw an `Access Denied` error.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+	    "Effect": "Allow",
+            "Principal": {
+	    "Service": "delivery.logs.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::<BUCKET_NAME>/<PREFIX>-lb-gql-n-logs/AWSLogs/<AWS_ACCOUNT_ID>/*"
+        }
+    ]
+}
+```
+
+:::note 
+
+Replace `<BUCKET_NAME>` with your `system-bucket` name.
+
+Replace `<PREFIX>` with your prefix.
+
+Replace `<AWS_ACCOUNT_ID>` with your Cumulus OU account number.


### PR DESCRIPTION
## Summary of Changes

For future Cumulus decoupling a Network Load Balancer is needed with a target group of the current Application Load balancer. Created NLB and Target Groups to the ALB as well as updated documentation.

Addresses [ORCA-889: Create Network Load balancer for VPC Link in DR account with proper configuration/target groups.](https://bugs.earthdata.nasa.gov/browse/ORCA-889)

## Changes

* Added Network Load Balancer and target groups in `modules/graphql_1/main.tf`
* Updated bucket permission for Network Load Balancer logs to S3 in `website/docs/developer/deployment-guide/creating-orca-archive-bucket.md`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deployed successfully, and verified the Application Load Balancer was registered to the target group.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets