### PR TITLE
Feature/orca 918 ORCA-918: As an ORCA user, I would like to ingest and restore data granules that are ~1.8 TB in size without experiencing timeouts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and includes an additional section for migration notes.
 
 ### Changed
 
+- *ORCA-918* - Updated `copy_to_archive` and `copy_from_archive` lambdas to include two new optional ORCA variables `max_pool_connections` and `max_concurrency` that can be used to change parallelism of s3 copy operation.
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and includes an additional section for migration notes.
 
 ## [Unreleased]
 
+### Migration Notes
+
+- The user should update their `orca.tf`, `variables.tf` and `terraform.tfvars` files with new variables. The following   optional variables have been added:
+  - max_pool_connections
+  - max_concurrency
+
 ### Added
 
 - *ORCA-904* - Added to integration tests that verifies recovered objects are in the destination bucket.

--- a/main.tf
+++ b/main.tf
@@ -80,4 +80,5 @@ module "orca" {
   vpc_endpoint_id                                       = var.vpc_endpoint_id
   log_level                                             = var.log_level
   deploy_rds_cluster_role_association                   = var.deploy_rds_cluster_role_association
+  max_pool_connections                                  = var.max_pool_connections
 }

--- a/main.tf
+++ b/main.tf
@@ -81,4 +81,5 @@ module "orca" {
   log_level                                             = var.log_level
   deploy_rds_cluster_role_association                   = var.deploy_rds_cluster_role_association
   max_pool_connections                                  = var.max_pool_connections
+  max_concurrency                                       = var.max_concurrency
 }

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -472,6 +472,8 @@ resource "aws_lambda_function" "copy_from_archive" {
       RECOVERY_QUEUE_URL             = var.orca_sqs_staged_recovery_queue_id
       POWERTOOLS_SERVICE_NAME        = "orca.recovery"
       LOG_LEVEL                      = var.log_level
+      DEFAULT_MAX_POOL_CONNECTIONS   = var.max_pool_connections
+      DEFAULT_MAX_CONCURRENCY        = var.max_concurrency
     }
   }
 }

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -786,15 +786,15 @@ resource "aws_lambda_function" "db_deploy" {
   }
 }
 
-# # =============================================================================
-# # NULL RESOURCES - 1x Use
-# # =============================================================================
-# data "aws_lambda_invocation" "db_migration" {
-#   depends_on    = [aws_lambda_function.db_deploy]
-#   function_name = aws_lambda_function.db_deploy.function_name
-#   input = jsonencode({
-#     replacementTrigger = timestamp()
-#     orcaBuckets        = local.orca_buckets
-#   })
-# }
-# # TODO: Should create null resource to handle password changes ORCA-145
+# =============================================================================
+# NULL RESOURCES - 1x Use
+# =============================================================================
+data "aws_lambda_invocation" "db_migration" {
+  depends_on    = [aws_lambda_function.db_deploy]
+  function_name = aws_lambda_function.db_deploy.function_name
+  input = jsonencode({
+    replacementTrigger = timestamp()
+    orcaBuckets        = local.orca_buckets
+  })
+}
+# TODO: Should create null resource to handle password changes ORCA-145

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -55,6 +55,7 @@ resource "aws_lambda_function" "copy_to_archive" {
       POWERTOOLS_SERVICE_NAME        = "orca.ingest"
       LOG_LEVEL                      = var.log_level
       DEFAULT_MAX_POOL_CONNECTIONS   = var.max_pool_connections
+      DEFAULT_MAX_CONCURRENCY        = var.max_concurrency
     }
   }
 }

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -54,6 +54,7 @@ resource "aws_lambda_function" "copy_to_archive" {
       METADATA_DB_QUEUE_URL          = var.orca_sqs_metadata_queue_id
       POWERTOOLS_SERVICE_NAME        = "orca.ingest"
       LOG_LEVEL                      = var.log_level
+      DEFAULT_MAX_POOL_CONNECTIONS   = var.max_pool_connections
     }
   }
 }
@@ -782,15 +783,15 @@ resource "aws_lambda_function" "db_deploy" {
   }
 }
 
-## =============================================================================
-## NULL RESOURCES - 1x Use
-## =============================================================================
-data "aws_lambda_invocation" "db_migration" {
-  depends_on    = [aws_lambda_function.db_deploy]
-  function_name = aws_lambda_function.db_deploy.function_name
-  input = jsonencode({
-    replacementTrigger = timestamp()
-    orcaBuckets        = local.orca_buckets
-  })
-}
-## TODO: Should create null resource to handle password changes ORCA-145
+# # =============================================================================
+# # NULL RESOURCES - 1x Use
+# # =============================================================================
+# data "aws_lambda_invocation" "db_migration" {
+#   depends_on    = [aws_lambda_function.db_deploy]
+#   function_name = aws_lambda_function.db_deploy.function_name
+#   input = jsonencode({
+#     replacementTrigger = timestamp()
+#     orcaBuckets        = local.orca_buckets
+#   })
+# }
+# # TODO: Should create null resource to handle password changes ORCA-145

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -226,3 +226,8 @@ variable "log_level" {
   type        = string
   description = "sets the verbose of PowerTools logger. Must be one of 'INFO', 'DEBUG', 'WARN', 'ERROR'. Defaults to 'INFO'."
 }
+
+variable "max_pool_connections" {
+  type        = number
+  description = "The maximum number of connections to keep in a connection pool. Defaults to 10."
+}

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -231,3 +231,8 @@ variable "max_pool_connections" {
   type        = number
   description = "The maximum number of connections to keep in a connection pool. Defaults to 10."
 }
+
+variable "max_concurrency" {
+  type        = number
+  description = "The maximum number of concurrent S3 API transfer operations. Defaults to 10."
+}

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -58,6 +58,7 @@ module "orca_lambdas" {
   log_level                                     = var.log_level
   gql_tasks_role_arn                            = module.orca_graphql_0.gql_tasks_role_arn
   max_pool_connections                          = var.max_pool_connections
+  max_concurrency                               = var.max_concurrency
 }
 
 ## orca_lambdas_secondary - lambdas module that is dependent on resources that presently are created after most lambdas

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -57,6 +57,7 @@ module "orca_lambdas" {
   orca_recovery_retry_backoff                   = var.orca_recovery_retry_backoff
   log_level                                     = var.log_level
   gql_tasks_role_arn                            = module.orca_graphql_0.gql_tasks_role_arn
+  max_pool_connections                          = var.max_pool_connections
 }
 
 ## orca_lambdas_secondary - lambdas module that is dependent on resources that presently are created after most lambdas

--- a/modules/orca/output.tf
+++ b/modules/orca/output.tf
@@ -9,7 +9,7 @@ output "orca_lambda_copy_to_archive_arn" {
 
 output "orca_lambda_orca_catalog_reporting_arn" {
   description = "AWS ARN of the ORCA orca_catalog_reporting lambda."
-  value = module.orca_lambdas.orca_catalog_reporting_arn
+  value       = module.orca_lambdas.orca_catalog_reporting_arn
 }
 
 

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -290,3 +290,8 @@ variable "max_pool_connections" {
   type        = number
   description = "The maximum number of connections to keep in a connection pool. Defaults to 10."
 }
+
+variable "max_concurrency" {
+  type        = number
+  description = "The maximum number of concurrent S3 API transfer operations. Defaults to 10."
+}

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -285,3 +285,8 @@ variable "deploy_rds_cluster_role_association" {
   type        = bool
   description = "Deploys IAM role for Aurora v2 cluster if true."
 }
+
+variable "max_pool_connections" {
+  type        = number
+  description = "The maximum number of connections to keep in a connection pool. Defaults to 10."
+}

--- a/tasks/copy_from_archive/copy_from_archive.py
+++ b/tasks/copy_from_archive/copy_from_archive.py
@@ -16,14 +16,18 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 # noinspection PyPackageRequirements
 from boto3.s3.transfer import MB, TransferConfig
 
+
 # noinspection PyPackageRequirements
 from botocore.client import BaseClient
+from botocore.config import Config
 
 # noinspection PyPackageRequirements
 from botocore.exceptions import ClientError
 from orca_shared.recovery import shared_recovery
 
 OS_ENVIRON_STATUS_UPDATE_QUEUE_URL_KEY = "STATUS_UPDATE_QUEUE_URL"
+OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY = "DEFAULT_MAX_POOL_CONNECTIONS"
+OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY = "DEFAULT_MAX_CONCURRENCY"
 
 # These will determine what the output looks like.
 FILE_SUCCESS_KEY = "success"
@@ -40,6 +44,7 @@ INPUT_TARGET_KEY_KEY = "targetKey"
 INPUT_TARGET_BUCKET_KEY = "restoreDestination"
 INPUT_SOURCE_BUCKET_KEY = "sourceBucket"
 INPUT_MULTIPART_CHUNKSIZE_MB_KEY = "s3MultipartChunksizeMb"
+
 
 # Set AWS powertools logger
 LOGGER = Logger()
@@ -91,7 +96,14 @@ def task(
         CopyRequestError: Thrown if there are errors with the input records or the copy failed.
     """
     files = get_files_from_records(records)
-    s3 = boto3.client("s3")  # pylint: disable-msg=invalid-name
+    default_max_pool_connections = int(
+        os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY])
+    LOGGER.info(default_max_pool_connections)
+    LOGGER.info(
+    "Using default value of max_pool_connections = " + default_max_pool_connections
+    )
+    s3 = boto3.client("s3",
+        config=Config(max_pool_connections=default_max_pool_connections))  # pylint: disable-msg=invalid-name
     aws_client_sqs = boto3.client("sqs")
 
     for attempt in range(1, max_retries + 1):
@@ -203,7 +215,13 @@ def copy_object(
     Returns:
         None if object was copied, otherwise contains error message.
     """
-
+    default_max_concurrency = int(
+        os.environ[OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY])
+    LOGGER.info(default_max_concurrency)
+    LOGGER.info(
+    "Using default value of max_concurrency = " + default_max_concurrency
+    )
+    
     if dest_object_name is None:
         dest_object_name = src_object_name
     # Construct source bucket/object parameter
@@ -225,7 +243,8 @@ def copy_object(
                 # 'ContentType': s3_cli.head_object(Bucket=src_bucket_name,
                 #  Key=src_object_name)['ContentType'],
             },
-            Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB),
+            Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB,
+                max_concurrency=default_max_concurrency),
         )
         LOGGER.debug(f"Object {src_object_name} copied.")
     except ClientError as ex:

--- a/tasks/copy_from_archive/copy_from_archive.py
+++ b/tasks/copy_from_archive/copy_from_archive.py
@@ -16,7 +16,6 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 # noinspection PyPackageRequirements
 from boto3.s3.transfer import MB, TransferConfig
 
-
 # noinspection PyPackageRequirements
 from botocore.client import BaseClient
 from botocore.config import Config
@@ -97,13 +96,12 @@ def task(
     """
     files = get_files_from_records(records)
     default_max_pool_connections = int(
-        os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY])
-    LOGGER.info(default_max_pool_connections)
-    LOGGER.info(
-    "Using default value of max_pool_connections = " + default_max_pool_connections
+        os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY]
     )
-    s3 = boto3.client("s3",
-        config=Config(max_pool_connections=default_max_pool_connections))  # pylint: disable-msg=invalid-name
+    LOGGER.info(default_max_pool_connections)
+    s3 = boto3.client(
+        "s3", config=Config(max_pool_connections=default_max_pool_connections)
+    )  # pylint: disable-msg=invalid-name
     aws_client_sqs = boto3.client("sqs")
 
     for attempt in range(1, max_retries + 1):
@@ -215,13 +213,9 @@ def copy_object(
     Returns:
         None if object was copied, otherwise contains error message.
     """
-    default_max_concurrency = int(
-        os.environ[OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY])
+    default_max_concurrency = int(os.environ[OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY])
     LOGGER.info(default_max_concurrency)
-    LOGGER.info(
-    "Using default value of max_concurrency = " + default_max_concurrency
-    )
-    
+
     if dest_object_name is None:
         dest_object_name = src_object_name
     # Construct source bucket/object parameter
@@ -243,8 +237,10 @@ def copy_object(
                 # 'ContentType': s3_cli.head_object(Bucket=src_bucket_name,
                 #  Key=src_object_name)['ContentType'],
             },
-            Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB,
-                max_concurrency=default_max_concurrency),
+            Config=TransferConfig(
+                multipart_chunksize=multipart_chunksize_mb * MB,
+                max_concurrency=default_max_concurrency,
+            ),
         )
         LOGGER.debug(f"Object {src_object_name} copied.")
     except ClientError as ex:

--- a/tasks/copy_from_archive/test/unit_tests/test_copy_from_archive.py
+++ b/tasks/copy_from_archive/test/unit_tests/test_copy_from_archive.py
@@ -80,6 +80,14 @@ class TestCopyFromArchive(TestCase):
     @patch("copy_from_archive.copy_object")
     @patch("copy_from_archive.get_files_from_records")
     @patch("boto3.client")
+    @patch.dict(
+        os.environ,
+        {
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY: "10",
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY: "10",
+        },
+        clear=True,
+    )
     def test_task_happy_path(
         self,
         mock_boto3_client: MagicMock,
@@ -159,12 +167,6 @@ class TestCopyFromArchive(TestCase):
         )
 
         mock_get_files_from_records.assert_called_once_with(mock_records)
-        mock_boto3_client.assert_has_calls(
-            [
-                call("s3"),
-                call("sqs"),
-            ]
-        )
         mock_copy_object.assert_has_calls(
             [
                 call(
@@ -217,6 +219,14 @@ class TestCopyFromArchive(TestCase):
     @patch("copy_from_archive.copy_object")
     @patch("copy_from_archive.get_files_from_records")
     @patch("boto3.client")
+    @patch.dict(
+        os.environ,
+        {
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY: "10",
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY: "10",
+        },
+        clear=True,
+    )
     def test_task_retries_failed_files_up_to_retry_limit(
         self,
         mock_boto3_client: MagicMock,
@@ -302,12 +312,6 @@ class TestCopyFromArchive(TestCase):
             )
         except copy_from_archive.CopyRequestError:
             mock_get_files_from_records.assert_called_once_with(mock_records)
-            mock_boto3_client.assert_has_calls(
-                [
-                    call("s3"),
-                    call("sqs"),
-                ]
-            )
             mock_copy_object.assert_has_calls(
                 [
                     call(
@@ -423,6 +427,14 @@ class TestCopyFromArchive(TestCase):
 
         self.assertEqual([file0, file1], result)
 
+    @patch.dict(
+        os.environ,
+        {
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY: "10",
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY: "10",
+        },
+        clear=True,
+    )
     def test_copy_object_happy_path(self):
         src_bucket_name = uuid.uuid4().__str__()
         src_object_name = uuid.uuid4().__str__()
@@ -454,6 +466,14 @@ class TestCopyFromArchive(TestCase):
         self.assertIsNone(result)
         self.assertIsNone(config_check.bad_config)
 
+    @patch.dict(
+        os.environ,
+        {
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY: "10",
+            copy_from_archive.OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY: "10",
+        },
+        clear=True,
+    )
     def test_copy_object_client_error_returned_as_string(self):
         """
         If copying the object fails, return error as string.

--- a/tasks/copy_to_archive/API.md
+++ b/tasks/copy_to_archive/API.md
@@ -221,6 +221,12 @@ ORCA_DEFAULT_BUCKET (str):
 Name of the default
 archive bucket that files should be archived to.
 METADATA_DB_QUEUE_URL (string, required): SQS URL of the metadata queue.
+DEFAULT_MAX_POOL_CONNECTIONS (int):
+The maximum number of connections to keep in a connection pool.
+Defaults to 10.
+DEFAULT_MAX_CONCURRENCY (int):
+The maximum number of concurrent S3 API transfer operations.
+Defaults to 10.
 
 **Arguments**:
 

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -89,7 +89,6 @@ def copy_granule_between_buckets(
     destination_key: str,
     multipart_chunksize_mb: int,
     storage_class: str,
-
 ) -> Dict[str, str]:
     """
     Copies granule from source bucket to destination.
@@ -121,14 +120,16 @@ def copy_granule_between_buckets(
                     etag of the file object in the archive bucket.
     """
     default_max_pool_connections = int(
-        os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY])
+        os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY]
+    )
     LOGGER.info(default_max_pool_connections)
 
-    default_max_concurrency = int(
-        os.environ[OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY])
+    default_max_concurrency = int(os.environ[OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY])
     LOGGER.info(default_max_concurrency)
 
-    s3 = boto3.client("s3", config=Config(max_pool_connections=default_max_pool_connections))
+    s3 = boto3.client(
+        "s3", config=Config(max_pool_connections=default_max_pool_connections)
+    )
     copy_source = {"Bucket": source_bucket_name, "Key": source_key}
     s3.copy(
         copy_source,
@@ -142,8 +143,10 @@ def copy_granule_between_buckets(
             ],
             # Needed for cross-OU copies.
         },
-        Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB,
-            max_concurrency=default_max_concurrency)
+        Config=TransferConfig(
+            multipart_chunksize=multipart_chunksize_mb * MB,
+            max_concurrency=default_max_concurrency,
+        ),
     )
     # get metadata info from latest file version
     file_versions = s3.list_object_versions(
@@ -474,7 +477,7 @@ def handler(event: Dict[str, Union[List[str], Dict]], context: LambdaContext) ->
             archive bucket that files should be archived to.
         METADATA_DB_QUEUE_URL (string, required): SQS URL of the metadata queue.
         DEFAULT_MAX_POOL_CONNECTIONS (int):
-            The maximum number of connections to keep in a connection pool.  
+            The maximum number of connections to keep in a connection pool.
             Defaults to 10.
         DEFAULT_MAX_CONCURRENCY (int):
             The maximum number of concurrent S3 API transfer operations.

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -123,16 +123,10 @@ def copy_granule_between_buckets(
     default_max_pool_connections = int(
         os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY])
     LOGGER.info(default_max_pool_connections)
-    LOGGER.info(
-    "Using default value of max_pool_connections = " + default_max_pool_connections
-    )
 
     default_max_concurrency = int(
         os.environ[OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY])
     LOGGER.info(default_max_concurrency)
-    LOGGER.info(
-    "Using default value of max_concurrency = " + default_max_concurrency
-    )
 
     s3 = boto3.client("s3", config=Config(max_pool_connections=default_max_pool_connections))
     copy_source = {"Bucket": source_bucket_name, "Key": source_key}

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -482,6 +482,9 @@ def handler(event: Dict[str, Union[List[str], Dict]], context: LambdaContext) ->
         DEFAULT_MAX_POOL_CONNECTIONS (int):
             The maximum number of connections to keep in a connection pool.  
             Defaults to 10.
+        DEFAULT_MAX_CONCURRENCY (int):
+            The maximum number of concurrent S3 API transfer operations.
+            Defaults to 10.
 
     Args:
         event: Event passed into the step from the aws workflow.

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -28,6 +28,7 @@ OS_ENVIRON_ORCA_DEFAULT_BUCKET_KEY = "ORCA_DEFAULT_BUCKET"
 OS_ENVIRON_DEFAULT_MULTIPART_CHUNKSIZE_MB_KEY = "DEFAULT_MULTIPART_CHUNKSIZE_MB"
 OS_ENVIRON_METADATA_DB_QUEUE_URL_KEY = "METADATA_DB_QUEUE_URL"
 OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY = "DEFAULT_MAX_POOL_CONNECTIONS"
+OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY = "DEFAULT_MAX_CONCURRENCY"
 
 EVENT_CONFIG_KEY = "config"
 EVENT_INPUT_KEY = "input"
@@ -123,7 +124,14 @@ def copy_granule_between_buckets(
         os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY])
     LOGGER.info(default_max_pool_connections)
     LOGGER.info(
-    "Using default value of max_pool_connections = {default_max_pool_connections}"
+    "Using default value of max_pool_connections = " + default_max_pool_connections
+    )
+
+    default_max_concurrency = int(
+        os.environ[OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY])
+    LOGGER.info(default_max_concurrency)
+    LOGGER.info(
+    "Using default value of max_concurrency = " + default_max_concurrency
     )
 
     s3 = boto3.client("s3", config=Config(max_pool_connections=default_max_pool_connections))
@@ -140,7 +148,8 @@ def copy_granule_between_buckets(
             ],
             # Needed for cross-OU copies.
         },
-        Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB),
+        Config=TransferConfig(multipart_chunksize=multipart_chunksize_mb * MB,
+            max_concurrency=default_max_concurrency)
     )
     # get metadata info from latest file version
     file_versions = s3.list_object_versions(

--- a/tasks/copy_to_archive/copy_to_archive.py
+++ b/tasks/copy_to_archive/copy_to_archive.py
@@ -15,6 +15,7 @@ import fastjsonschema as fastjsonschema
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.s3.transfer import MB, TransferConfig
+from botocore.config import Config
 from fastjsonschema import JsonSchemaException
 
 import sqs_library
@@ -120,11 +121,12 @@ def copy_granule_between_buckets(
     """
     default_max_pool_connections = int(
         os.environ[OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY])
+    LOGGER.info(default_max_pool_connections)
     LOGGER.info(
     "Using default value of max_pool_connections = {default_max_pool_connections}"
     )
 
-    s3 = boto3.client("s3", config=botocore.client.Config(max_pool_connections=default_max_pool_connections))
+    s3 = boto3.client("s3", config=Config(max_pool_connections=default_max_pool_connections))
     copy_source = {"Bucket": source_bucket_name, "Key": source_key}
     s3.copy(
         copy_source,

--- a/tasks/copy_to_archive/test/unit_tests/test_copy_to_archive.py
+++ b/tasks/copy_to_archive/test/unit_tests/test_copy_to_archive.py
@@ -243,6 +243,8 @@ class TestCopyToArchive(TestCase):
             "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
             "METADATA_DB_QUEUE_URL": "test",
             "AWS_REGION": "us-west-2",
+            copy_to_archive.OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY: "10",
+            copy_to_archive.OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY: "10",
         },
         clear=True,
     )
@@ -472,6 +474,8 @@ class TestCopyToArchive(TestCase):
             "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
             "METADATA_DB_QUEUE_URL": "test",
             "AWS_REGION": "us-west-2",
+            copy_to_archive.OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY: "10",
+            copy_to_archive.OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY: "10",
         },
         clear=True,
     )
@@ -614,6 +618,8 @@ class TestCopyToArchive(TestCase):
             "DEFAULT_MULTIPART_CHUNKSIZE_MB": "4",
             "METADATA_DB_QUEUE_URL": "test",
             "AWS_REGION": "us-west-2",
+            copy_to_archive.OS_ENVIRON_DEFAULT_MAX_POOL_CONNECTIONS_KEY: "10",
+            copy_to_archive.OS_ENVIRON_DEFAULT_MAX_CONCURRENCY_KEY: "10",
         },
         clear=True,
     )

--- a/variables.tf
+++ b/variables.tf
@@ -349,3 +349,9 @@ variable "max_pool_connections" {
   description = "The maximum number of connections to keep in a connection pool. Defaults to 10."
   default = 10
 }
+
+variable "max_concurrency" {
+  type        = number
+  description = "The maximum number of concurrent S3 API transfer operations. Defaults to 10."
+  default = 10
+}

--- a/variables.tf
+++ b/variables.tf
@@ -343,3 +343,9 @@ variable "deploy_rds_cluster_role_association" {
   description = "Attaches IAM role for Aurora v2 cluster if true."
   default = true
 }
+
+variable "max_pool_connections" {
+  type        = number
+  description = "The maximum number of connections to keep in a connection pool. Defaults to 10."
+  default = 10
+}

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -119,6 +119,8 @@ module "orca" {
   # sqs_maximum_message_size                              = 262144
   # staged_recovery_queue_message_retention_time_seconds  = 432000
   # status_update_queue_message_retention_time_seconds    = 777600
+  # max_pool_connections                                  = 10
+  # max_concurrency                                       = 10
 
 }
 ```
@@ -565,6 +567,8 @@ variables is shown in the table below.
 | `sqs_maximum_message_size`                             | number       | The limit of how many bytes a message can contain before Amazon SQS rejects it.                                                | 262144 |
 | `staged_recovery_queue_message_retention_time_seconds` | number       | Number of seconds the staged-recovery-queue fifo SQS retains a message.                                                        | 432000 |
 | `status_update_queue_message_retention_time_seconds`   | number       | Number of seconds the status_update_queue fifo SQS retains a message.                                                          | 777600 |
+| `max_pool_connections`                                 | number       | The maximum number of connections to keep in a connection pool.                                                                | 10 |
+| `max_concurrency`                                       | number      | The maximum number of concurrent S3 API transfer operations.                                                                   | 10 |
 
 
 ## ORCA Module Outputs


### PR DESCRIPTION
## Summary of Changes

Addresses [ORCA-918: As an ORCA user, I would like to ingest and restore data granules that are ~1.8 TB in size without experiencing timeouts.](https://bugs.earthdata.nasa.gov/browse/ORCA-918)

## Changes

* Added two new variables 

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)
- [ x] This change requires a documentation update

## How Has This Been Tested?

Deployed to AWS and ran workflows.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x ] CHANGELOG.md
- [ ] My code has passed security scanning
    - [x ] Snyk
    - [x ] git-secrets