### PR TITLE
ORCA-957: Add Security Group Rule to Allow DB to Perform S3 Import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ ORCA has added the capability to set log retention on ORCA Lambdas e.g. 30 days,
 - *ORCA-904* - Added to integration tests that verifies recovered objects are in the destination bucket.
 - *ORCA-907* - Added integration test for internal reconciliation at `integration_test/workflow_tests/test_packages/reconciliation` and updated documentation with new variables.
 - *LPCUMULUS-1474* - Added log groups that can have set retention periods in `modules/lambdas/main.tf` with a variable to set the retention in days. As well as added a script to delete the log groups AWS creates by default since those cannot be modified by Terraform.
+- *ORCA-957* Added outbound HTTPS security group rule in order for the Internal Reconciliation Workflow to perform the S3 import successfully at `modules/security_groups/main.tf` 
 
 ### Changed
 

--- a/modules/security_groups/main.tf
+++ b/modules/security_groups/main.tf
@@ -62,3 +62,13 @@ resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv6" {
   cidr_ipv6         = "::/0"
   ip_protocol       = "-1" 
 }
+
+resource "aws_security_group_rule" "rds_allow_s3_import" {
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "TCP"
+  description              = "Allows database to perform S3 Imports."
+  cidr_blocks              = ["0.0.0.0/0"] 
+  security_group_id        = var.rds_security_group_id
+}


### PR DESCRIPTION
## Summary of Changes

Added outbound HTTPS security group rule in order for the Internal Reconciliation Workflow to perform the S3 import successfully at `modules/security_groups/main.tf` 

Addresses [ORCA-957: Add Security Group Rule to Allow DB to Perform S3 Import](https://bugs.earthdata.nasa.gov/browse/ORCA-957)

## Changes

* Added outbound HTTPS security group rule in order for the Internal Reconciliation Workflow to perform the S3 import successfully at `modules/security_groups/main.tf` 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Successfully deployed rule and verified workflow passed. Integration test passed as well.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets

