### PR TITLE
ORCA-396: Create API gateway resource for performing ORCA delete functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ AWS X-Ray functionality has been added for the `copy_to_orca` lambda. For users 
 ### Added
 
 - *ORCA-885* - Added X-Ray for `copy_to_orca` lambda and a variable in `variables.tf` to enable/disable it as well as updated IAM permissions for use.
+- *ORCA-396* - Added API Gateway and resource paths for delete functionality, added placeholders for future Lmabdas since those are not ready yet and will have to be added at a later date.
 
 ### Changed
 

--- a/modules/delete_api/main.tf
+++ b/modules/delete_api/main.tf
@@ -1,0 +1,138 @@
+# Local Variables
+locals {
+  region          = data.aws_region.current_region.name
+  vpc_endpoint_id = var.vpc_endpoint_id != null ? var.vpc_endpoint_id : data.aws_vpc_endpoint.vpc_endpoint_id.id
+}
+
+data "aws_region" "current_region" {}
+
+data "aws_vpc_endpoint" "vpc_endpoint_id" {
+  vpc_id       = var.vpc_id
+  service_name = "com.amazonaws.${local.region}.execute-api"
+}
+
+# API Gateway- API for ORCA Delete Functionality
+resource "aws_api_gateway_rest_api" "orca_delete_api" {
+  name        = "${var.prefix}_orca_delete_api"
+  description = "API for hard and soft delete lambda functions"
+  endpoint_configuration {
+    types            = ["PRIVATE"]
+    vpc_endpoint_ids = [local.vpc_endpoint_id]
+  }
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "orca_delete_api_policy" {
+  statement {
+    resources = ["*"]
+    actions   = ["execute-api:Invoke"]
+    effect = "Allow"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+  }
+}
+
+resource "aws_api_gateway_rest_api_policy" "orca_delete_api_policy" {
+  rest_api_id = aws_api_gateway_rest_api.orca_delete_api.id
+  policy      = data.aws_iam_policy_document.orca_delete_api_policy.json
+}
+
+resource "aws_api_gateway_resource" "orca_soft_delete_api_resource" {
+  path_part   = "catalog"
+  parent_id   = aws_api_gateway_rest_api.orca_delete_api.root_resource_id
+  rest_api_id = aws_api_gateway_rest_api.orca_delete_api.id
+}
+
+resource "aws_api_gateway_method" "orca_soft_delete_api_method" {
+  rest_api_id   = aws_api_gateway_rest_api.orca_delete_api.id
+  resource_id   = aws_api_gateway_resource.orca_soft_delete_api_resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+  api_key_required = false
+}
+
+resource "aws_api_gateway_integration" "orca_soft_delete_api_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.orca_delete_api.id
+  resource_id             = aws_api_gateway_resource.orca_soft_delete_api_resource.id
+  http_method             = aws_api_gateway_method.orca_soft_delete_api_method.http_method
+  integration_http_method = "POST"
+  type                    = "AWS"
+  uri                     = <PLACE_HOLDER_FOR_SOFT_DELETE_LAMBDA>
+}
+
+resource "aws_api_gateway_method_response" "orca_soft_delete_response_200" {
+  rest_api_id = aws_api_gateway_rest_api.orca_delete_api.id
+  resource_id = aws_api_gateway_resource.orca_soft_delete_api_resource.id
+  http_method = aws_api_gateway_method.orca_soft_delete_api_method.http_method
+  status_code = "200"
+}
+
+resource "aws_lambda_permission" "orca_soft_delete_api_permission" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = "<PLACE_HOLDER_FOR_SOFT_DELETE_LAMBDA>"
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.orca_delete_api.execution_arn}/*/${aws_api_gateway_method.orca_soft_delete_api_method.http_method}${aws_api_gateway_resource.orca_soft_delete_api_resource.path}"
+}
+
+resource "aws_api_gateway_resource" "orca_hard_delete_api_resource" {
+  path_part   = "harddelete"
+  parent_id   = aws_api_gateway_rest_api.orca_delete_api.root_resource_id
+  rest_api_id = aws_api_gateway_rest_api.orca_delete_api.id
+}
+
+resource "aws_api_gateway_method" "orca_hard_delete_api_method" {
+  rest_api_id   = aws_api_gateway_rest_api.orca_delete_api.id
+  resource_id   = aws_api_gateway_resource.orca_hard_delete_api_resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+  api_key_required = false
+}
+
+resource "aws_api_gateway_integration" "orca_hard_delete_api_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.orca_delete_api.id
+  resource_id             = aws_api_gateway_resource.orca_hard_delete_api_resource.id
+  http_method             = aws_api_gateway_method.orca_hard_delete_api_method.http_method
+  integration_http_method = "POST"
+  type                    = "AWS"
+  uri                     = <PLACE_HOLDER_FOR_HARD_DELETE_LAMBDA>
+}
+
+resource "aws_api_gateway_method_response" "orca_hard_delete_response_200" {
+  rest_api_id = aws_api_gateway_rest_api.orca_delete_api.id
+  resource_id = aws_api_gateway_resource.orca_hard_delete_api_resource.id
+  http_method = aws_api_gateway_method.orca_hard_delete_api_method.http_method
+  status_code = "200"
+}
+
+resource "aws_lambda_permission" "orca_hard_delete_api_permission" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = "<PLACE_HOLDER_FOR_HARD_DELETE_LAMBDA>"
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.orca_delete_api.execution_arn}/*/${aws_api_gateway_method.orca_hard_delete_api_method.http_method}${aws_api_gateway_resource.orca_hard_delete_api_resource.path}"
+}
+
+#deployment for the API
+resource "aws_api_gateway_deployment" "orca_delete_api_deployment" {
+  rest_api_id = aws_api_gateway_rest_api.orca_delete_api.id
+  depends_on = [
+    aws_api_gateway_integration.orca_soft_delete_api_integration,
+    aws_api_gateway_integration.orca_hard_delete_api_integration
+  ]
+}
+resource "aws_api_gateway_stage" "orca_delete_api_stage_name" {
+  deployment_id = aws_api_gateway_deployment.orca_delete_api_deployment.id
+  rest_api_id   = aws_api_gateway_rest_api.orca_delete_api.id
+  stage_name    = var.api_gateway_stage_name
+}
+
+
+
+
+
+

--- a/modules/delete_api/output.tf
+++ b/modules/delete_api/output.tf
@@ -1,0 +1,4 @@
+output "orca_delete_api_deployment_invoke_url" {
+  value       = aws_api_gateway_deployment.orca_delete_api_deployment.invoke_url
+  description = "The URL to invoke the ORCA Delete API gateway. Excludes the resource path"
+}

--- a/modules/delete_api/variables.tf
+++ b/modules/delete_api/variables.tf
@@ -1,0 +1,26 @@
+# REQUIRED
+variable "prefix" {
+  type        = string
+  description = "Prefix used to prepend to all object names and tags."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to resources that support tags."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "Virtual Private Cloud AWS ID"
+}
+
+variable "api_gateway_stage_name" {
+  type        = string
+  description = "stage name for the ORCA cumulus reconciliation api gateway"
+  default     = "orca_delete_api"
+}
+
+variable "vpc_endpoint_id" {
+  type        = string
+  description = "NGAP vpc endpoint id needed to access the api. Defaults to null."
+}

--- a/modules/orca/main.tf
+++ b/modules/orca/main.tf
@@ -307,3 +307,27 @@ module "orca_api_gateway" {
   vpc_endpoint_id = var.vpc_endpoint_id
   tags            = var.tags
 }
+
+## orca_delete_api_gateway - api gateway module
+## =============================================================================
+module "orca_delete_api_gateway" {
+  depends_on = [
+    module.orca_lambdas
+  ]
+  source = "../delete_api"
+  ## --------------------------
+  ## Cumulus Variables
+  ## --------------------------
+  ## REQUIRED
+  prefix = var.prefix
+  vpc_id = var.vpc_id
+
+  ## --------------------------
+  ## ORCA Variables
+  ## --------------------------
+  ## REQUIRED
+  <PLACEHOLDER_FOR_LAMBDAS>
+  ## OPTIONAL
+  vpc_endpoint_id = var.vpc_endpoint_id
+  tags            = var.tags
+}

--- a/modules/orca/output.tf
+++ b/modules/orca/output.tf
@@ -120,6 +120,11 @@ output "orca_api_deployment_invoke_url" {
   description = "The URL to invoke the ORCA Cumulus reconciliation API gateway. Excludes the resource path"
 }
 
+output "orca_delete_api_deployment_invoke_url" {
+  value       = module.orca_delete_api_gateway.orca_delete_api_deployment_invoke_url
+  description = "The URL to invoke the ORCA Delete API gateway. Excludes the resource path"
+}
+
 ## GraphQL Module Outputs (graphql_0 and graphql_1)
 ## =============================================================================
 output "orca_graphql_load_balancer_dns_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -105,6 +105,11 @@ output "orca_api_deployment_invoke_url" {
   description = "The URL to invoke the ORCA Cumulus reconciliation API gateway. Excludes the resource path"
 }
 
+output "orca_delete_api_deployment_invoke_url" {
+  value       = module.orca_delete_api_gateway.orca_delete_api_deployment_invoke_url
+  description = "The URL to invoke the ORCA Delete API gateway. Excludes the resource path"
+}
+
 ## GraphQL Module Outputs (graphql_0 and graphql_1)
 ## =============================================================================
 output "orca_graphql_load_balancer_dns_name" {


### PR DESCRIPTION
## Summary of Changes

Added API Gateway and resource paths for delete functionality, added placeholders for future Lmabdas since those are not ready yet and will have to be added at a later date.

Addresses [ORCA-396: Create API gateway resource for performing ORCA delete functionality](https://bugs.earthdata.nasa.gov/browse/ORCA-396)

## Changes

* Added API Gateway and resource paths for delete functionality, added placeholders for future Lmabdas since those are not ready yet and will have to be added at a later date.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets
