### PR TITLE
ORCA-937: Fix pre-signed URL error in get_current_archive_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and includes an additional section for migration notes.
 
 - *ORCA-927* - Updated archive architecture to include metadata deadletter queue in `website/static/img/ORCA-Architecture-Archive-Container-Component-Updated.svg`
 
+- *ORCA-937* - Updated get_current_archive_list Lambda to use the gql_tasks_role to resolve database errors when trying to S3 import in `modules/lambdas/main.tf`. Updated gql_tasks_role with needed permissions in `modules/graphql_0/main.tf`, as well as updated Secrets Manager permissions to allow the role to get DB secret in `modules/secretsmanager/main.tf`.
+
 ### Deprecated
 
 ### Removed

--- a/modules/graphql_0/main.tf
+++ b/modules/graphql_0/main.tf
@@ -2,6 +2,16 @@ data "aws_vpc" "primary" {
   id = var.vpc_id
 }
 
+data "aws_region" "current_region" {}
+
+locals {
+  all_bucket_names  = length(var.orca_recovery_buckets) > 0 ? var.orca_recovery_buckets : [for k, v in var.buckets : v.name]
+  all_bucket_arns   = [for name in local.all_bucket_names : "arn:aws:s3:::${name}"]
+  all_bucket_paths  = [for name in local.all_bucket_names : "arn:aws:s3:::${name}/*"]
+  orca_bucket_arns  = [for k, v in var.buckets : "arn:aws:s3:::${v.name}" if v.type == "orca"]
+  orca_bucket_paths = [for k, v in var.buckets : "arn:aws:s3:::${v.name}/*" if v.type == "orca"]
+}
+
 data "aws_caller_identity" "current" {}
 
 # IAM role that tasks can use to make API requests to authorized AWS services. If you make a boto3 call, this is what carries it out.
@@ -12,6 +22,20 @@ data "aws_iam_policy_document" "assume_gql_tasks_role_policy_document" {
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
     actions = ["sts:AssumeRole"]
+  }
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["states.${data.aws_region.current_region.name}.amazonaws.com"]
+    }
   }
   statement {
     principals {
@@ -40,6 +64,116 @@ data "aws_iam_policy_document" "gql_tasks_role_policy_document" {
   statement {
     actions   = ["sts:AssumeRole"]
     resources = [aws_iam_role.gql_tasks_role.arn]
+  }
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "states:SendTaskFailure",
+      "states:SendTaskSuccess",
+      "states:GetActivityTask",
+      "states:GetExecutionHistory",
+      "states:DescribeActivity",
+      "states:DescribeExecution",
+      "states:ListStateMachines"
+    ]
+    resources = ["arn:aws:states:*:*:*"]
+  }
+  statement {
+    actions = [
+      "sns:publish",
+      "sns:List*"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "s3:GetBucket",
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:PutBucket"
+    ]
+    resources = local.all_bucket_arns
+  }
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+      "s3:ListMultipartUploadParts",
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion"
+    ]
+    resources = local.all_bucket_paths
+  }
+  statement {
+    actions = [
+      "s3:RestoreObject",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+      "s3:GetObjectVersion"
+    ]
+    resources = concat(local.orca_bucket_arns, local.orca_bucket_paths)
+  }
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey" #requested by Cumulus
+    ]
+    resources = [
+      "arn:aws:kms:::key/CMK"
+    ]
+  }
+  statement {
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "states:StartExecution",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "s3:GetObject",  # Get the manifest
+      "s3:PutObject"  # Copy the gzip to add missing metadata
+    ]
+    resources = ["arn:aws:s3:::${var.orca_reports_bucket_name}/*"]
   }
 }
 

--- a/modules/graphql_0/variables.tf
+++ b/modules/graphql_0/variables.tf
@@ -32,3 +32,22 @@ variable "deploy_rds_cluster_role_association" {
   type        = bool
   description = "Deploys IAM role for Aurora v2 cluster if true."
 }
+
+variable "buckets" {
+  type        = map(object({ name = string, type = string }))
+  description = "S3 bucket locations for the various storage types being used."
+}
+
+## Variables unique to ORCA
+## REQUIRED
+variable "orca_reports_bucket_name" {
+  type        = string
+  description = "The name of the bucket to store s3 inventory reports."
+}
+
+
+## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
+variable "orca_recovery_buckets" {
+  type        = list(string)
+  description = "List of bucket names that ORCA has permissions to restore data to."
+}

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -127,7 +127,7 @@ resource "aws_lambda_permission" "delete_old_reconcile_jobs_allow_cloudwatch_eve
 resource "aws_lambda_function" "get_current_archive_list" {
   ## REQUIRED
   function_name = "${var.prefix}_get_current_archive_list"
-  role          = var.restore_object_role_arn
+  role          = var.gql_tasks_role_arn
 
   ## OPTIONAL
   description      = "Receives a list of s3 events from an SQS queue, and loads the s3 inventory specified into postgres."

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -10,6 +10,10 @@ variable "lambda_subnet_ids" {
   description = "List of subnets the lambda functions have access to."
 }
 
+variable "gql_tasks_role_arn" {
+  type        = string
+  description = "The ARN of the role used by the code within the Graphql ECS Task."
+}
 
 variable "prefix" {
   type        = string

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -56,6 +56,7 @@ module "orca_lambdas" {
   orca_recovery_retry_interval                  = var.orca_recovery_retry_interval
   orca_recovery_retry_backoff                   = var.orca_recovery_retry_backoff
   log_level                                     = var.log_level
+  gql_tasks_role_arn               = module.orca_graphql_0.gql_tasks_role_arn
 }
 
 ## orca_lambdas_secondary - lambdas module that is dependent on resources that presently are created after most lambdas
@@ -161,6 +162,9 @@ module "orca_graphql_0" {
   ## OPTIONAL
   tags = var.tags
   deploy_rds_cluster_role_association = var.deploy_rds_cluster_role_association
+  orca_recovery_buckets                         = var.orca_recovery_buckets
+  orca_reports_bucket_name                      = var.orca_reports_bucket_name
+  buckets = var.buckets
 }
 
 ## orca_secretsmanager - secretsmanager module
@@ -185,6 +189,7 @@ module "orca_secretsmanager" {
   db_host_endpoint                = var.db_host_endpoint
   gql_ecs_task_execution_role_arn = module.orca_graphql_0.gql_ecs_task_execution_role_arn
   restore_object_role_arn         = module.orca_iam.restore_object_role_arn
+  gql_tasks_role_arn              = module.orca_graphql_0.gql_tasks_role_arn
 
   ## OPTIONAL
   db_admin_username = var.db_admin_username

--- a/modules/secretsmanager/main.tf
+++ b/modules/secretsmanager/main.tf
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "orca_kms_key_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [var.restore_object_role_arn, var.gql_ecs_task_execution_role_arn]
+      identifiers = [var.restore_object_role_arn, var.gql_ecs_task_execution_role_arn, var.gql_tasks_role_arn]
     }
   }
 }

--- a/modules/secretsmanager/variables.tf
+++ b/modules/secretsmanager/variables.tf
@@ -55,3 +55,8 @@ variable "db_admin_username" {
   description = "Username for RDS database administrator authentication"
   type        = string
 }
+
+variable "gql_tasks_role_arn" {
+  type = string
+  description = "The ARN of the role used by GraphQL and get_current_archive_list"  
+}


### PR DESCRIPTION
## Summary of Changes

Updated get_current_archive_list Lambda to use the gql_tasks_role to resolve database errors when trying to S3 import in `modules/lambdas/main.tf`. Updated gql_tasks_role with needed permissions in `modules/graphql_0/main.tf`, as well as updated Secrets Manager permissions to allow the role to get DB secret in `modules/secretsmanager/main.tf`.

Addresses [ORCA-937: Fix pre-signed URL error in get_current_archive_list](https://bugs.earthdata.nasa.gov/browse/ORCA-937)

## Changes

* Updated get_current_archive_list Lambda to use the gql_tasks_role to resolve database errors when trying to S3 import in `modules/lambdas/main.tf`
* Updated gql_tasks_role with needed permissions in `modules/graphql_0/main.tf`
*  Updated Secrets Manager permissions to allow the role to get DB secret in `modules/secretsmanager/main.tf`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Deployed successfully and Step Function Workflows succeed without errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
