### PR TITLE
ORCA-980: Generate Unique Message IDs for the metadata FIFO Queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Server access logging provides detailed records for the requests that are made t
 - *ORCA-934* - Updated db_comparison instance in `modules/db_compare_instance/main.tf` to use Amazon Linux 2023 AMI.
 - *ORCA-402* - Met with ORCA users to discuss ORCA delete functionality open questions and updated the research webpage.
 - *ORCA-966* - Updated `tasks/db_deploy/db_deploy.py` and `tasks/db_deploy/migrations` with `.begin()` for autocommits. As well as updated unit tests.
+- *ORCA-980* - Modified `tasks/copy_to_archive/sqs_library.py` to generate a unique MessageGroupId to enable the `post_to_catalog` lambda to processs SQS messages from the metadata SQS queue faster to prevent build up in the queue.
 
 ### Removed
 

--- a/tasks/copy_to_archive/sqs_library.py
+++ b/tasks/copy_to_archive/sqs_library.py
@@ -11,6 +11,7 @@ import json
 import os
 import random
 import time
+import uuid
 from typing import Any, Callable, Dict, TypeVar
 
 # Third party libraries
@@ -143,7 +144,7 @@ def post_to_metadata_queue(
     response = mysqs.send_message(
         QueueUrl=metadata_queue_url,
         MessageDeduplicationId=deduplication_id,
-        MessageGroupId="metadata_message",
+        MessageGroupId=f"metadata_message-{uuid.uuid4()}",
         MessageBody=body,
     )  # todo: Look at changes in post_to_queue_and_trigger_step_function ORCA-406
     LOGGER.debug(f"SQS Message Response: {json.dumps(response)}")


### PR DESCRIPTION
## Summary of Changes

Modified `tasks/copy_to_archive/sqs_library.py` to generate a unique MessageGroupId to enable the `post_to_catalog` lambda to processs SQS messages from the metadata SQS queue faster to prevent build up in the queue.

Addresses [ORCA-980: Generate Unique Message IDs for the metadata FIFO Queue](https://bugs.earthdata.nasa.gov/browse/ORCA-980)

## Changes

* Modified `tasks/copy_to_archive/sqs_library.py` to generate a unique MessageGroupId to enable the `post_to_catalog` lambda to processs SQS messages from the metadata SQS queue faster to prevent build up in the queue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in dev. LP tested in UAT then deployed to PROD. Change has resolved the issue of building up with messages as SQS messages are now being processed faster than they are coming in preventing an excessive build up of messages. Unit tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
