### PR TITLE
ORCA-567: Lock Down pip Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and includes an additional section for migration notes.
 
 ### Changed
 
+*ORCA-567* - Specified build scripts to use specific version of pip to resolve any future errors/issues that could be caused by using the latest version of pip.
+
 ### Deprecated
 
 ### Removed

--- a/ecs_tasks/internal_reconcile_report_generate/bin/run_tests.sh
+++ b/ecs_tasks/internal_reconcile_report_generate/bin/run_tests.sh
@@ -36,7 +36,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/graphql/bin/run_tests.sh
+++ b/graphql/bin/run_tests.sh
@@ -36,7 +36,7 @@ source ../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/integration_test/workflow_tests/bin/run_tests.sh
+++ b/integration_test/workflow_tests/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/lambda scripts/build.sh
+++ b/lambda scripts/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/lambda scripts/run_tests.sh
+++ b/lambda scripts/run_tests.sh
@@ -36,7 +36,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/shared_libraries/bin/build_api.sh
+++ b/shared_libraries/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/shared_libraries/bin/run_tests.sh
+++ b/shared_libraries/bin/run_tests.sh
@@ -35,7 +35,7 @@ source ../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/copy_from_archive/bin/build.sh
+++ b/tasks/copy_from_archive/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/copy_from_archive/bin/build_api.sh
+++ b/tasks/copy_from_archive/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/copy_from_archive/bin/run_tests.sh
+++ b/tasks/copy_from_archive/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/copy_to_archive/bin/build.sh
+++ b/tasks/copy_to_archive/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/copy_to_archive/bin/build_api.sh
+++ b/tasks/copy_to_archive/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/copy_to_archive/bin/run_tests.sh
+++ b/tasks/copy_to_archive/bin/run_tests.sh
@@ -33,7 +33,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/db_deploy/bin/build.sh
+++ b/tasks/db_deploy/bin/build.sh
@@ -43,7 +43,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/db_deploy/bin/build_doc.sh
+++ b/tasks/db_deploy/bin/build_doc.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q pydoc-markdown==3.10.1 --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/db_deploy/bin/run_tests.sh
+++ b/tasks/db_deploy/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 pip install "cython<3.0.0" wheel
 pip install "pyyaml==5.4.1" --no-build-isolation

--- a/tasks/delete_old_reconcile_jobs/bin/build.sh
+++ b/tasks/delete_old_reconcile_jobs/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/delete_old_reconcile_jobs/bin/build_api.sh
+++ b/tasks/delete_old_reconcile_jobs/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/delete_old_reconcile_jobs/bin/run_tests.sh
+++ b/tasks/delete_old_reconcile_jobs/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/extract_filepaths_for_granule/bin/build.sh
+++ b/tasks/extract_filepaths_for_granule/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/extract_filepaths_for_granule/bin/build_api.sh
+++ b/tasks/extract_filepaths_for_granule/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/extract_filepaths_for_granule/bin/run_tests.sh
+++ b/tasks/extract_filepaths_for_granule/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/get_current_archive_list/bin/build.sh
+++ b/tasks/get_current_archive_list/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/get_current_archive_list/bin/build_api.sh
+++ b/tasks/get_current_archive_list/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/get_current_archive_list/bin/run_tests.sh
+++ b/tasks/get_current_archive_list/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_job/bin/build.sh
+++ b/tasks/internal_reconcile_report_job/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_job/bin/build_api.sh
+++ b/tasks/internal_reconcile_report_job/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_job/bin/run_tests.sh
+++ b/tasks/internal_reconcile_report_job/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_mismatch/bin/build.sh
+++ b/tasks/internal_reconcile_report_mismatch/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_mismatch/bin/build_api.sh
+++ b/tasks/internal_reconcile_report_mismatch/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_mismatch/bin/run_tests.sh
+++ b/tasks/internal_reconcile_report_mismatch/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_orphan/bin/build.sh
+++ b/tasks/internal_reconcile_report_orphan/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_orphan/bin/build_api.sh
+++ b/tasks/internal_reconcile_report_orphan/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_orphan/bin/run_tests.sh
+++ b/tasks/internal_reconcile_report_orphan/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_phantom/bin/build.sh
+++ b/tasks/internal_reconcile_report_phantom/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_phantom/bin/build_api.sh
+++ b/tasks/internal_reconcile_report_phantom/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/internal_reconcile_report_phantom/bin/run_tests.sh
+++ b/tasks/internal_reconcile_report_phantom/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/orca_catalog_reporting/bin/build.sh
+++ b/tasks/orca_catalog_reporting/bin/build.sh
@@ -41,7 +41,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/orca_catalog_reporting/bin/build_api.sh
+++ b/tasks/orca_catalog_reporting/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/orca_catalog_reporting/bin/run_tests.sh
+++ b/tasks/orca_catalog_reporting/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/perform_orca_reconcile/bin/build.sh
+++ b/tasks/perform_orca_reconcile/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/perform_orca_reconcile/bin/build_api.sh
+++ b/tasks/perform_orca_reconcile/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/perform_orca_reconcile/bin/run_tests.sh
+++ b/tasks/perform_orca_reconcile/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_copy_request_to_queue/bin/build.sh
+++ b/tasks/post_copy_request_to_queue/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_copy_request_to_queue/bin/build_api.sh
+++ b/tasks/post_copy_request_to_queue/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_copy_request_to_queue/bin/run_tests.sh
+++ b/tasks/post_copy_request_to_queue/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_catalog/bin/build.sh
+++ b/tasks/post_to_catalog/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_catalog/bin/build_api.sh
+++ b/tasks/post_to_catalog/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_catalog/bin/run_tests.sh
+++ b/tasks/post_to_catalog/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_database/bin/build.sh
+++ b/tasks/post_to_database/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_database/bin/build_api.sh
+++ b/tasks/post_to_database/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_database/bin/run_tests.sh
+++ b/tasks/post_to_database/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_queue_and_trigger_step_function/bin/build.sh
+++ b/tasks/post_to_queue_and_trigger_step_function/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_queue_and_trigger_step_function/bin/build_api.sh
+++ b/tasks/post_to_queue_and_trigger_step_function/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/post_to_queue_and_trigger_step_function/bin/run_tests.sh
+++ b/tasks/post_to_queue_and_trigger_step_function/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_from_archive/bin/build.sh
+++ b/tasks/request_from_archive/bin/build.sh
@@ -42,7 +42,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_from_archive/bin/build_api.sh
+++ b/tasks/request_from_archive/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_from_archive/bin/run_tests.sh
+++ b/tasks/request_from_archive/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 run_and_check_returncode "pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org"

--- a/tasks/request_status_for_granule/bin/build.sh
+++ b/tasks/request_status_for_granule/bin/build.sh
@@ -43,7 +43,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_status_for_granule/bin/build_api.sh
+++ b/tasks/request_status_for_granule/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_status_for_granule/bin/run_tests.sh
+++ b/tasks/request_status_for_granule/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_status_for_job/bin/build.sh
+++ b/tasks/request_status_for_job/bin/build.sh
@@ -43,7 +43,7 @@ trap 'rm -rf build' EXIT
 
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv;rm -rf build;' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -t build -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_status_for_job/bin/build_api.sh
+++ b/tasks/request_status_for_job/bin/build_api.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q "pydoc-markdown>=4.0.0,<5.0.0" --trusted-host pypi.org --trusted-host files.pythonhosted.org

--- a/tasks/request_status_for_job/bin/run_tests.sh
+++ b/tasks/request_status_for_job/bin/run_tests.sh
@@ -34,7 +34,7 @@ source ../../bin/common/venv_management.sh
 ## -----------------------------------------------------------------------------
 run_and_check_returncode "create_and_activate_venv"
 trap 'deactivate_and_delete_venv' EXIT
-run_and_check_returncode "pip install -q --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+run_and_check_returncode "pip install -q --upgrade pip==24.2 --trusted-host pypi.org --trusted-host files.pythonhosted.org"
 
 ## Install the requirements
 pip install -q -r requirements-dev.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org


### PR DESCRIPTION
## Summary of Changes

The current pip install -q --upgrade pip gets the latest version, which can cause errors if the latest version changes functionality. Updated build scripts to specify version pip 24.2 (current version of pip) to prevent possible errors in the future.

Addresses [ORCA-567: Look into locking down pip version.](https://bugs.earthdata.nasa.gov/browse/ORCA-567

## Changes

* Specified build scripts to use specific version of pip to resolve any future errors/issues that could be caused by using the latest version of pip.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Build scripts ran successfully without errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets