### PR TITLE
ORCA-976: Fix snyk high vulnerability in ORCA lambdas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Server access logging provides detailed records for the requests that are made t
 
 ### Security
 
+- *ORCA-976* - Added gitpython to `requirements-dev.txt` files and set version to 3.1.41 to resolve snyk vulnerabilities
+
 ## [10.1.1] 2025-01-29
 
 ### Migration Notes

--- a/ecs_tasks/internal_reconcile_report_generate/requirements-dev.txt
+++ b/ecs_tasks/internal_reconcile_report_generate/requirements-dev.txt
@@ -12,3 +12,4 @@ requests~=2.28.1
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/graphql/requirements-dev.txt
+++ b/graphql/requirements-dev.txt
@@ -15,3 +15,4 @@ black==24.10.0
 isort==5.13.2
 coverage==7.2.7
 pytest==7.4.0
+gitpython==3.1.41

--- a/integration_test/workflow_tests/requirements.txt
+++ b/integration_test/workflow_tests/requirements.txt
@@ -10,3 +10,4 @@ dataclasses-json
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/shared_libraries/requirements.txt
+++ b/shared_libraries/requirements.txt
@@ -9,6 +9,7 @@ pydoc-markdown>=4.0.0,<5.0.0
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41
 
 
 ## Libraries needed for unit tests

--- a/tasks/copy_from_archive/requirements-dev.txt
+++ b/tasks/copy_from_archive/requirements-dev.txt
@@ -12,3 +12,4 @@ aws_lambda_powertools==3.2.0
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/copy_to_archive/requirements-dev.txt
+++ b/tasks/copy_to_archive/requirements-dev.txt
@@ -11,3 +11,4 @@ moto[sqs]==4.2.13
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/db_deploy/requirements-dev.txt
+++ b/tasks/db_deploy/requirements-dev.txt
@@ -9,6 +9,7 @@ pydoc-markdown==4.5.0
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41
 
 
 ## Standard unit test libraries

--- a/tasks/delete_old_reconcile_jobs/requirements-dev.txt
+++ b/tasks/delete_old_reconcile_jobs/requirements-dev.txt
@@ -16,3 +16,4 @@ boto3==1.28.76
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/extract_filepaths_for_granule/requirements-dev.txt
+++ b/tasks/extract_filepaths_for_granule/requirements-dev.txt
@@ -9,3 +9,4 @@ fastjsonschema==2.15.0
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/get_current_archive_list/requirements-dev.txt
+++ b/tasks/get_current_archive_list/requirements-dev.txt
@@ -17,3 +17,4 @@ fastjsonschema~=2.15.1
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/internal_reconcile_report_job/requirements-dev.txt
+++ b/tasks/internal_reconcile_report_job/requirements-dev.txt
@@ -16,3 +16,4 @@ fastjsonschema~=2.15.1
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/internal_reconcile_report_mismatch/requirements-dev.txt
+++ b/tasks/internal_reconcile_report_mismatch/requirements-dev.txt
@@ -16,3 +16,4 @@ fastjsonschema~=2.15.1
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/internal_reconcile_report_orphan/requirements-dev.txt
+++ b/tasks/internal_reconcile_report_orphan/requirements-dev.txt
@@ -16,3 +16,4 @@ fastjsonschema~=2.15.1
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/internal_reconcile_report_phantom/requirements-dev.txt
+++ b/tasks/internal_reconcile_report_phantom/requirements-dev.txt
@@ -16,3 +16,4 @@ fastjsonschema~=2.15.1
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/orca_catalog_reporting/requirements-dev.txt
+++ b/tasks/orca_catalog_reporting/requirements-dev.txt
@@ -11,3 +11,4 @@ coverage==7.2.7
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/perform_orca_reconcile/requirements-dev.txt
+++ b/tasks/perform_orca_reconcile/requirements-dev.txt
@@ -17,3 +17,4 @@ boto3==1.28.76
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/post_copy_request_to_queue/requirements-dev.txt
+++ b/tasks/post_copy_request_to_queue/requirements-dev.txt
@@ -18,3 +18,4 @@ SQLAlchemy~=2.0.5
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/post_to_catalog/requirements-dev.txt
+++ b/tasks/post_to_catalog/requirements-dev.txt
@@ -17,3 +17,4 @@ SQLAlchemy~=2.0.5
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/post_to_database/requirements-dev.txt
+++ b/tasks/post_to_database/requirements-dev.txt
@@ -16,3 +16,4 @@ fastjsonschema~=2.15.1
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/post_to_queue_and_trigger_step_function/requirements-dev.txt
+++ b/tasks/post_to_queue_and_trigger_step_function/requirements-dev.txt
@@ -17,3 +17,4 @@ boto3==1.28.76
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/request_from_archive/requirements-dev.txt
+++ b/tasks/request_from_archive/requirements-dev.txt
@@ -17,3 +17,4 @@ aws_lambda_powertools==3.2.0
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/request_status_for_granule/requirements-dev.txt
+++ b/tasks/request_status_for_granule/requirements-dev.txt
@@ -12,3 +12,4 @@ psycopg2-binary==2.9.9
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41

--- a/tasks/request_status_for_job/requirements-dev.txt
+++ b/tasks/request_status_for_job/requirements-dev.txt
@@ -12,3 +12,4 @@ psycopg2-binary==2.9.9
 flake8==7.0.0
 black==24.10.0
 isort==5.13.2
+gitpython==3.1.41


### PR DESCRIPTION
## Summary of Changes

Added gitpython to `requirements-dev.txt` files and set version to 3.1.41 to resolve snyk vulnerabilities.

Addresses [ORCA-976: Fix snyk high vulnerability in ORCA lambdas.](https://bugs.earthdata.nasa.gov/browse/ORCA-976)

## Changes

* Added gitpython to `requirements-dev.txt` files and set version to 3.1.41 to resolve snyk vulnerabilities. GitPython is a dependency of Bandit so it installs when Bandit is installed and for some reason it wasn't using a newer version of GitPython.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran unit tests successfully and verified correct version of GitPython 3.1.41 is installed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
