### PR TITLE
ORCA-910: Enable date-based partitioning in S3 server access logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and includes an additional section for migration notes.
 
 ### Migration Notes
 **Server Access Logging (OPTIONAL)**
+
 Server access logging provides detailed records for the requests that are made to a bucket. Server access logs are useful for many applications. For example, access log information can be useful in security and access audits.
 - To Enable
   1. Through the AWS Console navigate to S3 and select the bucket you want to enable server access logging on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and includes an additional section for migration notes.
 ## [Unreleased]
 
 ### Migration Notes
+**Server Access Logging (OPTIONAL)**
+Server access logging provides detailed records for the requests that are made to a bucket. Server access logs are useful for many applications. For example, access log information can be useful in security and access audits.
+- To Enable
+  1. Through the AWS Console navigate to S3 and select the bucket you want to enable server access logging on.
+  2. Select **Properties**
+  3. Scroll down to **Server access logging** and select **edit**
+  4. Select **Enable**
+  5. Select a destination bucket that the logs will be sent to. e.g. `s3://PREFIX-internal/PREFIX-internal-logs/`
+  6. Select the preferred log object key format and select **Save Changes**
 
 ### Added
 


### PR DESCRIPTION
## Summary of Changes

Added optional instructions for users to enable server access logging with data-based partitioning on S3 buckets.

Addresses [ORCA-910: Enable date-based partitioning in S3 server access logging](https://bugs.earthdata.nasa.gov/browse/ORCA-910)

## Changes

* Added optional instructions for users to enable server access logging with data-based partitioning on S3 buckets in CHANGELOG.md

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update

## How Has This Been Tested?

Enabled server access logging on development buckets and verified logs were received

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.mdte no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
