### PR TITLE
ORCA-1034: Implement Index in db_deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ AWS X-Ray functionality has been added for the `copy_to_orca` lambda. For users 
 - *ORCA-1030* - Modified `db_deploy` lambda to add a delete column in the ORCA DB granules table and set default value to false.
 - *ORCA-885* - Added X-Ray for `copy_to_orca` lambda and a variable in `variables.tf` to enable/disable it as well as updated IAM permissions for use.
 - *ORCA-396* - Added API Gateway and resource paths for delete functionality, added placeholders for future Lmabdas since those are not ready yet and will have to be added at a later date.
+- *ORCA-1034* - Added index on `granule_id` in the `files` table for faster deletes.
 
 ### Changed
 

--- a/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
+++ b/tasks/db_deploy/migrations/migrate_versions_7_to_8/migrate_sql.py
@@ -28,7 +28,7 @@ def schema_versions_data_sql() -> text:  # pragma: no cover
         -- Upsert the current version
         INSERT INTO schema_versions
           VALUES
-            (8, 'Added delete_file to granules tables.', NOW(), True)
+            (8, 'Added delete_file to granules tables and index to files table.', NOW(), True)
         ON CONFLICT (version_id)
         DO UPDATE SET is_latest = True;
     """
@@ -42,5 +42,7 @@ def add_delete_file_to_granules_table_sql() -> text:
         -- Add delete_file column to granules table
         ALTER TABLE orca.granules
             ADD COLUMN IF NOT EXISTS delete_file boolean NOT NULL DEFAULT FALSE;
+        -- Add index on granule_id in the files table for faster deletes
+        CREATE INDEX IF NOT EXISTS files_granule_id on orca.files USING btree (granule_id)
         """
     )


### PR DESCRIPTION
## Summary of Changes

Added index in files table on granule_id for faster deletes

Addresses [ORCA-1034: Implement Index in db_deploy](https://bugs.earthdata.nasa.gov/browse/ORCA-1034)

## Changes

* Added index in files table on granule_id for faster deletes

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on dev database to confirm index was created and speeds up deletes.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the necessary documentation (remove those that do not apply)
    - [x] CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] Manual tests (outlined above)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code has passed security scanning
    - [x] Snyk
    - [x] git-secrets