### PR TITLE
ORCA-948: Resolve errors with hashicorp/aws version 5.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and includes an additional section for migration notes.
 
 ### Changed
 
+- *ORCA-948* - Changed `versions.tf` file to add `<=5.81.0` to prevent a latest version having a breaking change.
+
 ### Removed
 
 ### Fixed

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.0.0, <=5.81.0"
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes

Changed `versions.tf` file to add `<=5.81.0` to prevent a latest version having a breaking change.

Addresses [ORCA-948: Resolve errors with hashicorp/aws version 5.82.0](https://bugs.earthdata.nasa.gov/browse/ORCA-948)

## Changes

* Changed `versions.tf` file to add `<=5.81.0`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`terraform init` installs hashicorp/aws version 5.81.0 instead of the latest (5.82.0)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
