### PR TITLE
ORCA-885: Implement X-ray tracing in ORCA lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and includes an additional section for migration notes.
 ## [Unreleased]
 
 ### Migration Notes
+AWS X-Ray functionality has been added for the `copy_to_orca` lambda. For users wanting to utilze X-Ray, set the `lambda_xray` variable in the tfvars file to `Active`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and includes an additional section for migration notes.
 
 ### Added
 
+- *ORCA-885* - Added X-Ray for `copy_to_orca` lambda and a variable in `variables.tf` to enable/disable it as well as updated IAM permissions for use.
+
 ### Changed
 
 - *ORCA-985* - Fixed deprecated argument warning in api-gateway/main.tf by removing `stage_name` from `aws_api_gateway_deployment` resource and deploying `aws_api_gateway_stage ` resource instead.

--- a/main.tf
+++ b/main.tf
@@ -84,4 +84,5 @@ module "orca" {
   max_pool_connections                                  = var.max_pool_connections
   max_concurrency                                       = var.max_concurrency
   deploy_rds_dedicated_instance_role_association        = var.deploy_rds_dedicated_instance_role_association
+  lambda_xray                                           = var.lambda_xray
 }

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -53,6 +53,10 @@ resource "aws_lambda_function" "copy_to_archive" {
     security_group_ids = [module.lambda_security_group.vpc_all_egress_id]
   }
 
+  tracing_config {
+    mode = var.lambda_xray
+  }
+
   environment {
     variables = {
       ORCA_DEFAULT_BUCKET            = var.orca_default_bucket

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -240,3 +240,8 @@ variable "max_concurrency" {
   type        = number
   description = "The maximum number of concurrent S3 API transfer operations. Defaults to 10."
 }
+
+variable "lambda_xray" {
+  type = string
+  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and Passthrough for disabled."
+}

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -243,5 +243,5 @@ variable "max_concurrency" {
 
 variable "lambda_xray" {
   type = string
-  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and Passthrough for disabled."
+  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and PassThrough for disabled."
 }

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -60,6 +60,7 @@ module "orca_lambdas" {
   gql_tasks_role_arn                            = module.orca_graphql_0.gql_tasks_role_arn
   max_pool_connections                          = var.max_pool_connections
   max_concurrency                               = var.max_concurrency
+  lambda_xray                                   = var.lambda_xray
 }
 
 ## orca_lambdas_secondary - lambdas module that is dependent on resources that presently are created after most lambdas

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -304,3 +304,8 @@ variable "deploy_rds_dedicated_instance_role_association" {
   type        = bool
   description = "Deploys IAM role for RDS dedicated instance."
 }
+
+variable "lambda_xray" {
+  type        = string
+  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and Passthrough for disabled."
+}

--- a/modules/orca/variables.tf
+++ b/modules/orca/variables.tf
@@ -307,5 +307,5 @@ variable "deploy_rds_dedicated_instance_role_association" {
 
 variable "lambda_xray" {
   type        = string
-  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and Passthrough for disabled."
+  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and PassThrough for disabled."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -367,3 +367,9 @@ variable "deploy_rds_dedicated_instance_role_association" {
   description = "Attaches IAM role for RDS dedicated instance"
   default = false
 }
+
+variable "lambda_xray" {
+  type        = string
+  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and Passthrough for disabled."
+  default     = "Passthrough"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -370,6 +370,6 @@ variable "deploy_rds_dedicated_instance_role_association" {
 
 variable "lambda_xray" {
   type        = string
-  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and Passthrough for disabled."
-  default     = "Passthrough"
+  description = "Enables or disables X-Ray on ORCA Lambdas, value set to Active for enabled and PassThrough for disabled."
+  default     = "PassThrough"
 }

--- a/website/docs/developer/deployment-guide/deployment-with-cumulus.md
+++ b/website/docs/developer/deployment-guide/deployment-with-cumulus.md
@@ -123,6 +123,7 @@ module "orca" {
   # status_update_queue_message_retention_time_seconds    = 777600
   # max_pool_connections                                  = 10
   # max_concurrency                                       = 10
+  # lambda_xray                                           = "PassThrough"
 
 }
 ```
@@ -573,6 +574,7 @@ variables is shown in the table below.
 | `status_update_queue_message_retention_time_seconds`   | number       | Number of seconds the status_update_queue fifo SQS retains a message.                                                          | 777600 |
 | `max_pool_connections`                                 | number       | The maximum number of connections to keep in a connection pool.                                                                | 10 |
 | `max_concurrency`                                       | number      | The maximum number of concurrent S3 API transfer operations.                                                                   | 10 |
+| `lambda_xray`                                  | string       | Enables or disables X-Ray on ORCA Lambdas, value set to `Active` for enabled and `PassThrough` for disabled.                                              | PassThrough |
 
 
 ## ORCA Module Outputs


### PR DESCRIPTION
## Summary of Changes

Added X-Ray for `copy_to_orca` lambda and a variable in `variables.tf` to enable/disable it as well as updated IAM permissions for use.

Addresses [ORCA-885: Implement X-ray tracing in ORCA lambda](https://bugs.earthdata.nasa.gov/browse/ORCA-885)

## Changes

* Added X-Ray for `copy_to_orca` lambda and a variable in `variables.tf` to enable/disable it as well as updated IAM permissions for use.
* 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Successfully deployed lambda with X-Ray enabled.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
