### PR TITLE
LPCUMULUS-1474: As a developer, I need to update our terraform deployment to set cloud watch log retention on our custom lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and includes an additional section for migration notes.
 ## [Unreleased]
 
 ### Migration Notes
-
+The user should update their orca.tf, variables.tf and terraform.tfvars files with new variable. The following optional variable has been added: `lambda_log_retention_in_days`
 **Delete Log Groups**
 ORCA has added the capability to set log retention on ORCA Lambdas e.g. 30 days, 60 days, 90 days, etc.
 - Deployment Steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,22 @@ and includes an additional section for migration notes.
 
 ## [Unreleased]
 
+### Migration Notes
+
+**Delete Log Groups**
+ORCA has added the capability to set log retention on ORCA Lambdas e.g. 30 days, 60 days, 90 days, etc.
+- Deployment Steps
+  1. Run the script located at bin/delete_log_groups.py
+     - These must be deleted before a `terraform apply` is ran due to the current log groups being created by AWS by default which retention cannot be modified via Terraform.
+  2. Set the `lambda_log_retention_in_days` variable to the number of days which you would like the logs to be retained. e.g. `lambda_log_retention_in_days = 30`
+     - To set the logs to never expire the variable does not have to be set since it is set to never expire by default, if you would still like the variable to be set to never expire the value can be set at 0 e.g. `lambda_log_retention_in_days = 0`
+  3. Once these steps are completed a `terraform apply` can be executed.
+
 ### Added
 
 - *ORCA-904* - Added to integration tests that verifies recovered objects are in the destination bucket.
 - *ORCA-907* - Added integration test for internal reconciliation at `integration_test/workflow_tests/test_packages/reconciliation` and updated documentation with new variables.
+- *LPCUMULUS-1474* - Added log groups that can have set retention periods in `modules/lambdas/main.tf` with a variable to set the retention in days. As well as added a script to delete the log groups AWS creates by default since those cannot be modified by Terraform.
 
 ### Changed
 

--- a/bin/delete_log_groups.py
+++ b/bin/delete_log_groups.py
@@ -1,0 +1,31 @@
+import subprocess
+import json
+
+# Gets user input for the prefix of lambdas to delete
+prefix = input("Enter Prefix: ")
+
+# Gets ORCA lambda functions with given prefix
+get_functions = f"aws lambda list-functions --query 'Functions[] | [?contains(FunctionName, `{prefix}`) == `true`]'"
+completed_process = subprocess.run(get_functions, shell=True, capture_output=True)
+output = completed_process.stdout
+convert = json.loads(output.decode("utf-8").replace("'","'"))
+
+for sub in convert:
+    lambda_output = sub['FunctionArn']
+    get_tags = f"aws lambda list-tags --resource {lambda_output}"
+    tags_process = subprocess.run(get_tags, shell=True, capture_output=True)
+    tag_output = tags_process.stdout
+    tag_convert = json.loads(tag_output.decode("utf-8").replace("'","'"))
+    try:
+        # Finds lambdas with the tag application set to ORCA and deletes their log groups to redeploy log groups with specified retention
+        for tag in tag_convert:
+            for attr in tag_convert[tag]:
+                if attr == 'application':
+                    if tag_convert[tag]['application'] == 'ORCA':
+                        print("Deleting " + sub['FunctionName'] + " log group.")
+                        del_log_group = sub['FunctionName']
+                        delete_log_group = f"aws logs delete-log-group --log-group-name /aws/lambda/{del_log_group}"
+                        subprocess.run(delete_log_group, shell=True, capture_output=True)
+    # Throws an error if deletion is interrupted
+    except KeyError as ke:
+        raise ke

--- a/main.tf
+++ b/main.tf
@@ -45,9 +45,9 @@ module "orca" {
   dlq_subscription_email       = var.dlq_subscription_email
   orca_default_bucket          = var.orca_default_bucket
   orca_reports_bucket_name     = var.orca_reports_bucket_name
-  lambda_log_retention_in_days = var.lambda_log_retention_in_days
 
   ## OPTIONAL
+  lambda_log_retention_in_days                          = var.lambda_log_retention_in_days
   archive_recovery_queue_message_retention_time_seconds = var.archive_recovery_queue_message_retention_time_seconds
   db_admin_username                                     = var.db_admin_username
   db_name                                               = local.db_name

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,13 @@ module "orca" {
   ## ORCA Variables
   ## --------------------------
   ## REQUIRED
-  db_admin_password        = var.db_admin_password
-  db_host_endpoint         = var.db_host_endpoint
-  db_user_password         = var.db_user_password
-  dlq_subscription_email   = var.dlq_subscription_email
-  orca_default_bucket      = var.orca_default_bucket
-  orca_reports_bucket_name = var.orca_reports_bucket_name
+  db_admin_password            = var.db_admin_password
+  db_host_endpoint             = var.db_host_endpoint
+  db_user_password             = var.db_user_password
+  dlq_subscription_email       = var.dlq_subscription_email
+  orca_default_bucket          = var.orca_default_bucket
+  orca_reports_bucket_name     = var.orca_reports_bucket_name
+  lambda_log_retention_in_days = var.lambda_log_retention_in_days
 
   ## OPTIONAL
   archive_recovery_queue_message_retention_time_seconds = var.archive_recovery_queue_message_retention_time_seconds

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -24,6 +24,13 @@ module "lambda_security_group" {
 # =============================================================================
 # Ingest Lambdas Definitions and Resources
 # =============================================================================
+# log group for the copy_to_archive function
+resource "aws_cloudwatch_log_group" "copy_to_archive_log_group" {
+  name = "/aws/lambda/${var.prefix}_copy_to_orca"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
 
 # copy_to_archive - Copies files to the archive bucket
 resource "aws_lambda_function" "copy_to_archive" {
@@ -56,6 +63,10 @@ resource "aws_lambda_function" "copy_to_archive" {
       LOG_LEVEL                      = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.copy_to_archive_log_group
+  ]
+
 }
 
 ## =============================================================================
@@ -64,6 +75,14 @@ resource "aws_lambda_function" "copy_to_archive" {
 
 # delete_old_reconcile_jobs - Deletes old internal reconciliation reports, reducing DB size.
 # ==============================================================================
+# log group for the delete_old_reconcile_jobs function
+resource "aws_cloudwatch_log_group" "delete_old_reconcile_jobs_log_group" {
+  name = "/aws/lambda/${var.prefix}_delete_old_reconcile_jobs"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "delete_old_reconcile_jobs" {
   ## REQUIRED
   function_name = "${var.prefix}_delete_old_reconcile_jobs"
@@ -92,6 +111,9 @@ resource "aws_lambda_function" "delete_old_reconcile_jobs" {
       LOG_LEVEL                               = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.delete_old_reconcile_jobs_log_group
+  ]
 }
 
 # rule to run the lambda periodically
@@ -124,6 +146,14 @@ resource "aws_lambda_permission" "delete_old_reconcile_jobs_allow_cloudwatch_eve
 
 # get_current_archive_list - From an s3 event for an s3 inventory report's manifest.json, pulls inventory report into postgres.
 # ==============================================================================
+# log group for the get_current_archive_list function
+resource "aws_cloudwatch_log_group" "get_current_archive_list_log_group" {
+  name = "/aws/lambda/${var.prefix}_get_current_archive_list"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "get_current_archive_list" {
   ## REQUIRED
   function_name = "${var.prefix}_get_current_archive_list"
@@ -152,6 +182,17 @@ resource "aws_lambda_function" "get_current_archive_list" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.get_current_archive_list_log_group
+  ]
+}
+
+# log group for the perform_orca_reconcile function
+resource "aws_cloudwatch_log_group" "perform_orca_reconcile_log_group" {
+  name = "/aws/lambda/${var.prefix}_perform_orca_reconcile"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
 }
 
 resource "aws_lambda_function" "perform_orca_reconcile" {
@@ -182,10 +223,21 @@ resource "aws_lambda_function" "perform_orca_reconcile" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.perform_orca_reconcile_log_group
+  ]
 }
 
 # internal_reconcile_report_job - Receives page index from end user and returns available internal reconciliation jobs from the Orca database.
 # ==============================================================================
+# log group for the internal_reconcile_report_job function
+resource "aws_cloudwatch_log_group" "internal_reconcile_report_job_log_group" {
+  name = "/aws/lambda/${var.prefix}_internal_reconcile_report_job"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "internal_reconcile_report_job" {
   ## REQUIRED
   function_name = "${var.prefix}_internal_reconcile_report_job"
@@ -213,10 +265,21 @@ resource "aws_lambda_function" "internal_reconcile_report_job" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.internal_reconcile_report_job_log_group
+  ]
 }
 
 # internal_reconcile_report_mismatch - Receives job id and page index from end user and returns reporting information of files that have records in the S3 bucket but are missing from ORCA catalog.
 # ==============================================================================
+# log group for the internal_reconcile_report_mismatch function
+resource "aws_cloudwatch_log_group" "internal_reconcile_report_mismatch_log_group" {
+  name = "/aws/lambda/${var.prefix}_internal_reconcile_report_mismatch"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "internal_reconcile_report_mismatch" {
   ## REQUIRED
   function_name = "${var.prefix}_internal_reconcile_report_mismatch"
@@ -244,10 +307,21 @@ resource "aws_lambda_function" "internal_reconcile_report_mismatch" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.internal_reconcile_report_mismatch_log_group
+  ]
 }
 
 # internal_reconcile_report_orphan - Receives job id and page index from end user and returns reporting information of files that have records in the S3 bucket but are missing from ORCA catalog.
 # ==============================================================================
+# log group for the internal_reconcile_report_orphan function
+resource "aws_cloudwatch_log_group" "internal_reconcile_report_orphan_log_group" {
+  name = "/aws/lambda/${var.prefix}_internal_reconcile_report_orphan"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "internal_reconcile_report_orphan" {
   ## REQUIRED
   function_name = "${var.prefix}_internal_reconcile_report_orphan"
@@ -275,10 +349,21 @@ resource "aws_lambda_function" "internal_reconcile_report_orphan" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.internal_reconcile_report_orphan_log_group
+  ]
 }
 
 # internal_reconcile_report_phantom - Receives job id and page index from end user and returns reporting information of files that have records in the ORCA catalog but are missing from S3 bucket.
 # ==============================================================================
+# log group for the internal_reconcile_report_phantom function
+resource "aws_cloudwatch_log_group" "internal_reconcile_report_phantom_log_group" {
+  name = "/aws/lambda/${var.prefix}_internal_reconcile_report_phantom"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "internal_reconcile_report_phantom" {
   ## REQUIRED
   function_name = "${var.prefix}_internal_reconcile_report_phantom"
@@ -306,6 +391,9 @@ resource "aws_lambda_function" "internal_reconcile_report_phantom" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.internal_reconcile_report_phantom_log_group
+  ]
 }
 
 ## =============================================================================
@@ -314,6 +402,14 @@ resource "aws_lambda_function" "internal_reconcile_report_phantom" {
 
 # extract_filepaths_for_granule - Translates input for request_from_archive lambda
 # ==============================================================================
+# log group for the extract_filepaths_for_granule function
+resource "aws_cloudwatch_log_group" "extract_filepaths_for_granule_log_group" {
+  name = "/aws/lambda/${var.prefix}_extract_filepaths_for_granule"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "extract_filepaths_for_granule" {
   ## REQUIRED
   function_name = "${var.prefix}_extract_filepaths_for_granule"
@@ -339,6 +435,9 @@ resource "aws_lambda_function" "extract_filepaths_for_granule" {
       LOG_LEVEL               = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.extract_filepaths_for_granule_log_group
+  ]
 }
 
 data "aws_iam_policy_document" "assume_lambda_role_extract" {
@@ -403,6 +502,14 @@ resource "aws_iam_role_policy" "extract_filepaths_for_granule_policy" {
 
 # request_from_archive - Requests files from archive
 # ==============================================================================
+# log group for the request_from_archive function
+resource "aws_cloudwatch_log_group" "request_from_archive_log_group" {
+  name = "/aws/lambda/${var.prefix}_request_from_archive"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "request_from_archive" {
   ## REQUIRED
   function_name = "${var.prefix}_request_from_archive"
@@ -436,11 +543,22 @@ resource "aws_lambda_function" "request_from_archive" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.request_from_archive_log_group
+  ]
 }
 
 
 # copy_from_archive - Copies files from archive to destination bucket
 # ==============================================================================
+# log group for the copy_from_archive function
+resource "aws_cloudwatch_log_group" "copy_from_archive_log_group" {
+  name = "/aws/lambda/${var.prefix}_copy_from_archive"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "copy_from_archive" {
   ## REQUIRED
   function_name = "${var.prefix}_copy_from_archive"
@@ -472,6 +590,9 @@ resource "aws_lambda_function" "copy_from_archive" {
       LOG_LEVEL                      = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.copy_from_archive_log_group
+  ]
 }
 
 # Additional resources needed by copy_from_archive
@@ -495,6 +616,14 @@ resource "aws_lambda_permission" "copy_from_archive_allow_sqs_trigger" {
 
 # post_to_database - Posts entries from SQS queue to database.
 # ==============================================================================
+# log group for the post_to_database function
+resource "aws_cloudwatch_log_group" "post_to_database_log_group" {
+  name = "/aws/lambda/${var.prefix}_post_to_database"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "post_to_database" {
   ## REQUIRED
   function_name = "${var.prefix}_post_to_database"
@@ -522,6 +651,9 @@ resource "aws_lambda_function" "post_to_database" {
       LOG_LEVEL                  = var.log_level
     }
   }
+   depends_on = [
+    aws_cloudwatch_log_group.post_to_database_log_group
+  ]
 }
 
 # Additional resources needed by post_to_database
@@ -545,6 +677,14 @@ resource "aws_lambda_permission" "post_to_database_allow_sqs_trigger" {
 
 # request_status_for_granule - Provides recovery status information on a specific granule
 # ==============================================================================
+# log group for the request_status_for_granule function
+resource "aws_cloudwatch_log_group" "request_status_for_granule_log_group" {
+  name = "/aws/lambda/${var.prefix}_request_status_for_granule"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "request_status_for_granule" {
   ## REQUIRED
   function_name = "${var.prefix}_request_status_for_granule"
@@ -572,11 +712,22 @@ resource "aws_lambda_function" "request_status_for_granule" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.request_status_for_granule_log_group
+  ]
 }
 
 
 # request_status_for_job - Provides recovery status information for a job.
 # ==============================================================================
+# log group for the request_status_for_job function
+resource "aws_cloudwatch_log_group" "request_status_for_job_log_group" {
+  name = "/aws/lambda/${var.prefix}_request_status_for_job"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "request_status_for_job" {
   ## REQUIRED
   function_name = "${var.prefix}_request_status_for_job"
@@ -604,10 +755,21 @@ resource "aws_lambda_function" "request_status_for_job" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.request_status_for_job_log_group
+  ]
 }
 
 # post_copy_request_to_queue - Posts to two queues for notifying copy_from_archive lambda and updating the DB."
 # ==============================================================================
+# log group for the post_copy_request_to_queue function
+resource "aws_cloudwatch_log_group" "post_copy_request_to_queue_log_group" {
+  name = "/aws/lambda/${var.prefix}_post_copy_request_to_queue"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "post_copy_request_to_queue" {
   ## REQUIRED
   function_name = "${var.prefix}_post_copy_request_to_queue"
@@ -637,6 +799,9 @@ resource "aws_lambda_function" "post_copy_request_to_queue" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.post_copy_request_to_queue_log_group
+  ]
 }
 
 # Additional resources needed by post_copy_request_to_queue
@@ -661,6 +826,14 @@ resource "aws_lambda_permission" "post_copy_request_to_queue_allow_sqs_trigger" 
 
 # orca_catalog_reporting - Returns reconcilliation report data
 # ==============================================================================
+# log group for the orca_catalog_reporting function
+resource "aws_cloudwatch_log_group" "orca_catalog_reporting_log_group" {
+  name = "/aws/lambda/${var.prefix}_orca_catalog_reporting"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "orca_catalog_reporting" {
   ## REQUIRED
   function_name = "${var.prefix}_orca_catalog_reporting"
@@ -688,11 +861,22 @@ resource "aws_lambda_function" "orca_catalog_reporting" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.orca_catalog_reporting_log_group
+  ]
 }
 
 
 # post_to_catalog - Posts provider/collection/granule/file info from SQS queue to database.
 # ===========================================================================================
+# log group for the post_to_catalog function
+resource "aws_cloudwatch_log_group" "post_to_catalog_log_group" {
+  name = "/aws/lambda/${var.prefix}_post_to_catalog"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "post_to_catalog" {
   ## REQUIRED
   function_name = "${var.prefix}_post_to_catalog"
@@ -720,6 +904,9 @@ resource "aws_lambda_function" "post_to_catalog" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.post_to_catalog_log_group
+  ]
 }
 
 # Additional resources needed by post_to_catalog
@@ -748,6 +935,14 @@ resource "aws_lambda_permission" "post_to_catalog_allow_sqs_trigger" {
 
 # db_deploy - Lambda that deploys database resources
 # ==============================================================================
+# log group for the db_deploy function
+resource "aws_cloudwatch_log_group" "db_deploy_log_group" {
+  name = "/aws/lambda/${var.prefix}_db_deploy"
+  retention_in_days = var.lambda_log_retention_in_days
+
+  tags = var.tags
+}
+
 resource "aws_lambda_function" "db_deploy" {
   depends_on = [
     module.lambda_security_group,
@@ -780,6 +975,9 @@ resource "aws_lambda_function" "db_deploy" {
       LOG_LEVEL                  = var.log_level
     }
   }
+  depends_on = [
+    aws_cloudwatch_log_group.db_deploy_log_group
+  ]
 }
 
 ## =============================================================================

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -946,7 +946,8 @@ resource "aws_cloudwatch_log_group" "db_deploy_log_group" {
 resource "aws_lambda_function" "db_deploy" {
   depends_on = [
     module.lambda_security_group,
-    var.restore_object_role_arn
+    var.restore_object_role_arn,
+    aws_cloudwatch_log_group.db_deploy_log_group
   ]
 
   ## REQUIRED
@@ -975,9 +976,6 @@ resource "aws_lambda_function" "db_deploy" {
       LOG_LEVEL                  = var.log_level
     }
   }
-  depends_on = [
-    aws_cloudwatch_log_group.db_deploy_log_group
-  ]
 }
 
 ## =============================================================================

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -45,13 +45,6 @@ variable "default_multipart_chunksize_mb" {
   description = "The default maximum size of chunks to use when copying. Can be overridden by collection config."
 }
 
-variable "lambda_log_retention_in_days" {
-  type = number
-  description = "Lambda log retention in days"
-  default = 0
-}
-
-
 ## Variables unique to ORCA
 ## REQUIRED
 
@@ -126,6 +119,11 @@ variable "restore_object_role_arn" {
 }
 
 ## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
+
+variable "lambda_log_retention_in_days" {
+  type = number
+  description = "Lambda log retention in days"
+}
 
 variable "lambda_runtime" {
   type        = string

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -45,6 +45,12 @@ variable "default_multipart_chunksize_mb" {
   description = "The default maximum size of chunks to use when copying. Can be overridden by collection config."
 }
 
+variable "lambda_log_retention_in_days" {
+  type = number
+  description = "Lambda log retention in days"
+  default = 0
+}
+
 
 ## Variables unique to ORCA
 ## REQUIRED

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -36,9 +36,9 @@ module "orca_lambdas" {
   orca_sqs_status_update_queue_id     = module.orca_sqs.orca_sqs_status_update_queue_id
   orca_sqs_status_update_queue_arn    = module.orca_sqs.orca_sqs_status_update_queue_arn
   restore_object_role_arn             = module.orca_iam.restore_object_role_arn
-  lambda_log_retention_in_days        = var.lambda_log_retention_in_days
 
   ## OPTIONAL
+  lambda_log_retention_in_days                  = var.lambda_log_retention_in_days
   lambda_runtime                                = var.lambda_runtime
   orca_delete_old_reconcile_jobs_frequency_cron = var.orca_delete_old_reconcile_jobs_frequency_cron
   orca_default_recovery_type                    = var.orca_default_recovery_type

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -36,6 +36,7 @@ module "orca_lambdas" {
   orca_sqs_status_update_queue_id     = module.orca_sqs.orca_sqs_status_update_queue_id
   orca_sqs_status_update_queue_arn    = module.orca_sqs.orca_sqs_status_update_queue_arn
   restore_object_role_arn             = module.orca_iam.restore_object_role_arn
+  lambda_log_retention_in_days        = var.lambda_log_retention_in_days
 
   ## OPTIONAL
   lambda_runtime                                = var.lambda_runtime

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -53,12 +53,6 @@ variable "default_multipart_chunksize_mb" {
   description = "The default maximum size of chunks to use when copying. Can be overridden by collection config."
 }
 
-variable "lambda_log_retention_in_days" {
-  type = number
-  description = "Lambda log retention in days"
-}
-
-
 ## Variables unique to ORCA
 ## REQUIRED
 
@@ -102,6 +96,11 @@ variable "dlq_subscription_email" {
 }
 
 ## OPTIONAL - Default variable value is set in ../variables.tf to keep default values centralized.
+
+variable "lambda_log_retention_in_days" {
+  type = number
+  description = "Lambda log retention in days"
+}
 variable "archive_recovery_queue_message_retention_time_seconds" {
   type        = number
   description = "The number of seconds archive-recovery-queue SQS retains a message in seconds. Maximum value is 14 days."

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -53,6 +53,11 @@ variable "default_multipart_chunksize_mb" {
   description = "The default maximum size of chunks to use when copying. Can be overridden by collection config."
 }
 
+variable "lambda_log_retention_in_days" {
+  type = number
+  description = "Lambda log retention in days"
+}
+
 
 ## Variables unique to ORCA
 ## REQUIRED

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "db_cluster_identifier" {
   description = "DB Cluster Identifier to associate with the IAM Role"
 }
 
+variable "lambda_log_retention_in_days" {
+  type = number
+  description = "Lambda log retention in days"
+  default = 0
+}
+
 ## OPTIONAL
 variable "aws_profile" {
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -47,13 +47,13 @@ variable "db_cluster_identifier" {
   description = "DB Cluster Identifier to associate with the IAM Role"
 }
 
+## OPTIONAL
+
 variable "lambda_log_retention_in_days" {
   type = number
   description = "Lambda log retention in days"
   default = 0
 }
-
-## OPTIONAL
 variable "aws_profile" {
   type    = string
   default = null

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -90,6 +90,7 @@ module "orca" {
   rds_security_group_id    = var.rds_security_group_id
 
   ## OPTIONAL
+  # lambda_log_retention_in_days                          = 0
   # archive_recovery_queue_message_retention_time_seconds = 777600
   # db_admin_username                                     = "postgres"
   # default_multipart_chunksize_mb                        = 250
@@ -533,6 +534,7 @@ variables is shown in the table below.
 
 | Variable                                              | Type          | Definition                                                                                                                     | Default
 | ----------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------- |
+| `lambda_log_retention_in_days`                         | number       | sets the number of days ORCA Lambda Logs are retained.                                                                     | 0 |
 | `archive_recovery_queue_message_retention_time_seconds`| string       | The number of seconds archive-recovery-queue SQS retains a message in seconds.                                                 | 777600     |
 | `db_admin_username`                                    | string       | Username for RDS database administrator authentication.                                                                        | "postgres" |
 | `default_multipart_chunksize_mb`                       | number       | The default maximum size of chunks to use when copying. Can be overridden by collection config.                                | 250 |


### PR DESCRIPTION
## Summary of Changes

Added CloudWatch Log Group resources and relevant variables to be able to set log retention on the ORCA Lambda's log groups. As well as added a script to delete AWS created log groups since those cannot be edited by Terraform.

Addresses [LPCUMULUS-1474: As a developer, I need to update our terraform deployment to set cloud watch log retention on our custom lambdas](https://bugs.earthdata.nasa.gov/browse/LPCUMULUS-1474)

## Changes

* Added CloudWatch Log Group Resources at `modules/lambdas/main.tf`
* Added variables for retention in days at `variables.tf`
* Added Log Group Deletion Script at `bin/delete_log_groups.py`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Successfully ran scripts and verified deletion of the AWS created log groups and deployed new log groups. Verified retention can be changed and Lambdas send logs to their respective new log groups.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets