### PR TITLE
ORCA-1030: Modify db_deploy to add delete column in granules table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ AWS X-Ray functionality has been added for the `copy_to_orca` lambda. For users 
 ### Added
 
 - *ORCA-1011* - Modified `db_deploy` lambda to add a delete column in the ORCA DB files table. Created a new schema version 8 for migration.
+- *ORCA-1030* - Modified `db_deploy` lambda to add a delete column in the ORCA DB granules table and set default value to false.
 - *ORCA-885* - Added X-Ray for `copy_to_orca` lambda and a variable in `variables.tf` to enable/disable it as well as updated IAM permissions for use.
 - *ORCA-396* - Added API Gateway and resource paths for delete functionality, added placeholders for future Lmabdas since those are not ready yet and will have to be added at a later date.
 

--- a/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate.py
+++ b/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate.py
@@ -17,7 +17,7 @@ def migrate_versions_7_to_8(
 ) -> None:
     """
     Performs the migration of the ORCA schema from version 7 to version 8 of
-    the ORCA schema. This includes adding the delete_file column to files.
+    the ORCA schema. This includes adding the delete_file column to granules.
 
     Args:
         config: Connection information for the database.
@@ -42,9 +42,9 @@ def migrate_versions_7_to_8(
         connection.execute(sql.text("SET search_path TO orca, public;"))
 
         # Create storage_class table
-        LOGGER.debug("Adding delete_file column to files table ...")
-        connection.execute(sql.add_delete_file_to_files_table_sql())
-        LOGGER.info("delete_file column added to files table.")
+        LOGGER.debug("Adding delete_file column to granules table ...")
+        connection.execute(sql.add_delete_file_to_granules_table_sql())
+        LOGGER.info("delete_file column added to granules table.")
 
         # If v8 is the latest version, update the schema_versions table.
         if is_latest_version:

--- a/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
@@ -41,6 +41,6 @@ def add_delete_file_to_granules_table_sql() -> text:
         """
         -- Add delete_file column to granules table
         ALTER TABLE orca.granules
-            AADD COLUMN IF NOT EXISTS delete_file boolean NOT NULL DEFAULT FALSE;
+            ADD COLUMN IF NOT EXISTS delete_file boolean NOT NULL DEFAULT FALSE;
         """
     )

--- a/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
@@ -28,7 +28,7 @@ def schema_versions_data_sql() -> text:  # pragma: no cover
         -- Upsert the current version
         INSERT INTO schema_versions
           VALUES
-            (8, 'Added delete_file to files tables.', NOW(), True)
+            (8, 'Added delete_file to granules tables.', NOW(), True)
         ON CONFLICT (version_id)
         DO UPDATE SET is_latest = True;
     """

--- a/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
@@ -35,19 +35,12 @@ def schema_versions_data_sql() -> text:  # pragma: no cover
     )
 
 
-def add_delete_file_to_files_table_sql() -> text:
+def add_delete_file_to_granules_table_sql() -> text:
     """ """
     return text(  # nosec
         """
-        -- Add delete_file column to files table
-        ALTER TABLE orca.files
-            ADD COLUMN IF NOT EXISTS delete_file boolean;
-
-        -- Populate the delete_file column setting
-        -- non-matches to a value of "UNKNOWN"
-        -- ##############################################
-        UPDATE orca.files
-            SET delete_file = 'UNKNOWN'
-            WHERE delete_file IS NULL;
+        -- Add delete_file column to granules table
+        ALTER TABLE orca.granules
+            AADD COLUMN IF NOT EXISTS delete_file boolean NOT NULL DEFAULT FALSE;
         """
     )


### PR DESCRIPTION
## Summary of Changes

Based on the changes in the RDS hard delete prototype we need to modify the db_deploy lambda to add the new delete column into the granules table instead of the files table.

Addresses [ORCA-1030: Modify db_deploy to add delete column in granules table](https://bugs.earthdata.nasa.gov/browse/ORCA-1030)

## Changes

* Switched delete column from files table to granules table and set default value to false

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on dev database and verified column with default values was created in the granules table.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets