### PR TITLE
ORCA-934: Research and update ORCA DB Compare EC2 Instance to use Amazon 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Server access logging provides detailed records for the requests that are made t
 ### Changed
 
 - *ORCA-940* - Updated bandit package to latest version 1.8.2.
+- *ORCA-934* - Updated db_comparison instance in `modules/db_compare_instance/main.tf` to use Amazon Linux 2023 AMI.
 ### Removed
 
 ### Fixed

--- a/modules/db_compare_instance/main.tf
+++ b/modules/db_compare_instance/main.tf
@@ -48,7 +48,7 @@ data "cloudinit_config" "config" {
   }
  
   part {
-    filename     = "psql.sh"
+    filename     = "a_psql.sh"
     content_type = "text/x-shellscript"
     content      = "${data.template_file.install.rendered}"
   }
@@ -93,7 +93,7 @@ data "aws_ami" "ami" {
  
   filter {
     name   = "name"
-    values = ["edc-app-base-*-amzn-linux2-x86_64"]
+    values = ["edc-app-base-*-al2023-x86_64"]
   }
   owners = ["863143145967"]
 }

--- a/modules/db_compare_instance/scripts/db_compare.sh
+++ b/modules/db_compare_instance/scripts/db_compare.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 source /home/db_config.sh
  
 PGPASSWORD=$v1_password psql --host=$v1_endpoint --port=5432 --username=$v1_user --dbname=$v1_database -c "SELECT 'collections' AS v1_cluster, COUNT(*) AS row_count FROM collections

--- a/modules/db_compare_instance/scripts/db_config.sh
+++ b/modules/db_compare_instance/scripts/db_config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 archive_bucket=""
 v1_endpoint="" 
 v1_database=""

--- a/modules/db_compare_instance/scripts/psql.sh
+++ b/modules/db_compare_instance/scripts/psql.sh
@@ -1,6 +1,5 @@
-
-#!/bin/sh
-amazon-linux-extras install -y postgresql13
+#!/bin/bash
+dnf install -y postgresql16
  
 cp /var/lib/cloud/instance/scripts/db_compare.sh /home/db_compare.sh
 chmod 755 /home/db_compare.sh


### PR DESCRIPTION
## Summary of Changes

Modified `modules/db_compare_instance/main.tf` to use Amazon Linux 2023 AMI as well as updated the scripts in `/modules/db_compare_instance/scripts`.

Addresses [ORCA-934: Research and update ORCA DB Compare EC2 Instance to use Amazon 2023](https://bugs.earthdata.nasa.gov/browse/ORCA-934)

## Changes

* Modified `modules/db_compare_instance/main.tf` to use Amazon Linux 2023 AMI.
* Modified scripts to run successfully using the new AMI which is based off a different distribution than Amazon Linux 2.
* Modified the psql script name in `modules/db_compare_instance/main.tf` from `psql.sh` to `a_psql.sh` to ensure that script is ran first.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Successfully deployed instance and verified psql was installed. Verified that other scripts were able to run successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets