### PR TITLE
ORCA-650: Make use of sqlalchemy fetchone property instead of looping in relevant lambdas if applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Server access logging provides detailed records for the requests that are made t
 - *ORCA-402* - Met with ORCA users to discuss ORCA delete functionality open questions and updated the research webpage.
 - *ORCA-966* - Updated `tasks/db_deploy/db_deploy.py` and `tasks/db_deploy/migrations` with `.begin()` for autocommits. As well as updated unit tests.
 - *ORCA-980* - Modified `tasks/copy_to_archive/sqs_library.py` to generate a unique MessageGroupId to enable the `post_to_catalog` lambda to processs SQS messages from the metadata SQS queue faster to prevent build up in the queue.
+- *ORCA-650* - Modified `tasks/get_current_archive_list/get_current_archive_list.py` and `tasks/post_to_catalog/post_to_catalog.py` and relevant unit tests to utilize SQLAlchemy fetchone() property to eliminate looping.
 
 ### Removed
 

--- a/tasks/get_current_archive_list/get_current_archive_list.py
+++ b/tasks/get_current_archive_list/get_current_archive_list.py
@@ -191,8 +191,11 @@ def create_job(
                     }
                 ],
             )
-            for sql_result in rows.mappings():
+            sql_result = rows.mappings().fetchone()
+            if sql_result:
                 job_id = sql_result["id"]
+            else:
+                raise ValueError("No job ID found.")
     except Exception as sql_ex:
         LOGGER.error(f"Error while creating job: {sql_ex}")
         raise

--- a/tasks/get_current_archive_list/test/unit_tests/test_get_current_archive_list.py
+++ b/tasks/get_current_archive_list/test/unit_tests/test_get_current_archive_list.py
@@ -279,7 +279,7 @@ class TestGetCurrentArchiveList(
         mock_job_id = Mock()
         returned_rows = {"id": mock_job_id}
         mock_execute_result = Mock()
-        mock_execute_result.mappings = Mock(return_value=[returned_rows])
+        mock_execute_result.mappings.return_value.fetchone.return_value = returned_rows
         mock_execute = Mock()
         mock_execute.return_value = mock_execute_result
         mock_connection = Mock()

--- a/tasks/post_to_catalog/post_to_catalog.py
+++ b/tasks/post_to_catalog/post_to_catalog.py
@@ -131,12 +131,11 @@ def create_catalog_records(
                 ],
             )
 
-            for (
-                row
-            ) in (
-                results.mappings()
-            ):  # Need loop due to limitations on the underlying object. Welcome alternatives.
-                granule_id = row["id"]
+            sql_result = results.mappings().fetchone()
+            if sql_result:
+                granule_id = sql_result["id"]
+            else:
+                raise ValueError("No job ID found.")
 
             file_parameters = []
             for file in granule["files"]:

--- a/tasks/post_to_catalog/test/unit_tests/test_post_to_catalog.py
+++ b/tasks/post_to_catalog/test/unit_tests/test_post_to_catalog.py
@@ -235,7 +235,9 @@ class TestPostToDatabase(
         internal_id = random.randint(0, 10000)  # nosec
         mock_engine = Mock()
         mock_execute_result = Mock()
-        mock_execute_result.mappings = Mock(return_value=[{"id": internal_id}])
+        mock_execute_result.mappings.return_value.fetchone.return_value = {
+            "id": internal_id
+        }
         mock_execute = Mock()
         mock_execute.return_value = mock_execute_result
         mock_engine.begin.return_value = Mock()
@@ -283,6 +285,7 @@ class TestPostToDatabase(
                     ],
                 ),
                 call().mappings(),
+                call().mappings().fetchone(),
                 call(
                     mock_create_file_sql.return_value,
                     [


### PR DESCRIPTION
## Summary of Changes

Modified `tasks/get_current_archive_list/get_current_archive_list.py` and `tasks/post_to_catalog/post_to_catalog.py` and relevant unit tests to utilize SQLAlchemy fetchone() property to eliminate looping.

Addresses [ORCA-650: Make use of sqlalchemy fetchone property instead of looping in relevant lambdas if applicable](https://bugs.earthdata.nasa.gov/browse/ORCA-650)

## Changes

* Modified `tasks/get_current_archive_list/get_current_archive_list.py` and `tasks/post_to_catalog/post_to_catalog.py` and relevant unit tests to utilize SQLAlchemy fetchone() property to eliminate looping.
* Other Lambdas would still need looping funcionality with fetchone()

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Lambdas run successfully and updated unit tests pass without error.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Unit tests
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets