### PR TITLE
ORCA-966: Modify db_deploy for autocommits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ Server access logging provides detailed records for the requests that are made t
 - *ORCA-940* - Updated bandit package to latest version 1.8.2.
 - *ORCA-934* - Updated db_comparison instance in `modules/db_compare_instance/main.tf` to use Amazon Linux 2023 AMI.
 - *ORCA-402* - Met with ORCA users to discuss ORCA delete functionality open questions and updated the research webpage.
-- 
+- *ORCA-966* - Updated `tasks/db_deploy/db_deploy.py` and `tasks/db_deploy/migrations` with `.begin()` for autocommits. As well as updated unit tests.
+
 ### Removed
 
 

--- a/tasks/db_deploy/db_deploy.py
+++ b/tasks/db_deploy/db_deploy.py
@@ -84,7 +84,7 @@ def task(config: PostgresConnectionInfo, orca_buckets: List[str]) -> None:
     postgres_admin_engine = create_engine(create_admin_uri(config, LOGGER), future=True)
 
     # Connect as admin user to the postgres database
-    with postgres_admin_engine.connect() as connection:
+    with postgres_admin_engine.begin() as connection:
         # Check if database exists. If not, start from scratch.
         if not app_db_exists(connection, config.user_database_name):
             LOGGER.info(
@@ -102,7 +102,7 @@ def task(config: PostgresConnectionInfo, orca_buckets: List[str]) -> None:
     )
 
     # Connect as admin user to config["user_database"] database.
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
         # reset user password
         reset_user_password(connection, config, config.user_username)
         # Determine if we need a fresh install or need a migration based on if
@@ -211,7 +211,7 @@ def reset_user_password(
         connection.execute(
             reset_user_password_sql, {"user_password": config.user_password}
         )
-        connection.commit()
+
         LOGGER.info(f"Password for {config.user_username} has been reset")
 
     else:

--- a/tasks/db_deploy/migrations/migrate_versions_1_to_2/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_1_to_2/migrate.py
@@ -42,7 +42,7 @@ def migrate_versions_1_to_2(
     )
 
     # Create all the new objects, users, roles, etc.
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
         # Create the roles first since they are needed by schema and users
         LOGGER.debug("Creating the ORCA dbo role ...")
         connection.execute(
@@ -98,11 +98,10 @@ def migrate_versions_1_to_2(
         connection.execute(sql.recovery_file_table_sql())
         LOGGER.info("recovery_file table created.")
 
-        # Commit if there are no issues
-        connection.commit()
+
 
     # Migrate the data and drop old tables, schema, users, roles
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
         # Change to admin role and set search path
         LOGGER.debug("Changing to the admin role ...")
         connection.execute(sql.text("RESET ROLE;"))
@@ -163,5 +162,4 @@ def migrate_versions_1_to_2(
             connection.execute(sql.schema_versions_data_sql())
             LOGGER.info("Data added to the schema_versions table.")
 
-        # Commit if there are no issues
-        connection.commit()
+

--- a/tasks/db_deploy/migrations/migrate_versions_2_to_3/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_2_to_3/migrate.py
@@ -28,7 +28,7 @@ def migrate_versions_2_to_3(
     )
 
     # Create new objects, users, roles, etc.
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
         # Change to DBO role and set search path
         LOGGER.debug("Changing to the dbo role to modify objects ...")
         connection.execute(sql.text("SET ROLE orca_dbo;"))
@@ -46,5 +46,4 @@ def migrate_versions_2_to_3(
             connection.execute(sql.schema_versions_data_sql())
             LOGGER.info("Data added to the schema_versions table.")
 
-        # Commit if there are no issues
-        connection.commit()
+

--- a/tasks/db_deploy/migrations/migrate_versions_3_to_4/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_3_to_4/migrate.py
@@ -29,7 +29,7 @@ def migrate_versions_3_to_4(
         create_admin_uri(config, LOGGER, config.user_database_name), future=True
     )
 
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
         # Change to DBO role and set search path
         LOGGER.debug("Changing to the dbo role to create objects ...")
         connection.execute(sql.text("SET ROLE orca_dbo;"))
@@ -65,5 +65,4 @@ def migrate_versions_3_to_4(
             connection.execute(sql.schema_versions_data_sql())
             LOGGER.info("Data added to the schema_versions table.")
 
-        # Commit if there are no issues
-        connection.commit()
+

--- a/tasks/db_deploy/migrations/migrate_versions_4_to_5/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_4_to_5/migrate.py
@@ -41,7 +41,7 @@ def migrate_versions_4_to_5(
         create_admin_uri(config, LOGGER, config.user_database_name), future=True
     )
 
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
 
         # Create extension for the database as the admin user
         LOGGER.debug("Creating extension aws_s3 ...")
@@ -109,5 +109,4 @@ def migrate_versions_4_to_5(
             connection.execute(sql.schema_versions_data_sql())
             LOGGER.info("Data added to the schema_versions table.")
 
-        # Commit if there are no issues
-        connection.commit()
+

--- a/tasks/db_deploy/migrations/migrate_versions_5_to_6/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_5_to_6/migrate.py
@@ -35,7 +35,7 @@ def migrate_versions_5_to_6(
         create_admin_uri(config, LOGGER, config.user_database_name), future=True
     )
 
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
 
         # Change to DBO role and set search path
         LOGGER.debug("Changing to the dbo role to create objects ...")
@@ -73,5 +73,4 @@ def migrate_versions_5_to_6(
             connection.execute(sql.schema_versions_data_sql())
             LOGGER.info("Data added to the schema_versions table.")
 
-        # Commit if there are no issues
-        connection.commit()
+

--- a/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_6_to_7/migrate.py
@@ -32,7 +32,7 @@ def migrate_versions_6_to_7(
         create_admin_uri(config, LOGGER, config.user_database_name), future=True
     )
 
-    with user_admin_engine.connect() as connection:
+    with user_admin_engine.begin() as connection:
 
         # Change to DBO role and set search path
         LOGGER.debug("Changing to the dbo role to create objects ...")
@@ -55,5 +55,4 @@ def migrate_versions_6_to_7(
             connection.execute(sql.schema_versions_data_sql())
             LOGGER.info("Data added to the schema_versions table.")
 
-        # Commit if there are no issues
-        connection.commit()
+

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_1_to_2/test_migrate_v2.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_1_to_2/test_migrate_v2.py
@@ -168,7 +168,6 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                         call.execute(mock_recovery_status_table()),
                         call.execute(mock_recovery_job_table()),
                         call.execute(mock_recovery_file_table()),
-                        call.commit(),
                         call.execute(mock_text("RESET ROLE;")),
                         call.execute(mock_text("SET search_path TO orca, dr, public;")),
                         call.execute(mock_recovery_status_data()),
@@ -183,7 +182,6 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                         call.execute(mock_drop_dbo_user()),
                         call.execute(mock_drop_druser_user()),
                         call.execute(mock_schema_versions_data()),
-                        call.commit(),
                     ]
 
                 else:
@@ -207,7 +205,6 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                         call.execute(mock_recovery_status_table()),
                         call.execute(mock_recovery_job_table()),
                         call.execute(mock_recovery_file_table()),
-                        call.commit(),
                         call.execute(mock_text("RESET ROLE;")),
                         call.execute(mock_text("SET search_path TO orca, dr, public;")),
                         call.execute(mock_recovery_status_data()),
@@ -221,11 +218,10 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                         call.execute(mock_drop_dr_role()),
                         call.execute(mock_drop_dbo_user()),
                         call.execute(mock_drop_druser_user()),
-                        call.commit(),
                     ]
 
                 # Check that items were called in the proper order
-                mock_conn_enter = mock_create_engine().connect().__enter__()
+                mock_conn_enter = mock_create_engine().begin().__enter__()
                 mock_conn_enter.assert_has_calls(execution_order, any_order=False)
                 self.assertEqual(
                     len(execution_order), len(mock_conn_enter.method_calls)

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_2_to_3/test_migrate_v3.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_2_to_3/test_migrate_v3.py
@@ -88,7 +88,6 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                         call.execute(mock_text("SET search_path TO orca, public;")),
                         call.execute(mock_add_multipart_chunksize_sql()),
                         call.execute(mock_schema_versions_data()),
-                        call.commit(),
                     ]
 
                 else:
@@ -97,10 +96,9 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                         call.execute(mock_text("SET ROLE orca_dbo;")),
                         call.execute(mock_text("SET search_path TO orca, public;")),
                         call.execute(mock_add_multipart_chunksize_sql()),
-                        call.commit(),
                     ]
                 # Check that items were called in the proper order
-                mock_conn_enter = mock_create_engine().connect().__enter__()
+                mock_conn_enter = mock_create_engine().begin().__enter__()
                 mock_conn_enter.assert_has_calls(execution_order, any_order=False)
                 self.assertEqual(
                     len(execution_order), len(mock_conn_enter.method_calls)

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_3_to_4/test_migrate_v4.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_3_to_4/test_migrate_v4.py
@@ -104,10 +104,9 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                 else:
                     mock_schema_versions_data.assert_not_called()
 
-                execution_order.append(call.commit())
 
                 # Check that items were called in the proper order
-                mock_conn_enter = mock_create_engine().connect().__enter__()
+                mock_conn_enter = mock_create_engine().begin().__enter__()
                 mock_conn_enter.assert_has_calls(execution_order, any_order=False)
                 self.assertEqual(
                     len(execution_order), len(mock_conn_enter.method_calls)

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_4_to_5/test_migrate_v5.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_4_to_5/test_migrate_v5.py
@@ -158,11 +158,9 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                 else:
                     mock_schema_versions_data.assert_not_called()
 
-                # Add the commit at the end
-                execution_order.append(call.commit())
 
                 # Check that items were called in the proper order
-                mock_conn_enter = mock_create_engine().connect().__enter__()
+                mock_conn_enter = mock_create_engine().begin().__enter__()
                 mock_conn_enter.assert_has_calls(execution_order, any_order=False)
 
             # Reset the mocks for next loop

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_5_to_6/test_migrate_v6.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_5_to_6/test_migrate_v6.py
@@ -116,11 +116,9 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                 else:
                     mock_schema_versions_data_sql.assert_not_called()
 
-                # Add the commit at the end
-                execution_order.append(call.commit())
 
                 # Check that items were called in the proper order
-                mock_conn_enter = mock_create_engine().connect().__enter__()
+                mock_conn_enter = mock_create_engine().begin().__enter__()
                 mock_conn_enter.assert_has_calls(execution_order, any_order=False)
                 self.assertEqual(
                     len(execution_order), len(mock_conn_enter.method_calls)

--- a/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_v7.py
+++ b/tasks/db_deploy/test/unit_tests/migrations/migrate_versions_6_to_7/test_migrate_v7.py
@@ -99,11 +99,9 @@ class TestMigrateDatabaseLibraries(unittest.TestCase):
                 else:
                     mock_schema_versions_data_sql.assert_not_called()
 
-                # Add the commit at the end
-                execution_order.append(call.commit())
 
                 # Check that items were called in the proper order
-                mock_conn_enter = mock_create_engine().connect().__enter__()
+                mock_conn_enter = mock_create_engine().begin().__enter__()
                 mock_conn_enter.assert_has_calls(execution_order, any_order=False)
                 self.assertEqual(
                     len(execution_order), len(mock_conn_enter.method_calls)

--- a/tasks/db_deploy/test/unit_tests/test_db_deploy.py
+++ b/tasks/db_deploy/test/unit_tests/test_db_deploy.py
@@ -142,7 +142,7 @@ class TestDbDeployFunctions(unittest.TestCase):
             mock_create_admin_uri.return_value, future=True
         )
         mock_app_db_exists.assert_called_with(
-            mock_create_engine().connect().__enter__(), config.user_database_name
+            mock_create_engine().begin().__enter__(), config.user_database_name
         )
         mock_create_database.assert_called_once_with(config)
         mock_create_fresh_orca_install.assert_called_once_with(config, orca_buckets)
@@ -184,7 +184,7 @@ class TestDbDeployFunctions(unittest.TestCase):
         db_deploy.task(config, orca_buckets)
         mock_fresh_install.assert_called_with(config, orca_buckets)
         mock_reset_user_password.assert_called_once_with(
-            mock_create_engine.return_value.connect.return_value.__enter__.return_value,
+            mock_create_engine.return_value.begin.return_value.__enter__.return_value,
             config,
             config.user_username,
         )
@@ -229,7 +229,7 @@ class TestDbDeployFunctions(unittest.TestCase):
         db_deploy.task(config, orca_buckets)
         mock_perform_migration.assert_called_with(1, config, orca_buckets)
         mock_reset_user_password.assert_called_once_with(
-            mock_create_engine.return_value.connect.return_value.__enter__.return_value,
+            mock_create_engine.return_value.begin.return_value.__enter__.return_value,
             config,
             config.user_username,
         )
@@ -275,7 +275,7 @@ class TestDbDeployFunctions(unittest.TestCase):
         db_deploy.task(config, orca_buckets)
         mock_logger_info.assert_called_with(message)
         mock_reset_user_password.assert_called_once_with(
-            mock_create_engine.return_value.connect.return_value.__enter__.return_value,
+            mock_create_engine.return_value.begin.return_value.__enter__.return_value,
             config,
             config.user_username,
         )


### PR DESCRIPTION
## Summary of Changes

Updated `tasks/db_deploy/db_deploy.py` and `tasks/db_deploy/migrations` with `.begin()` for autocommits. As well as updated unit tests.

Addresses [ORCA-966: Modify db_deploy for autocommits](https://bugs.earthdata.nasa.gov/browse/ORCA-966)

## Changes

* Updated `tasks/db_deploy/db_deploy.py` and `tasks/db_deploy/migrations` with `.begin()` for autocommits. As well as updated unit tests.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests succeed, ran db_deploy lambda and verified schemas, tables, and roles were successfully created on a fresh database.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
